### PR TITLE
wd: fix dlopen library

### DIFF
--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -59,7 +59,7 @@ static void __attribute__((constructor)) wd_cipher_open_driver(void)
 	void *driver;
 
 	/* Fix me: vendor driver should be put in /usr/lib/wd/ */
-	driver = dlopen("/usr/lib/wd/libhisi_sec.so", RTLD_NOW);
+	driver = dlopen("libhisi_sec.so", RTLD_NOW);
 	if (!driver)
 		WD_ERR("fail to open libhisi_sec.so\n");
 }

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -70,8 +70,7 @@ static void __attribute__((constructor)) wd_comp_open_driver(void)
 {
 	void *driver;
 
-	/* Fix me: vendor driver should be put in /usr/lib/wd/ */
-	driver = dlopen("/usr/lib/wd/libhisi_zip.so", RTLD_NOW);
+	driver = dlopen("libhisi_zip.so", RTLD_NOW);
 	if (!driver)
 		WD_ERR("Fail to open libhisi_zip.so\n");
 }

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -59,7 +59,7 @@ static void __attribute__((constructor)) wd_dh_open_driver(void)
 {
 	void *driver;
 
-	driver = dlopen("/usr/lib/wd/libhisi_hpre.so", RTLD_NOW);
+	driver = dlopen("libhisi_hpre.so", RTLD_NOW);
 	if (!driver)
 		WD_ERR("Fail to open libhisi_hpre.so\n");
 }

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -53,7 +53,7 @@ static void __attribute__((constructor)) wd_digest_open_driver(void)
 	void *driver;
 
 	/* Fix me: vendor driver should be put in /usr/lib/wd/ */
-	driver = dlopen("/usr/lib/wd/libhisi_sec.so", RTLD_NOW);
+	driver = dlopen("libhisi_sec.so", RTLD_NOW);
 	if (!driver)
 		WD_ERR("fail to open libhisi_sec.so\n");
 }

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -100,7 +100,7 @@ static void __attribute__((constructor)) wd_rsa_open_driver(void)
 {
 	void *driver;
 
-	driver = dlopen("/usr/lib/wd/libhisi_hpre.so", RTLD_NOW);
+	driver = dlopen("libhisi_hpre.so", RTLD_NOW);
 	if (!driver)
 		WD_ERR("Fail to open libhisi_hpre.so\n");
 }


### PR DESCRIPTION
"sudo make install" load library to /usr/local/lib by default
application search shared library according to env, like LD_LIBRARY_PATH
absolute path should not be used

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>