### PR TITLE
wd: remove duplicated libhisi_hpre_la_LIBADD parts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,9 +40,4 @@ libhisi_sec_la_LIBADD= $(libwd_la_OBJECTS) $(libwd_crypto_la_OBJECTS)
 libhisi_hpre_la_SOURCES=drv/hisi_hpre.c drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h wd_hpre_drv.h
 libhisi_hpre_la_LIBADD= $(libwd_la_OBJECTS) $(libwd_crypto_la_OBJECTS)
-
-libhisi_hpre_la_SOURCES=drv/hisi_hpre.c drv/hisi_qm_udrv.c \
-                hisi_qm_udrv.h wd_hpre_drv.h
-libhisi_hpre_la_LIBADD= -ldl
-
 SUBDIRS=. test


### PR DESCRIPTION
libhisi_hpre_la_LIBADD is overlapped

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>