### PR TITLE
conf.sh: add --includedir

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -23,4 +23,5 @@ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure \
 	--enable-perf=yes \
 	--host aarch64-linux-gnu \
 	--target aarch64-linux-gnu \
+	--includedir=/usr/local/include/uadk \
 	$COMPILE_TYPE


### PR DESCRIPTION
By default headers are copyied to /usr/local/include,
add --includedir=/usr/local/include/uadk
For example app.c #include <uadk/wd.h>

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>