### PR TITLE
Fix zip poll

### DIFF
--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -220,8 +220,7 @@ int lib_poll_func(__u32 pos, __u32 expect, __u32 *count)
 static void *poll_thread_func(void *arg)
 {
 	struct hizip_test_info *info = (struct hizip_test_info *)arg;
-	struct wd_ctx_config *ctx_conf = &info->ctx_conf;
-	int i, ret = 0, total = 0;
+	int ret = 0, total = 0;
 	__u32 expected = 0, received;
 
 	if (!info->opts->sync_mode)
@@ -235,13 +234,11 @@ static void *poll_thread_func(void *arg)
 			usleep(10);
 			continue;
 		}
-		for (i = 0; i < ctx_conf->ctx_num; i++) {
-			expected = 1;
-			received = 0;
-			ret = wd_comp_poll(expected, &received);
-			if (ret == 0)
-				total += received;
-		}
+		expected = 1;
+		received = 0;
+		ret = wd_comp_poll(expected, &received);
+		if (ret == 0)
+			total += received;
 		if (count == total) {
 			pthread_mutex_unlock(&mutex);
 			break;

--- a/test/sched_sample.c
+++ b/test/sched_sample.c
@@ -174,9 +174,10 @@ static int sample_poll_region(struct sample_sched_ctx *ctx, __u32 begin,
 	for (i = begin; i <= end; i++) {
 		/* RR schedule, one time poll one */
 		ret = ctx->poll_func(i, 1, &poll_num);
-		if (ret)
+		if ((ret < 0) && (ret != -EAGAIN))
 			return ret;
-
+		else if (ret == -EAGAIN)
+			continue;
 		*count += poll_num;
 		if (*count >= expect)
 			break;


### PR DESCRIPTION
hzhuang1@j13-d06-02:~/warpdriver$ sudo ./test/hisi_zip_test/test_sva_perf  -l 1000 -q 16 -m 1
Couldn't open file /sys/kernel/debug/tracing/events/iommu/dev_fault/id
Compress bz=512000 nb=1000×10, speed=7609.6 MB/s (±0.0% N=1) overall=7551.6 MB/s (±0.0%)

After running commands above with a couple of times, a new error is reported.

hzhuang1@j13-d06-02:~/warpdriver$ sudo ./test/hisi_zip_test/test_sva_perf  -l 1000 -q 8 -m 1
Couldn't open file /sys/kernel/debug/tracing/events/iommu/dev_fault/id
qm send is err(-16)!

hzhuang1@j13-d06-02:~/warpdriver$ sudo dmesg | tail -n 5
[  120.114938] FAT-fs (sda1): Volume was not properly unmounted. Some data may be corrupt. Please run fsck.
[  120.421400] Adding 64142332k swap on /dev/sda3.  Priority:-2 extents:1 across:64142332k 
[  125.109418] hns3 0000:bd:00.0 enp189s0f0: link up
[ 9986.276431] hisi_zip 0000:75:00.0: All 64 queues of QM are busy!
[ 9992.218237] hisi_zip 0000:75:00.0: All 64 queues of QM are busy!
