### PR TITLE
wd: test:test_sva_perf support file comp testcase

### DIFF
--- a/test/hisi_zip_test/Makefile.am
+++ b/test/hisi_zip_test/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS=-Wall -fno-strict-aliasing -I../../include
 
 bin_PROGRAMS=test_sva_perf
 
-test_sva_perf_SOURCES=test_sva_perf.c test_lib.c ../sched_sample.c
+test_sva_perf_SOURCES=test_sva_perf.c sva_file_test.c test_lib.c ../sched_sample.c
 
 if WD_STATIC_DRV
 test_sva_perf_LDADD=../../.libs/libwd.a ../../.libs/libwd_comp.a \

--- a/test/hisi_zip_test/sva_file_test.c
+++ b/test/hisi_zip_test/sva_file_test.c
@@ -1,0 +1,580 @@
+/*
+ * Copyright 2019 Huawei Technologies Co.,Ltd.All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <unistd.h>
+#include <getopt.h>
+#define __USE_GNU
+#include <pthread.h>
+#include <sched.h>
+#include <sys/time.h>
+#include <sys/syscall.h>
+
+#include "wd.h"
+#include "hisi_qm_udrv.h"
+#include "test_lib.h"
+
+
+struct test_zip_pthread_dt {
+	int cpu_id;
+	int thread_num;
+	int alg_type;
+	int op_type;
+	int hw_flag;
+	int blksize;
+	int iteration;
+	void *src;
+	void *dst;
+	__u32 src_len;
+	__u32 dst_len;
+	float com_time;
+	float decom_time;
+};
+
+struct user_comp_param {
+	int cpu_id;
+	pid_t tid;
+	int alg_type;
+	__u32 out_len;
+};
+
+#define TEST_MAX_THRD		2048
+#define MAX_CORES		128
+
+static pthread_t system_test_thrds[TEST_MAX_THRD];
+static pthread_t system_test_poll_thrds;
+static struct test_zip_pthread_dt test_thrds_data[TEST_MAX_THRD];
+
+/* bytes of data for a request */
+static int block_size = 512000;
+static int verify;
+
+pid_t gettid(void)
+{
+	return syscall(__NR_gettid);
+}
+
+/* stream mode test thread */
+void *zlib_sys_stream_test_thread(void *args)
+{
+	int cpu_id, ret;
+	pid_t tid;
+	cpu_set_t mask;
+	struct test_zip_pthread_dt *pdata = args;
+	int i = pdata->iteration;
+
+	cpu_id = pdata->cpu_id;
+	tid = gettid();
+
+	CPU_ZERO(&mask);
+	if (cpu_id) {
+		if (cpu_id <= 0 || cpu_id > MAX_CORES) {
+			dbg("set cpu no affinity!\n");
+			goto therad_no_affinity;
+		}
+		CPU_SET(cpu_id, &mask);
+		if (pthread_setaffinity_np(pthread_self(),
+		    sizeof(mask), &mask) < 0) {
+			perror("pthread_setaffinity fail!\n");
+			return NULL;
+		}
+	}
+
+therad_no_affinity:
+
+	dbg("%s entry thread_id=%d\n", __func__, (int)tid);
+	do {
+		if (pdata->op_type == WD_DIR_COMPRESS) {
+			ret = hw_stream_compress(pdata->alg_type,
+					pdata->blksize,
+					pdata->dst,
+					&pdata->dst_len,
+					pdata->src,
+					pdata->src_len);
+			if (ret < 0)
+				WD_ERR("comp fail! id=%d tid=%d ret=%d\n",
+						cpu_id, (int)tid, ret);
+		} else if (pdata->op_type == WD_DIR_DECOMPRESS) {
+			ret = hw_stream_decompress(pdata->alg_type,
+					pdata->blksize,
+					pdata->dst,
+					&pdata->dst_len,
+					pdata->src,
+					pdata->src_len);
+			if (ret < 0)
+				WD_ERR("decomp fail! id=%d tid=%d ret=%d\n",
+						cpu_id, (int)tid, ret);
+		}
+
+		if (verify) {
+			ret = hw_stream_decompress(pdata->alg_type,
+						   pdata->blksize,
+						   pdata->src,
+						   &pdata->src_len,
+						   pdata->dst,
+						   pdata->dst_len);
+			if (ret < 0)
+				WD_ERR("loop verify fail! ret=%d, id=%d\n",
+					ret, cpu_id);
+			else
+				dbg("loop verify success! id=%d\n", cpu_id);
+		}
+
+	} while (--i);
+	dbg("%s end thread_id=%d\n", __func__, (int)tid);
+
+	return NULL;
+
+}
+
+static int out_len;
+
+void zip_callback(void *req, void *param)
+{
+
+
+	dbg("[%s],test entry \n", __func__);
+	struct wd_comp_req *preq = req;
+
+	if (!req || !param) {
+		WD_ERR("callback input NULL!\n");
+		return;
+
+	}
+	out_len = preq->dst_len;
+
+	dbg("[%s], consume=%d, produce=%d\n",
+	    __func__, preq->src_len, preq->dst_len);
+
+}
+
+#define MAX_POLL_COUNTS 10
+void *zip_sys_async_test_poll_thread(void *args)
+{
+	int cpu_id;
+	pid_t tid;
+	struct test_zip_pthread_dt *pdata = args;
+	__u32 count = 0;
+	__u32 totalcount = 0;
+	int recnt = 0;
+	int ret = 0;
+
+	cpu_id = pdata->cpu_id;
+	tid = gettid();
+
+
+	do {
+		count = 0;
+		dbg("poll start, expt =%d , have =%d!\n", pdata->iteration, totalcount);
+		ret = wd_comp_poll(pdata->iteration, &count);
+		if (ret < 0)
+			WD_ERR("poll fail! thread_id=%d, tid=%d. ret:%d\n", cpu_id, (int)tid, ret);
+		if (count > 0)
+			recnt = 0;
+		totalcount += count;
+		if (totalcount < pdata->iteration * pdata->thread_num) {
+			usleep(100000);
+			dbg("poll thread now no task, expt =%d , have =%d!\n", pdata->iteration, totalcount);
+			if (++recnt > MAX_POLL_COUNTS) {
+				WD_ERR("poll thread  no task, 1s timeout, expt =%d , have =%d!\n", pdata->iteration * pdata->thread_num, totalcount);
+				break;
+			}
+		}
+
+	} while (totalcount < pdata->iteration * pdata->thread_num);
+
+	WD_ERR("thread_id = %d, test poll end, count=%d\n", pdata->cpu_id, totalcount);
+
+	pdata->dst_len = out_len;
+
+	return NULL;
+}
+
+void *zip_sys_async_test_thread(void *args)
+{
+	int cpu_id;
+	cpu_set_t mask;
+	pid_t tid;
+	struct test_zip_pthread_dt *pdata = args;
+	struct user_comp_param u_param;
+	int i = pdata->iteration;
+	int loop;
+	handle_t h_sess;
+	struct wd_comp_sess_setup setup;
+	struct wd_comp_req req;
+	__u32 count = 0;
+	int ret = 0;
+
+
+	cpu_id = pdata->cpu_id;
+	tid = gettid();
+
+	CPU_ZERO(&mask);
+	if (cpu_id) {
+		if (cpu_id <= 0 || cpu_id > MAX_CORES) {
+			dbg("set cpu no affinity!\n");
+			goto therad_no_affinity;
+		}
+		CPU_SET(cpu_id, &mask);
+		if (pthread_setaffinity_np(pthread_self(),
+		    sizeof(mask), &mask) < 0) {
+			perror("pthread_setaffinity fail!\n");
+			return NULL;
+		}
+	}
+
+therad_no_affinity:
+
+	setup.alg_type = pdata->alg_type;
+	setup.mode = CTX_MODE_ASYNC;
+	h_sess = wd_comp_alloc_sess(&setup);
+	if (!h_sess) {
+		fprintf(stderr,"fail to alloc comp sess!\n");
+		return NULL;
+	}
+
+	u_param.alg_type = pdata->alg_type;
+	u_param.cpu_id = cpu_id;
+	u_param.tid = tid;
+
+	req.src = pdata->src;
+	req.src_len = pdata->src_len;
+	req.dst = pdata->dst;
+	req.dst_len = pdata->dst_len;
+	req.op_type = pdata->op_type;
+	req.cb = (void *)zip_callback;
+	req.cb_param = &u_param;
+
+	dbg("%s:input req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+	loop = 1;
+	dbg("%s entry thread_id=%d\n", __func__, (int)tid);
+	do {
+		i = pdata->iteration;
+		count = 0;
+		do {
+			ret = wd_do_comp_async(h_sess, &req);
+			if (ret == -EBUSY) {
+				WD_ERR("%s(): async test no cache,wait 10ms!\n", __func__);
+				usleep(10000);
+				continue;
+			}
+			count++;
+
+		} while (--i);
+
+		WD_ERR("thread_id = %d, test send end, count=%d\n", pdata->cpu_id, count);
+
+	} while (--loop);
+
+
+	pdata->dst_len = u_param.out_len;
+
+	dbg("%s:output req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, pdata->dst_len);
+
+	wd_comp_free_sess(h_sess);
+
+	dbg("%s end thread_id=%d\n", __func__, pdata->cpu_id);
+
+	return NULL;
+}
+
+void  *zip_sys_block_test_thread(void *args)
+{
+	int cpu_id, ret;
+	cpu_set_t mask;
+	pid_t tid;
+	struct test_zip_pthread_dt *pdata = args;
+	int i = pdata->iteration;
+
+	cpu_id = pdata->cpu_id;
+	tid = gettid();
+
+	CPU_ZERO(&mask);
+	if (cpu_id) {
+		if (cpu_id <= 0 || cpu_id > MAX_CORES) {
+			dbg("set cpu no affinity!\n");
+			goto therad_no_affinity;
+		}
+		CPU_SET(cpu_id, &mask);
+		if (pthread_setaffinity_np(pthread_self(),
+		    sizeof(mask), &mask) < 0) {
+			perror("pthread_setaffinity fail!\n");
+			return NULL;
+		}
+	}
+
+therad_no_affinity:
+
+	dbg("%s entry thread_id=%d\n", __func__, (int)tid);
+	do {
+		if (pdata->op_type == WD_DIR_COMPRESS) {
+			ret = hw_blk_compress(pdata->alg_type, pdata->blksize,
+					      pdata->dst, &pdata->dst_len,
+					      pdata->src, pdata->src_len);
+			if (ret < 0)
+				WD_ERR("comp fail! thread_id=%d, tid=%d\n",
+					cpu_id, (int)tid);
+		} else if (pdata->op_type == WD_DIR_DECOMPRESS) {
+			ret = hw_blk_decompress(pdata->alg_type, pdata->blksize,
+						pdata->dst, &pdata->dst_len,
+						pdata->src, pdata->src_len);
+			if (ret < 0)
+				WD_ERR("decomp fail! thread_id=%d, tid=%d\n",
+					cpu_id, (int)tid);
+		}
+		if (verify) {
+			ret = hw_blk_decompress(pdata->alg_type, pdata->blksize,
+						pdata->src, &pdata->src_len,
+						pdata->dst, pdata->dst_len);
+			if (ret < 0)
+				WD_ERR("loop verify fail! ret=%d, id=%d\n",
+					ret, cpu_id);
+			else
+				dbg("loop verify success! id=%d\n", cpu_id);
+		}
+	} while (--i);
+	dbg("%s end thread_id=%d\n", __func__, pdata->cpu_id);
+
+	return NULL;
+}
+
+#define SCHED_TWO "sched_two"
+static struct wd_ctx_config ctx_conf;
+
+static __u32 sched_two_pick_next(handle_t h_sched_ctx,
+				    const void *req,
+				    const struct sched_key *key)
+{
+	struct wd_comp_req *c_req = (struct wd_comp_req *)req;
+
+	if (c_req->op_type == WD_DIR_COMPRESS){
+		return 0;
+	} else {
+		return 1;
+	}
+}
+
+#define MAX_RETRY_COUNTS 2000
+static int sched_two_poll_policy(handle_t h_sched_ctx, const struct wd_ctx_config *cfg,
+				 __u32 expect,
+				 __u32 *count)
+{
+	int i, ret;
+	int recv_count = 0;
+	__u32 cnt[1024] = {0};
+
+	for (i = 0; i < ctx_conf.ctx_num; i++) {
+		do {
+			ret = wd_comp_poll_ctx(ctx_conf.ctxs[i].ctx, expect, &cnt[i]);
+			if (ret == -WD_HW_EACCESS) {
+				WD_ERR("wd comp recv hw err!\n");
+				return ret;
+			} else if (ret == -EAGAIN) {
+				usleep(1);
+				if (++recv_count > MAX_RETRY_COUNTS) {
+					WD_ERR("wd comp poll recv timeout fail!\n");
+					return -ETIMEDOUT;
+
+					*count += cnt[i];
+					break;
+				}
+			}
+
+			*count += cnt[i];
+		} while (ret == -EAGAIN);
+
+		recv_count = 0;
+	}
+
+	return 0;
+}
+
+#define MAX_LEN (~0U)
+
+int comp_file_test(FILE *source, FILE *dest, struct priv_options *opts)
+{
+	int fd;
+	struct stat s;
+	int i, j, ret;
+	int cnt = 0;
+	void *file_buf;
+	__u32 in_len, sz;
+	float tc = 0;
+	float speed;
+	ulong templen = 0;
+	float total_in = 0;
+	float total_out = 0;
+	int count = 0;
+	struct wd_sched *sched = NULL;
+	struct hizip_test_info info = {0};
+	struct timeval start_tval, end_tval;
+	struct test_options *copts = &opts->common;
+	int mode = copts->is_stream;
+	int thread_num = copts->thread_num;
+
+	fd = fileno(source);
+	SYS_ERR_COND(fstat(fd, &s) < 0, "fstat");
+	in_len = s.st_size;
+
+	file_buf = calloc(1, in_len);
+
+	sz = fread(file_buf, 1, in_len, source);
+	if (sz != in_len)
+		WD_ERR("read file sz != in_len!\n");
+	count = in_len/block_size;
+
+	if (!count)
+		count = 1;
+
+	dbg("%s entry blocksize=%d, count=%d, threadnum= %d, in_len=%d\n",
+	    __func__, block_size, count, thread_num, in_len);
+
+	ret = init_ctx_config(copts, sched, &info);
+	if (ret)
+		return ret;
+
+	cnt = copts->thread_num;
+	for (i = 0; i < cnt; i++) {
+		test_thrds_data[i].thread_num = cnt;
+		test_thrds_data[i].cpu_id = i;
+		test_thrds_data[i].alg_type = copts->alg_type;
+		test_thrds_data[i].op_type = copts->op_type;
+		test_thrds_data[i].blksize = copts->block_size;
+		test_thrds_data[i].iteration = copts->run_num;
+		test_thrds_data[i].src = file_buf;
+		test_thrds_data[i].src_len = in_len;
+		templen = (ulong)in_len * 2;
+		if(templen > MAX_LEN){
+			test_thrds_data[i].dst_len =  MAX_LEN;
+		} else {
+			test_thrds_data[i].dst_len =  templen;
+		}
+		test_thrds_data[i].src = calloc(1, test_thrds_data[i].src_len);
+		if (test_thrds_data[i].src == NULL)
+			goto buf_free;
+		memcpy(test_thrds_data[i].src, file_buf, in_len);
+		test_thrds_data[i].dst = calloc(1, test_thrds_data[i].dst_len);
+		if (test_thrds_data[i].dst == NULL)
+			goto src_buf_free;
+	}
+
+	gettimeofday(&start_tval, NULL);
+	for (i = 0; i < cnt; i++) {
+		if (mode == MODE_STREAM)
+			ret = pthread_create(&system_test_thrds[i], NULL,
+					     zlib_sys_stream_test_thread,
+					     &test_thrds_data[i]);
+		else if (mode == CTX_MODE_ASYNC)
+			ret = pthread_create(&system_test_thrds[i], NULL,
+					     zip_sys_async_test_thread,
+					     &test_thrds_data[i]);
+		else
+			ret = pthread_create(&system_test_thrds[i], NULL,
+					     zip_sys_block_test_thread,
+					     &test_thrds_data[i]);
+		if (ret) {
+			WD_ERR("Create %dth thread fail!\n", i);
+			return ret;
+		}
+	}
+
+	if (mode == CTX_MODE_ASYNC)
+			ret = pthread_create(&system_test_poll_thrds, NULL,
+					     zip_sys_async_test_poll_thread,
+					     &test_thrds_data[0]);
+
+	for (i = 0; i < copts->thread_num; i++) {
+		ret = pthread_join(system_test_thrds[i], NULL);
+		if (ret) {
+			WD_ERR("Join %dth thread fail!\n", i);
+			return ret;
+		}
+	}
+
+	if (mode == CTX_MODE_ASYNC) {
+		ret = pthread_join(system_test_poll_thrds, NULL);
+		if (ret) {
+			WD_ERR("Join poll thread fail!\n");
+			return ret;
+		}
+	}
+
+	gettimeofday(&end_tval, NULL);
+	for (i = 0; i < copts->thread_num; i++) {
+		total_in += test_thrds_data[i].src_len;
+		total_out += test_thrds_data[i].dst_len;
+	}
+	tc = (float)((end_tval.tv_sec-start_tval.tv_sec) * 1000000 +
+		     end_tval.tv_usec - start_tval.tv_usec);
+	dbg("%s end threadnum= %d, out_len=%u\n",
+	    __func__, thread_num, test_thrds_data[thread_num-1].dst_len);
+
+
+	if (mode == CTX_MODE_ASYNC) {
+		sz = fwrite(test_thrds_data[thread_num - 1].dst, 1,
+			    out_len, dest);
+
+	} else {
+		sz = fwrite(test_thrds_data[thread_num - 1].dst, 1,
+			    test_thrds_data[thread_num - 1].dst_len, dest);
+	}
+	for (i = 0; i < thread_num; i++) {
+		dbg("%s:free src[%d]:%p\n", __func__, i, test_thrds_data[i].src);
+		free(test_thrds_data[i].src);
+		dbg("%s:free dst[%d]:%p\n", __func__, i, test_thrds_data[i].dst);
+		free(test_thrds_data[i].dst);
+	}
+	if (copts->op_type == WD_DIR_COMPRESS) {
+		speed = total_in / tc /
+			1024 / 1024 * 1000 * 1000 * copts->run_num,
+		fprintf(stderr,
+			"Compress bz=%d, threadnum= %d, speed=%0.3f MB/s, timedelay=%0.1f us\n",
+			block_size, thread_num, speed,
+			tc / thread_num / count / copts->run_num);
+	} else {
+		speed = total_out / tc /
+			1024 / 1024 * 1000 * 1000 * copts->run_num,
+		fprintf(stderr,
+			"Decompress bz=%d, threadnum= %d, speed=%0.3f MB/s, timedelay=%0.1f us\n",
+			block_size, thread_num, speed,
+			tc / thread_num / count / copts->run_num);
+	}
+
+	free(file_buf);
+	uninit_config(&info, sched);
+
+	return 0;
+
+src_buf_free:
+	free(test_thrds_data[i].src);
+
+buf_free:
+	for (j = 0; j < i; j++) {
+		free(test_thrds_data[i].src);
+		free(test_thrds_data[i].dst);
+	}
+
+	free(file_buf);
+
+	WD_ERR("thread malloc fail!ENOMEM!\n");
+
+	return -ENOMEM;
+}
+

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -78,6 +78,205 @@ static int hizip_check_rand(unsigned char *buf, unsigned int size, void *opaque)
 	return 0;
 }
 
+/**
+ * compress() - compress memory buffer.
+ * @alg_type: alg_type.
+ *
+ * This function compress memory buffer.
+ */
+int hw_blk_compress(int alg_type, int blksize,
+		    unsigned char *dst, __u32 *dstlen,
+		    unsigned char *src, __u32 srclen)
+{
+	handle_t h_sess;
+	struct wd_comp_sess_setup setup;
+	struct wd_comp_req req;
+	int ret = 0;
+
+	setup.alg_type = alg_type;
+	setup.mode = CTX_MODE_SYNC;
+	h_sess = wd_comp_alloc_sess(&setup);
+	if (!h_sess) {
+		fprintf(stderr,"fail to alloc comp sess!\n");
+		return -EINVAL;
+	}
+	req.src = src;
+	req.src_len = srclen;
+	req.dst = dst;
+	req.dst_len = *dstlen;
+	req.op_type = WD_DIR_COMPRESS;
+
+	dbg("%s:input req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+	ret = wd_do_comp_sync(h_sess, &req);
+	if (ret < 0) {
+		fprintf(stderr,"fail to do comp sync(ret = %d)!\n", ret);
+		return ret;
+	}
+
+	if (req.status) {
+		fprintf(stderr,"fail to do comp sync(status = %d)!\n",
+		req.status);
+		wd_comp_free_sess(h_sess);
+		return req.status;
+	}
+	*dstlen = req.dst_len;
+
+	dbg("%s:output req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+	wd_comp_free_sess(h_sess);
+
+	return ret;
+}
+
+int hw_blk_decompress(int alg_type, int blksize,
+		      unsigned char *dst, __u32 *dstlen,
+		      unsigned char *src, __u32 srclen)
+{
+	handle_t h_sess;
+	struct wd_comp_sess_setup setup;
+	struct wd_comp_req req;
+	int ret = 0;
+
+
+	setup.alg_type = alg_type;
+	setup.mode = CTX_MODE_SYNC;
+	h_sess = wd_comp_alloc_sess(&setup);
+	if (!h_sess) {
+		fprintf(stderr,"fail to alloc comp sess!\n");
+		return -EINVAL;
+	}
+	req.src = src;
+	req.src_len = srclen;
+	req.dst = dst;
+	req.dst_len = *dstlen;
+	req.op_type = WD_DIR_DECOMPRESS;
+
+	dbg("%s:input req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+
+	ret = wd_do_comp_sync(h_sess, &req);
+	if (ret < 0) {
+		fprintf(stderr,"fail to do comp sync(ret = %d)!\n", ret);
+		return ret;
+	}
+
+	if (req.status) {
+		fprintf(stderr,"fail to do comp sync(status = %d)!\n",
+		req.status);
+		wd_comp_free_sess(h_sess);
+		return req.status;
+	}
+	*dstlen = req.dst_len;
+
+	dbg("%s:output req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+	wd_comp_free_sess(h_sess);
+
+	return ret;
+}
+
+int hw_stream_compress(int alg_type, int blksize,
+		       unsigned char *dst, __u32 *dstlen,
+		       unsigned char *src, __u32 srclen)
+{
+	handle_t h_sess;
+	struct wd_comp_sess_setup setup;
+	struct wd_comp_req req;
+	int ret = 0;
+
+	setup.alg_type = alg_type;
+	setup.mode = CTX_MODE_SYNC;
+	h_sess = wd_comp_alloc_sess(&setup);
+	if (!h_sess) {
+		fprintf(stderr,"fail to alloc comp sess!\n");
+		return -EINVAL;
+	}
+	req.src = src;
+	req.src_len = srclen;
+	req.dst = dst;
+	req.dst_len = *dstlen;
+	req.op_type = WD_DIR_COMPRESS;
+
+	dbg("%s:input req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+	ret = wd_do_comp_sync2(h_sess, &req);
+	if (ret < 0) {
+		fprintf(stderr,"fail to do comp sync(ret = %d)!\n", ret);
+		return ret;
+	}
+
+	if (req.status) {
+		fprintf(stderr,"fail to do comp sync(status = %d)!\n",
+		req.status);
+		wd_comp_free_sess(h_sess);
+		return req.status;
+	}
+	*dstlen = req.dst_len;
+
+	dbg("%s:output req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+	wd_comp_free_sess(h_sess);
+
+	return ret;
+}
+
+
+int hw_stream_decompress(int alg_type, int blksize,
+		       unsigned char *dst, __u32 *dstlen,
+		       unsigned char *src, __u32 srclen)
+{
+	handle_t h_sess;
+	struct wd_comp_sess_setup setup;
+	struct wd_comp_req req;
+	int ret = 0;
+
+
+	setup.alg_type = alg_type;
+	setup.mode = CTX_MODE_SYNC;
+	h_sess = wd_comp_alloc_sess(&setup);
+	if (!h_sess) {
+		fprintf(stderr,"fail to alloc comp sess!\n");
+		return -EINVAL;
+	}
+	req.src = src;
+	req.src_len = srclen;
+	req.dst = dst;
+	req.dst_len = *dstlen;
+	req.op_type = WD_DIR_DECOMPRESS;
+
+	dbg("%s:input req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+
+	ret = wd_do_comp_sync2(h_sess, &req);
+	if (ret < 0) {
+		fprintf(stderr,"fail to do comp sync(ret = %d)!\n", ret);
+		return ret;
+	}
+
+	if (req.status) {
+		fprintf(stderr,"fail to do comp sync(status = %d)!\n",
+		req.status);
+		wd_comp_free_sess(h_sess);
+		return req.status;
+	}
+	*dstlen = req.dst_len;
+
+	dbg("%s:output req: src:%p, dst:%p,src_len: %d, dst_len:%d\n",
+	    __func__, req.src, req.dst, req.src_len, req.dst_len);
+
+	wd_comp_free_sess(h_sess);
+
+	return ret;
+}
+
 void hizip_prepare_random_input_data(struct hizip_test_info *info)
 {
 	__u32 seed = 0;
@@ -195,7 +394,7 @@ void *send_thread_func(void *arg)
 				ret = wd_do_comp_sync(h_sess, &info->req);
 			}
 			if (ret < 0) {
-				WD_ERR("hizip test fail with %d\n", ret);
+				WD_ERR("do comp test fail with %d\n", ret);
 				return NULL;
 			}
 			left -= copts->block_size;
@@ -464,6 +663,15 @@ int parse_common_option(const char opt, const char *optarg,
 		opts->q_num = strtol(optarg, NULL, 0);
 		if (opts->q_num <= 0)
 			return 1;
+		break;
+	case 'd':
+		opts->op_type = WD_DIR_DECOMPRESS;
+		break;
+	case 'F':
+		opts->is_file = true;
+		break;
+	case 'S':
+		opts->is_stream = MODE_STREAM;
 		break;
 	case 's':
 		opts->total_len = strtol(optarg, NULL, 0);

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -9,7 +9,7 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <unistd.h>
-
+#include <sys/stat.h>
 #include "wd_comp.h"
 
 #define SYS_ERR_COND(cond, msg, ...) \
@@ -22,6 +22,11 @@ do { \
 		exit(EXIT_FAILURE); \
 	} \
 } while (0)
+
+enum mode {
+	MODE_BLOCK,
+	MODE_STREAM,
+};
 
 /*
  * I observed a worst case of 1.041x expansion with random data, but let's say 2
@@ -50,6 +55,8 @@ struct test_options {
 	bool verify;
 	bool verbose;
 	bool is_decomp;
+	bool is_stream;
+	bool is_file;
 };
 
 struct priv_options {
@@ -137,6 +144,27 @@ int hizip_verify_random_output(char *out_buf, struct test_options *opts,
 void *mmap_alloc(size_t len);
 int lib_poll_func(__u32 pos, __u32 expect, __u32 *count);
 typedef int (*check_output_fn)(unsigned char *buf, unsigned int size, void *opaque);
+
+/* for block interface */
+int hw_blk_compress(int alg_type, int blksize,
+		    unsigned char *dst, __u32 *dstlen,
+		    unsigned char *src, __u32 srclen);
+
+int hw_blk_decompress(int alg_type, int blksize,
+		      unsigned char *dst, __u32 *dstlen,
+		      unsigned char *src, __u32 srclen);
+
+/* for stream memory interface */
+int hw_stream_compress(int alg_type, int blksize,
+		       unsigned char *dst, __u32 *dstlen,
+		       unsigned char *src, __u32 srclen);
+
+int hw_stream_decompress(int alg_type, int blksize,
+		         unsigned char *dst, __u32 *dstlen,
+		         unsigned char *src, __u32 srclen);
+
+int comp_file_test(FILE *source, FILE *dest, struct priv_options *opts);
+
 #ifdef USE_ZLIB
 int hizip_check_output(void *buf, size_t size, size_t *checked,
 		       check_output_fn check_output, void *opaque);
@@ -172,7 +200,7 @@ static inline void hizip_test_adjust_len(struct test_options *opts)
 		opts->block_size * opts->block_size;
 }
 
-#define COMMON_OPTSTRING "hb:n:q:c:l:s:Vvzt:m:d"
+#define COMMON_OPTSTRING "hb:n:q:c:l:FSs:Vvzt:m:d"
 
 #define COMMON_HELP "%s [opts]\n"					\
 	"  -b <size>     block size\n"					\
@@ -180,6 +208,8 @@ static inline void hizip_test_adjust_len(struct test_options *opts)
 	"  -q <num>      number of queues\n"				\
 	"  -c <num>      number of caches\n"				\
 	"  -l <num>      number of compact runs\n"			\
+	"  -F <file>     input file, default no input\n"					\
+	"  -S <mode>     stream mode, default block mode\n"					\
 	"  -s <size>     total size\n"					\
 	"  -V            verify output\n"				\
 	"  -v            display detailed performance information\n"	\

--- a/test/hisi_zip_test/test_sva_perf.c
+++ b/test/hisi_zip_test/test_sva_perf.c
@@ -566,7 +566,7 @@ static int run_one_child(struct priv_options *opts)
 
 		ret = hizip_test_sched(sched, copts, info);
 		if (ret < 0) {
-			WD_ERR("hizip test fail with %d\n", ret);
+			WD_ERR("hizip test sched fail with %d\n", ret);
 			break;
 		}
 	}
@@ -684,7 +684,7 @@ static int run_bind_test(struct priv_options *opts)
 	return success ? 0 : -EFAULT;
 }
 
-static int run_test(struct priv_options *opts)
+static int run_test(struct priv_options *opts, FILE *source, FILE *dest)
 {
 	int i;
 	int ret;
@@ -695,6 +695,9 @@ static int run_test(struct priv_options *opts)
 	struct hizip_stats variation;
 	struct hizip_stats stats[n];
 
+	if(opts->common.is_file) {
+		return comp_file_test(source, dest, opts);
+	}
 	memset(&avg , 0, sizeof(avg));
 	memset(&std , 0, sizeof(std));
 	memset(&variation , 0, sizeof(variation));
@@ -801,13 +804,15 @@ int main(int argc, char **argv)
 			.q_num		= 1,
 			.run_num	= 1,
 			.compact_run_num = 1,
-			.thread_num	= 0,
+			.thread_num	= 1,
 			.sync_mode	= 0,
 			.block_size	= 512000,
 			.total_len	= opts.common.block_size * 10,
 			.verify		= false,
 			.verbose	= false,
 			.is_decomp	= false,
+			.is_stream	= false,
+			.is_file	= false,
 		},
 		.warmup_num		= 0,
 		.display_stats		= STATS_PRETTY,
@@ -906,5 +911,5 @@ int main(int argc, char **argv)
 		     argv[0]
 		    );
 
-	return run_test(&opts);
+	return run_test(&opts, stdin, stdout);
 }


### PR DESCRIPTION
sample:

for block mode, only support 8M file max.
./test_sva_perf -F < file > out.gz
./test_sva_perf -F -d < out.gz > file

for stream mode, support (u32) 4GB-1.
./test_sva_perf -F -S < file > out.gz
./test_sva_perf -F -S -d < out.gz > file

also support multi-therad, use -t num.

Signed-off-by: Hao Fang <fanghao11@huawei.com>