### PR TITLE
wd: aead: fix loading share library

### DIFF
--- a/wd_aead.c
+++ b/wd_aead.c
@@ -53,7 +53,7 @@ static void __attribute__((constructor)) wd_aead_open_driver(void)
 {
 	void *driver;
 
-	driver = dlopen("/usr/lib/wd/libhisi_sec.so", RTLD_NOW);
+	driver = dlopen("libhisi_sec.so", RTLD_NOW);
 	if (!driver)
 		WD_ERR("failed to open libhisi_sec.so\n");
 }


### PR DESCRIPTION
Do not use absolute path, otherwise shared library load fail.
Instead, shared library path should rely on environment path.
log:
openat(AT_FDCWD, "/usr/lib/wd/libhisi_sec.so", O_RDONLY|O_CLOEXEC) = -1 ENOENT
(No such file or directory)

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>