### PR TITLE
wd/cipher: remove g_ prefix from global variable

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -38,11 +38,15 @@ Build kernel and install the kernel image on Hisilicon platform.
 
 Configure UADK
 
+    $ ./cleanup.sh
     $ ./autogen.sh
     $ ./conf.sh
 
     UADK could be configured as either static or dynamic library by conf.sh.
     By default, it's configured as dynamic library.
+
+    If user wants to switch between static and dynamic library, he needs to
+    make sure that cleanup.sh is executed before build.
 
     $ make
     $ make install

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -269,11 +269,11 @@ struct hisi_sec_sqe {
 	struct hisi_sec_sqe_type2 type2;
 };
 
-static int g_digest_a_alg[WD_DIGEST_TYPE_MAX] = {
+static int digest_a_alg[WD_DIGEST_TYPE_MAX] = {
 	A_ALG_SM3, A_ALG_MD5, A_ALG_SHA1, A_ALG_SHA256, A_ALG_SHA224,
 	A_ALG_SHA384, A_ALG_SHA512, A_ALG_SHA512_224, A_ALG_SHA512_256
 };
-static int g_hmac_a_alg[WD_DIGEST_TYPE_MAX] = {
+static int hmac_a_alg[WD_DIGEST_TYPE_MAX] = {
 	A_ALG_HMAC_SM3, A_ALG_HMAC_MD5, A_ALG_HMAC_SHA1,
 	A_ALG_HMAC_SHA256, A_ALG_HMAC_SHA224, A_ALG_HMAC_SHA384,
 	A_ALG_HMAC_SHA512, A_ALG_HMAC_SHA512_224, A_ALG_HMAC_SHA512_256
@@ -606,7 +606,7 @@ static int fill_digest_bd2_alg(struct wd_digest_msg *msg,
 	sqe->type2.mac_key_alg = msg->out_bytes / WORD_BYTES;
 	if (msg->mode == WD_DIGEST_NORMAL)
 		sqe->type2.mac_key_alg |=
-		g_digest_a_alg[msg->alg] << AUTH_ALG_OFFSET;
+		digest_a_alg[msg->alg] << AUTH_ALG_OFFSET;
 	else if (msg->mode == WD_DIGEST_HMAC) {
 		if (msg->key_bytes & WORD_ALIGNMENT_MASK) {
 			WD_ERR("Invalid digest key_bytes!\n");
@@ -617,7 +617,7 @@ static int fill_digest_bd2_alg(struct wd_digest_msg *msg,
 		sqe->type2.a_key_addr = (__u64)msg->key;
 
 		sqe->type2.mac_key_alg |=
-		(__u32)(g_hmac_a_alg[msg->alg] << AUTH_ALG_OFFSET);
+		(__u32)(hmac_a_alg[msg->alg] << AUTH_ALG_OFFSET);
 	} else {
 		WD_ERR("Invalid digest mode!\n");
 		return -WD_EINVAL;

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -200,13 +200,12 @@ static inline void hizip_test_adjust_len(struct test_options *opts)
 		opts->block_size * opts->block_size;
 }
 
-#define COMMON_OPTSTRING "hb:n:q:c:l:FSs:Vvzt:m:d"
+#define COMMON_OPTSTRING "hb:n:q:l:FSs:Vvzt:m:d"
 
 #define COMMON_HELP "%s [opts]\n"					\
 	"  -b <size>     block size\n"					\
 	"  -n <num>      number of runs\n"				\
 	"  -q <num>      number of queues\n"				\
-	"  -c <num>      number of caches\n"				\
 	"  -l <num>      number of compact runs\n"			\
 	"  -F            input file, default no input\n"					\
 	"  -S            stream mode, default block mode\n"					\


### PR DESCRIPTION
Remove "g_" prefix from global variable.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>