### PR TITLE
test: sec: Use the schedule API replace the stub of cipher test.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ libwd_crypto_la_SOURCES=wd_cipher.c wd_cipher.h wd_cipher_drv.h \
 			wd_dh.c wd_dh.h wd_dh_drv.h \
 			wd_digest.c wd_digest.h wd_digest_drv.h \
 			wd_util.c wd_util.h
-libwd_crypto_la_LIBADD= $(libwd_la_OBJECTS) -ldl
+libwd_crypto_la_LIBADD= $(libwd_la_OBJECTS) -ldl -lnuma
 
 libhisi_sec_la_SOURCES=drv/hisi_sec.c drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h wd_cipher_drv.h wd_aead_drv.h

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -109,18 +109,14 @@ struct wd_sched {
 	__u32 (*pick_next_ctx)(handle_t h_sched_ctx,
 				  const void *req,
 				  const struct sched_key *key);
-	int (*poll_policy)(handle_t h_sched_ctx,
-			   const struct wd_ctx_config *config,
-			   __u32 expect,
-			   __u32 *count);
+	int (*poll_policy)(handle_t h_sched_ctx, __u32 expect, __u32 *count);
 	handle_t h_sched_ctx;
 };
 
 static inline void wd_spinlock(struct wd_lock *lock)
 {
 	while (__atomic_test_and_set(&lock->lock, __ATOMIC_ACQUIRE))
-		while (__atomic_load_n(&lock->lock, __ATOMIC_RELAXED))
-			;
+		while (__atomic_load_n(&lock->lock, __ATOMIC_RELAXED));
 }
 
 static inline void wd_unspinlock(struct wd_lock *lock)

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -74,6 +74,7 @@ struct wd_cipher_sess {
 	void			*priv;
 	void			*key;
 	__u32			key_bytes;
+	int				numa;
 };
 
 struct wd_cipher_req {
@@ -86,6 +87,7 @@ struct wd_cipher_req {
 	__u32			out_buf_bytes;
 	__u32			out_bytes;
 	__u16			state;
+	__u8			type;
 	wd_alg_cipher_cb_t	*cb;
 	void			*cb_param;
 };

--- a/test/hisi_hpre_test/test_hisi_hpre.c
+++ b/test/hisi_hpre_test/test_hisi_hpre.c
@@ -1033,8 +1033,7 @@ __u32 hpre_pick_next_ctx(handle_t sched_ctx,
 	return last_ctx;
 }
 
-int rsa_poll_policy(handle_t h_sched_ctx, const struct wd_ctx_config *config,
-		__u32 expect, __u32 *count)
+int rsa_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
 {
 	int ret;
 	struct wd_ctx *ctxs;
@@ -1058,8 +1057,7 @@ int rsa_poll_policy(handle_t h_sched_ctx, const struct wd_ctx_config *config,
 	return 0;
 }
 
-int dh_poll_policy(handle_t h_sched_ctx, const struct wd_ctx_config *config,
-		__u32 expect, __u32 *count)
+int dh_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
 {
 	int ret;
 	struct wd_ctx *ctxs;

--- a/test/hisi_sec_test/Makefile.am
+++ b/test/hisi_sec_test/Makefile.am
@@ -2,11 +2,11 @@ AM_CFLAGS=-Wall -O0 -fno-strict-aliasing -I../../include -pthread
 
 bin_PROGRAMS=test_hisi_sec
 
-test_hisi_sec_SOURCES=test_hisi_sec.c test_hisi_sec.h
+test_hisi_sec_SOURCES=test_hisi_sec.c ../sched_sample.c
 
 if WD_STATIC_DRV
 test_hisi_sec_LDADD=../../.libs/libwd.a ../../.libs/libwd_crypto.a \
-			../../.libs/libhisi_sec.a
+			../../.libs/libhisi_sec.a /usr/lib/aarch64-linux-gnu/libnuma.a
 else
 test_hisi_sec_LDADD=-L../../.libs -lwd -lwd_crypto -lhisi_sec
 endif

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -619,5 +619,5 @@ int wd_aead_poll_ctx(__u32 index, __u32 expt, __u32 *count)
 
 int wd_aead_poll(__u32 expt, __u32 *count)
 {
-	return g_wd_aead_setting.sched.poll_policy(0, 0, expt, count);
+	return g_wd_aead_setting.sched.poll_policy(0, expt, count);
 }

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -609,12 +609,10 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 int wd_comp_poll(__u32 expt, __u32 *count)
 {
 	handle_t h_sched_ctx;
-	struct wd_ctx_config *config;
 	struct wd_sched *sched;
 
 	h_sched_ctx = wd_comp_setting.sched.h_sched_ctx;
-	config = (struct wd_ctx_config *)&wd_comp_setting.config;
 	sched = &wd_comp_setting.sched;
 
-	return sched->poll_policy(h_sched_ctx, config, expt, count);
+	return sched->poll_policy(h_sched_ctx, expt, count);
 }

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -404,7 +404,7 @@ int wd_dh_poll_ctx(__u32 pos, __u32 expt, __u32 *count)
 
 int wd_dh_poll(__u32 expt, __u32 *count)
 {
-	return wd_dh_setting.sched.poll_policy(0, 0, expt, count);
+	return wd_dh_setting.sched.poll_policy(0, expt, count);
 }
 
 int wd_dh_get_mode(handle_t sess, __u8 *alg_mode)

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -411,5 +411,5 @@ int wd_digest_poll_ctx(__u32 index, __u32 expt, __u32 *count)
 
 int wd_digest_poll(__u32 expt, __u32 *count)
 {
-	return g_wd_digest_setting.sched.poll_policy(0, 0, expt, count);
+	return g_wd_digest_setting.sched.poll_policy(0, expt, count);
 }

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -464,7 +464,7 @@ int wd_rsa_poll_ctx(__u32 pos, __u32 expt, __u32 *count)
 
 int wd_rsa_poll(__u32 expt, __u32 *count)
 {
-	return wd_rsa_setting.sched.poll_policy(0, 0, expt, count);
+	return wd_rsa_setting.sched.poll_policy(0, expt, count);
 }
 
 int wd_rsa_kg_in_data(struct wd_rsa_kg_in *ki, char **data)


### PR DESCRIPTION
The sec cipher test used the stub that only surport the simple case.
Tish patch add the scheudle API to cipher.

Signed-ff by: Zhenkun Mi <mi_zhenkun@163.com>