### PR TITLE
test: sec: Add the ctx num para in sec test app

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -186,7 +186,7 @@ static int hisi_qm_setup_info(struct hisi_qp *qp, struct hisi_qm_priv *config)
 
 	ret = hisi_qm_setup_db(qp->h_ctx, q_info);
 	if (ret) {
-		WD_ERR("setup region fail\n");
+		WD_ERR("setup db fail\n");
 		goto err_out;
 	}
 


### PR DESCRIPTION
For support the multiple ctxs test case, the test app
support the ctx option for user.We can input the value
to control app alloc multi hareware queue resource and
procsess the data.

Signed-ff by: Zhenkun Mi <mi_zhenkun@163.com>