### PR TITLE
test: zip: fix to accept kill signal

### DIFF
--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -434,6 +434,9 @@ static void *poll_thread_func(void *arg)
 	if (!info->opts->sync_mode)
 		return NULL;
 	while (1) {
+		if (info->faults & INJECT_SIG_WORK)
+			kill(getpid(), SIGTERM);
+
 		pthread_mutex_lock(&mutex);
 		if (!expected)
 			expected = 1;
@@ -686,6 +689,8 @@ int hizip_test_sched(struct wd_sched *sched,
 		ret = wd_do_comp_sync(h_sess, &info->req);
 		if (ret < 0)
 			return ret;
+		if (info->faults & INJECT_SIG_WORK)
+			kill(getpid(), SIGTERM);
 	}
 	info->total_out = info->req.dst_len;
 	return 0;

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -120,6 +120,8 @@ struct hizip_test_info {
 	} tv;
 	/* Test is expected to fail */
 	bool faulting;
+	/* copy of faults field in struct priv_options */
+	unsigned long faults;
 };
 
 void stat_start(struct hizip_test_info *info);

--- a/test/hisi_zip_test/test_sva_perf.c
+++ b/test/hisi_zip_test/test_sva_perf.c
@@ -534,6 +534,8 @@ static int run_one_child(struct priv_options *opts, struct uacce_dev_list *list)
 	memset(&priv_ctx, 0, sizeof(struct priv_context));
 	priv_ctx.opts = opts;
 
+	info->faults = opts->faults;
+
 	info->opts = copts;
 	info->list = list;
 


### PR DESCRIPTION
The operation of handling kill signal is missing. Append it back to fix
the issue.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>