### PR TITLE
wd: mempool: Add the mempool block pool funtion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ $(SUBDIRS):
 
 all: $(DYNOBJS) $(STCOBJS) $(TARGET_DYNLIB) $(TARGET_STCLIB) $(DYNAPP)	\
      $(STCAPP)
-libwd.so.$(VERSION): wd.o
+libwd.so.$(VERSION): wd.o wd_mempool.o
 	$(CC) $(DYNCFLAGS) -o $@ $?
 	$(LN) libwd.so.$(VERSION) libwd.so
 
@@ -90,7 +90,7 @@ zip_sva_perf: test/hisi_zip_test/test_sva_perf.o test/sched_sample.o	\
 	$(CC) -Wl,-rpath=/usr/local/lib -o $@ $^ -L. -lwd -lwd_comp	\
 		-lpthread -lm -lz
 
-libwd.a: wd.lo
+libwd.a: wd.lo wd_mempool.lo
 	$(AR) $(ARFLAGS) $@ $^
 
 libwd_crypto.a: wd_aead.lo wd_cipher.lo wd_digest.lo wd_util.lo		\

--- a/wd_mempool.c
+++ b/wd_mempool.c
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include "wd.h"
+
+struct blkpool {
+	void **blk_elem; /* all the block unit addrs saved in blk_elem */
+	size_t depth;    /* the block pool deph, stack depth */
+	size_t top;      /* the stack top pos for blk_elem */
+	size_t blk_size; /* the size of one block */
+	handle_t mp;     /* record from which mempool */
+};
+
+struct mempool {
+	void *addr;
+	size_t size;
+};
+
+void *wd_blockpool_alloc(handle_t blockpool)
+{
+	struct blkpool *bp = (struct blkpool*)blockpool;
+	
+	if (!bp)
+		return NULL;
+
+	if (bp->top > 0) {
+		bp->top--;
+		return bp->blk_elem[bp->top];
+	}
+	
+	return NULL;
+}
+
+void wd_blockpool_free(handle_t blockpool, void *addr)
+{
+	struct blkpool *bp = (struct blkpool*)blockpool;
+	
+	if (!bp || !addr)
+		return;
+
+	if (bp->top < bp->depth) {
+		bp->blk_elem[bp->top] = addr;
+		bp->top++;
+	}
+}
+
+handle_t wd_blockpool_create(handle_t mempool, size_t block_size, size_t block_num)
+{
+	struct blkpool *bp;
+	struct mempool *mp = (struct mempool*)mempool;
+	size_t i;
+
+	if (!mp) {
+		WD_ERR("Mempool is NULL\n");
+		return -EINVAL;
+	}
+
+	if (block_size * block_num > mp->size) {
+		WD_ERR("block_size = %lu, block_num = %lu, mmp size = %lu\n", block_size, block_num, mp->size);
+		return -EINVAL;
+	}
+
+	bp = malloc(sizeof(struct blkpool));
+	if (!bp)
+		return -ENOMEM;
+
+	bp->blk_elem = malloc(sizeof(void*) * block_num);
+		if (!bp->blk_elem) {
+			free(bp);
+			return -ENOMEM;
+	}
+
+	for (i = 0; i < block_num; i++) {
+		bp->blk_elem[i] = mp->addr + block_size * i;
+	}
+
+	bp->top = block_num;
+	bp->depth = block_num;
+	bp->blk_size = block_size;
+	bp->mp = mempool;
+
+	return (handle_t)bp;
+}
+
+void wd_blockpool_destory(handle_t blockpool)
+{
+	struct blkpool *bp = (struct blkpool*)blockpool;
+
+	if (bp) {
+		if (bp->blk_elem)
+			free(bp->blk_elem);
+
+		free(bp);
+	}
+
+	/* Reserve : give back the mempool to the big pool */
+	//wd_mempool_reback(bp->mp);
+}


### PR DESCRIPTION
To solve the page fault in the kernel, uadk will support the
memory pin feature. The user app need a mechanism to manage
the memory, we name it wd_mempool, this patch finish one part
of the mempool, blk_pool.

Signed-ff by: Zhenkun Mi <mi_zhenkun@163.com>