### PR TITLE
wd/test: Fix zip test app name in sanity_test.sh

### DIFF
--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -17,12 +17,12 @@ hpre_result=-1
 # failed: return 1; success: return 0
 run_zip_test()
 {
-	test_sva_perf -b 8192000 -l 1000 -v -m 0 &> /dev/null
+	zip_sva_perf -b 8192 -l 1000 -v -m 0 &> /dev/null
 	if [ $? -ne 0 ]; then
 		return 1
 	fi
 
-	test_sva_perf -b 8192000 -l 1 -v -m 1 &> /dev/null
+	zip_sva_perf -b 8192 -l 1 -v -m 1 &> /dev/null
 	if [ $? -ne 0 ]; then
 		return 1
 	fi


### PR DESCRIPTION
As zip test APP name has changed, fix it to new name zip_sva_perf.
Also fix block size to 8192 to avoid test warning.

Signed-off-by: Zhou Wang <wangzhou1@hisilicon.com>