### PR TITLE
wd: Remove lock in aead/cipher/digest async APIs

### DIFF
--- a/include/hisi_qm_udrv.h
+++ b/include/hisi_qm_udrv.h
@@ -4,6 +4,7 @@
 
 #include <linux/types.h>
 #include <stdbool.h>
+#include <pthread.h>
 
 #include "config.h"
 #include "wd.h"
@@ -40,6 +41,7 @@ struct hisi_qm_queue_info {
 	__u16 qc_type;
 	__u16 used_num;
 	bool cqc_phase;
+	pthread_spinlock_t lock;
 };
 
 struct hisi_qp {

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -572,7 +572,6 @@ int wd_do_aead_async(handle_t h_sess, struct wd_aead_req *req)
 	memset(msg->aiv, 0, req->iv_bytes);
 	msg->tag = idx;
 
-	pthread_mutex_lock(&ctx->lock);
 	ret = wd_aead_setting.driver->aead_send(ctx->ctx, msg);
 	if (ret < 0) {
 		if (ret != -EBUSY)
@@ -580,7 +579,6 @@ int wd_do_aead_async(handle_t h_sess, struct wd_aead_req *req)
 		wd_put_msg_to_pool(&wd_aead_setting.pool, index, msg->tag);
 		free(msg->aiv);
 	}
-	pthread_mutex_unlock(&ctx->lock);
 
 	return ret;
 }
@@ -600,9 +598,7 @@ int wd_aead_poll_ctx(__u32 index, __u32 expt, __u32 *count)
 	}
 
 	do {
-		pthread_mutex_lock(&ctx->lock);
 		ret = wd_aead_setting.driver->aead_recv(ctx->ctx, &resp_msg);
-		pthread_mutex_unlock(&ctx->lock);
 		if (ret == -EAGAIN) {
 			break;
 		} else if (ret < 0) {

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -415,15 +415,12 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req)
 	fill_request_msg(msg, req, sess);
 	msg->tag = idx;
 
-	pthread_mutex_lock(&ctx->lock);
-
 	ret = wd_cipher_setting.driver->cipher_send(ctx->ctx, msg);
 	if (ret < 0) {
 		if (ret != -EBUSY)
 			WD_ERR("wd cipher async send err!\n");
 		wd_put_msg_to_pool(&wd_cipher_setting.pool, index, msg->tag);
 	}
-	pthread_mutex_unlock(&ctx->lock);
 
 	return ret;
 }
@@ -443,10 +440,8 @@ int wd_cipher_poll_ctx(__u32 index, __u32 expt, __u32* count)
 	}
 
 	do {
-		pthread_mutex_lock(&ctx->lock);
 		ret = wd_cipher_setting.driver->cipher_recv(ctx->ctx,
-							      &resp_msg);
-		pthread_mutex_unlock(&ctx->lock);
+							    &resp_msg);
 		if (ret == -EAGAIN) {
 			break;
 		} else if (ret < 0) {

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -326,7 +326,7 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 	if (unlikely(!dsess || !req || !req->cb)) {
 		WD_ERR("digest input sess or req is NULL.\n");
 		return -EINVAL;
-    }
+	}
 
 	ret = digest_param_ckeck(dsess, req);
 	if (ret)
@@ -353,16 +353,12 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 	fill_request_msg(msg, req, dsess);
 	msg->tag = idx;
 
-	pthread_mutex_lock(&ctx->lock);
-
 	ret = wd_digest_setting.driver->digest_send(ctx->ctx, msg);
 	if (ret < 0) {
 		WD_ERR("failed to send BD, hw is err!\n");
 		wd_put_msg_to_pool(&wd_digest_setting.pool, index, msg->tag);
 		return ret;
 	}
-
-	pthread_mutex_unlock(&ctx->lock);
 
 	return 0;
 }
@@ -382,10 +378,8 @@ int wd_digest_poll_ctx(__u32 index, __u32 expt, __u32 *count)
 	}
 
 	do {
-		pthread_mutex_lock(&ctx->lock);
 		ret = wd_digest_setting.driver->digest_recv(ctx->ctx,
-							      &recv_msg);
-		pthread_mutex_unlock(&ctx->lock);
+							    &recv_msg);
 		if (ret == -EAGAIN) {
 			break;
 		} else if (ret < 0) {


### PR DESCRIPTION
Remove locks in aead/cipher/digest async APIs to qm send/recv functions.
Performance of async one thread/ctx will improve:

numactl --cpubind 1 --membind 1  test_hisi_sec --perf --async --pktlen 1024 \
	--block 1024 --blknum 100000 --times 100000 --multi 1 --ctxnum 1
Former:

time_used:122203 us, send task num:100000
Async mode Pro-51002, thread_id-51002, speed:818310.500000 ops, Perf: 818310 KB/s

Improve to:

time_used:39032 us, send task num:100000
Async mode Pro-60956, thread_id-60956, speed:2562000.500000 ops, Perf: 2562000 KB/s

Signed-off-by: Zhou Wang <wangzhou1@hisilicon.com>