### PR TITLE
sec: cipher: Modify buff filling in cipher test

### DIFF
--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -299,6 +299,7 @@ static void fill_request_msg(struct wd_cipher_msg *msg,
 	msg->key_bytes = sess->key_bytes;
 	msg->iv = req->iv;
 	msg->iv_bytes = req->iv_bytes;
+	msg->data_fmt = req->data_fmt;
 }
 
 int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)


### PR DESCRIPTION
The buff support the sgl of pbuff mode, when sgl mode,
the buff should be created and free by different mode in test.
Now only modify the onece test case of cipher.

Signed-off-by: mizhenkun <mi_zhenkun@163.com>