### PR TITLE
docs: introduce documents in README

### DIFF
--- a/README
+++ b/README
@@ -30,3 +30,12 @@ include/*
 
 docs/*
 	Documentations.
+
+
+======================================
+
+The information of deploying UADK is in INSTALL file.
+
+The design document is in docs/wd_design.md file.
+
+The rules of library version are in docs/maintenance.md file.


### PR DESCRIPTION
Introduce different documents in README. Let user know how to work with
UADK.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>