### PR TITLE
drv: hisi_comp: fix condition on parse_zip_sqe return

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ else	# WITH_UADK_V1
 # x = current - age
 # y = age
 # z = revision
-UADK_VERSION = -version-info 3:0:1
+UADK_VERSION = -version-info 3:1:1
 
 include_HEADERS = include/wd.h include/wd_cipher.h include/wd_comp.h \
 		  include/wd_dh.h include/wd_digest.h include/wd_rsa.h \

--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -326,7 +326,7 @@ static int parse_zip_sqe(struct hisi_qp *qp, struct hisi_zip_sqe *sqe,
 		       ctx_st, status, type);
 		recv_msg->req.status = WD_IN_EPARA;
 	} else {
-		if (!sqe->consumed || !sqe->produced)
+		if (!sqe->produced)
 			return -EAGAIN;
 		recv_msg->req.status = 0;
 	}


### PR DESCRIPTION
When UADK sends the last SQE to hardware accelerator, consumer may
be 0 but producer still records data of previous SQE.

Signed-off-by: wenkai lin <linwenkai755@qq.com>