### PR TITLE
wd: sec: Add cipher sgl mode

### DIFF
--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -678,6 +678,155 @@ static int cipher_iv_check(struct wd_cipher_msg *msg)
 	return 0;
 }
 
+static void hisi_sec_put_sgl(handle_t h_qp, struct wd_cipher_msg *msg)
+{
+	handle_t h_sgl_pool;
+
+	if (msg->data_fmt != WD_SGL_BUF)
+		return;
+
+	h_sgl_pool = hisi_qm_get_sglpool(h_qp);
+	if (!h_sgl_pool)
+		return;
+
+	hisi_qm_put_hw_sgl(h_sgl_pool, msg->in);
+	hisi_qm_put_hw_sgl(h_sgl_pool, msg->out);
+}
+
+static int hisi_sec_fill_sgl(handle_t h_qp, struct wd_cipher_msg *msg,
+		struct hisi_sec_sqe *sqe)
+{
+	handle_t h_sgl_pool;
+	void *hw_sgl_in;
+	void *hw_sgl_out;
+
+	if (msg->data_fmt != WD_SGL_BUF)
+		return 0;
+
+	h_sgl_pool = hisi_qm_get_sglpool(h_qp);
+	if (!h_sgl_pool)
+		return -ENOMEM;
+
+	hw_sgl_in = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)msg->in);
+	if (!hw_sgl_in) {
+		WD_ERR("failed to get hw sgl in!\n");
+		return -ENOMEM;
+	}
+
+	hw_sgl_out = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)msg->out);
+	if (!hw_sgl_out) {
+		WD_ERR("failed to get hw sgl out!\n");
+		hisi_qm_put_hw_sgl(h_sgl_pool, hw_sgl_in);
+		return -ENOMEM;
+	}
+
+	sqe->sds_sa_type |= 0x80;
+	/*
+	 * src_addr_type: 0~1 bits not used now.
+	 * dst_addr_type: 2~4 bits;
+	 * mac_addr_type: 5~7 bits;
+	 */
+	sqe->sdm_addr_type |= 0x04;
+
+	msg->in = hw_sgl_in;
+	msg->out = hw_sgl_out;
+
+	return 0;
+}
+
+static int hisi_sec_fill_sgl_v3(handle_t h_qp, struct wd_cipher_msg *msg,
+		struct hisi_sec_sqe3 *sqe)
+{
+	handle_t h_sgl_pool;
+	void *hw_sgl_in;
+	void *hw_sgl_out;
+
+	if (msg->data_fmt != WD_SGL_BUF)
+		return 0;
+
+	h_sgl_pool = hisi_qm_get_sglpool(h_qp);
+	if (!h_sgl_pool)
+		return -ENOMEM;
+
+	hw_sgl_in = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)msg->in);
+	if (!hw_sgl_in) {
+		WD_ERR("failed to get hw sgl in!\n");
+		return -ENOMEM;
+	}
+
+	hw_sgl_out = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)msg->out);
+	if (!hw_sgl_out) {
+		WD_ERR("failed to get hw sgl out!\n");
+		hisi_qm_put_hw_sgl(h_sgl_pool, hw_sgl_in);
+		return -ENOMEM;
+	}
+
+	/*
+	 * src_addr_type: 11~13 bit
+	 * dst_addr_type: 14~16 bit
+	 */
+	sqe->bd_param |= 0x4800;
+
+	msg->in = hw_sgl_in;
+	msg->out = hw_sgl_out;
+
+	return 0;
+}
+
+
+void dump_sqe(struct hisi_sec_sqe *sqe)
+{
+	printf("*************************************");
+	printf("type_auth_cipher: 0x%x\n", sqe->type_auth_cipher);
+	printf("sds_sa_type: 0x%x\n", sqe->sds_sa_type);
+	printf("sdm_addr_type: 0x%x\n", sqe->sdm_addr_type);
+	printf("rsvd0: 0x%x\n", sqe->rsvd0);
+	printf("huk_ci_key: 0x%x\n", sqe->huk_ci_key);
+	printf("ai_apd_cs: 0x%x\n", sqe->ai_apd_cs);
+	printf("rca_key_frm: 0x%x\n", sqe->rca_key_frm);
+	printf("iv_tls_ld: 0x%x\n", sqe->iv_tls_ld);
+
+	printf("mac_key_alg: 0x%x\n", sqe->type2.mac_key_alg);
+	printf("icvw_kmode: 0x%x\n", sqe->type2.icvw_kmode);
+	printf("c_alg: 0x%x\n", sqe->type2.c_alg);
+	printf("rsvd4: 0x%x\n", sqe->type2.rsvd4);
+	printf("alen_ivllen: 0x%x\n", sqe->type2.alen_ivllen);
+	printf("clen_ivhlen: 0x%x\n", sqe->type2.clen_ivhlen);
+	printf("auth_src_offset: 0x%x\n", sqe->type2.auth_src_offset);
+	printf("cipher_src_offset: 0x%x\n", sqe->type2.cipher_src_offset);
+	printf("cs_ip_header_offset: 0x%x\n", sqe->type2.cs_ip_header_offset);
+	printf("cs_udp_header_offset: 0x%x\n", sqe->type2.cs_udp_header_offset);
+	printf("pass_word_len: 0x%x\n", sqe->type2.pass_word_len);
+	printf("dk_len: 0x%x\n", sqe->type2.dk_len);
+	printf("salt3: 0x%x\n", sqe->type2.salt3);
+	printf("salt2: 0x%x\n", sqe->type2.salt2);
+	printf("salt1: 0x%x\n", sqe->type2.salt1);
+	printf("salt0: 0x%x\n", sqe->type2.salt0);
+	printf("tag: 0x%x\n", sqe->type2.tag);
+	printf("rsvd5: 0x%x\n", sqe->type2.rsvd5);
+	printf("cph_pad: 0x%x\n", sqe->type2.cph_pad);
+	printf("c_pad_len_field: 0x%x\n", sqe->type2.c_pad_len_field);
+	printf("long_a_data_len: 0x%llx\n", sqe->type2.long_a_data_len);
+	printf("a_ivin_addr: 0x%llx\n", sqe->type2.a_ivin_addr);
+	printf("a_key_addr: 0x%llx\n", sqe->type2.a_key_addr);
+	printf("mac_addr: 0x%llx\n", sqe->type2.mac_addr);
+	printf("c_ivin_addr: 0x%llx\n", sqe->type2.c_ivin_addr);
+	printf("c_key_addr: 0x%llx\n", sqe->type2.c_key_addr);
+	printf("data_src_addr: 0x%llx\n", sqe->type2.data_src_addr);
+	printf("data_dst_addr: 0x%llx\n", sqe->type2.data_dst_addr);
+	printf("done_flag: 0x%x\n", sqe->type2.done_flag);
+	printf("error_type: 0x%x\n", sqe->type2.error_type);
+	printf("warning_type: 0x%x\n", sqe->type2.warning_type);
+	printf("mac_i3: 0x%x\n", sqe->type2.mac_i3);
+	printf("mac_i2: 0x%x\n", sqe->type2.mac_i2);
+	printf("mac_i1: 0x%x\n", sqe->type2.mac_i1);
+	printf("mac_i0: 0x%x\n", sqe->type2.mac_i0);
+	printf("check_sum_i: 0x%x\n", sqe->type2.check_sum_i);
+	printf("tls_pad_len_i: 0x%x\n", sqe->type2.tls_pad_len_i);
+	printf("rsvd12: 0x%x\n", sqe->type2.rsvd12);
+	printf("counter: 0x%x\n", sqe->type2.counter);
+}
+
 int hisi_sec_cipher_send(handle_t ctx, struct wd_cipher_msg *msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
@@ -727,6 +876,12 @@ int hisi_sec_cipher_send(handle_t ctx, struct wd_cipher_msg *msg)
 		return ret;
 	}
 
+	ret = hisi_sec_fill_sgl(h_qp, msg, &sqe);
+	if (ret) {
+		WD_ERR("failed to get sgl!\n");
+		return ret;
+	}
+
 	sqe.type2.clen_ivhlen |= (__u32)msg->in_bytes;
 	sqe.type2.data_src_addr = (__u64)msg->in;
 	sqe.type2.data_dst_addr = (__u64)msg->out;
@@ -748,6 +903,7 @@ int hisi_sec_cipher_send(handle_t ctx, struct wd_cipher_msg *msg)
 
 	ret = hisi_qm_send(h_qp, &sqe, 1, &count);
 	if (ret < 0) {
+		hisi_sec_put_sgl(h_qp, msg);
 		return ret;
 	}
 
@@ -767,6 +923,8 @@ int hisi_sec_cipher_recv(handle_t ctx, struct wd_cipher_msg *recv_msg)
 
 	parse_cipher_bd2(&sqe, recv_msg);
 	recv_msg->tag = sqe.type2.tag;
+
+	hisi_sec_put_sgl(h_qp, recv_msg);
 
 	return 0;
 }
@@ -788,22 +946,22 @@ static int fill_cipher_bd3_alg(struct wd_cipher_msg *msg,
 
 	switch (msg->alg) {
 	case WD_CIPHER_SM4:
-		sqe->c_mode_alg = C_ALG_SM4 << SEC_CALG_OFFSET_V3;
-		sqe->c_icv_key = CKEY_LEN_SM4 << SEC_CKEY_OFFSET_V3;
+		sqe->c_mode_alg |= C_ALG_SM4 << SEC_CALG_OFFSET_V3;
+		sqe->c_icv_key |= CKEY_LEN_SM4 << SEC_CKEY_OFFSET_V3;
 		break;
 	case WD_CIPHER_AES:
-		sqe->c_mode_alg = C_ALG_AES << SEC_CALG_OFFSET_V3;
+		sqe->c_mode_alg |= C_ALG_AES << SEC_CALG_OFFSET_V3;
 		ret = get_aes_c_key_len(msg, &c_key_len);
-		sqe->c_icv_key = (__u16)c_key_len << SEC_CKEY_OFFSET_V3;
+		sqe->c_icv_key |= (__u16)c_key_len << SEC_CKEY_OFFSET_V3;
 		break;
 	case WD_CIPHER_DES:
-		sqe->c_mode_alg = C_ALG_DES << SEC_CALG_OFFSET_V3;
-		sqe->c_icv_key = CKEY_LEN_DES << SEC_CKEY_OFFSET_V3;
+		sqe->c_mode_alg |= C_ALG_DES << SEC_CALG_OFFSET_V3;
+		sqe->c_icv_key |= CKEY_LEN_DES << SEC_CKEY_OFFSET_V3;
 		break;
 	case WD_CIPHER_3DES:
-		sqe->c_mode_alg = C_ALG_3DES;
+		sqe->c_mode_alg |= C_ALG_3DES;
 		ret = get_3des_c_key_len(msg, &c_key_len);
-		sqe->c_icv_key = (__u16)c_key_len << SEC_CKEY_OFFSET_V3;
+		sqe->c_icv_key |= (__u16)c_key_len << SEC_CKEY_OFFSET_V3;
 		break;
 	default:
 		WD_ERR("Invalid cipher type!\n");
@@ -893,6 +1051,12 @@ int hisi_sec_cipher_send_v3(handle_t ctx, struct wd_cipher_msg *msg)
 		return ret;
 	}
 
+	ret = hisi_sec_fill_sgl_v3(h_qp, msg, &sqe);
+	if (ret) {
+		WD_ERR("failed to get sgl!\n");
+		return ret;
+	}
+
 	sqe.c_len_ivin |= (__u32)msg->in_bytes;
 	sqe.data_src_addr = (__u64)msg->in;
 	sqe.data_dst_addr = (__u64)msg->out;
@@ -951,6 +1115,8 @@ int hisi_sec_cipher_recv_v3(handle_t ctx, struct wd_cipher_msg *recv_msg)
 
 	parse_cipher_bd3(&sqe, recv_msg);
 	recv_msg->tag = sqe.tag;
+
+	hisi_sec_put_sgl(h_qp, recv_msg);
 
 	return 0;
 }
@@ -1136,7 +1302,7 @@ static int fill_digest_bd3_alg(struct wd_digest_msg *msg,
 		return -WD_EINVAL;
 	}
 
-	sqe->auth_mac_key = (msg->out_bytes / WORD_BYTES) <<
+	sqe->auth_mac_key |= (msg->out_bytes / WORD_BYTES) <<
 				SEC_MAC_OFFSET_V3;
 	if (msg->mode == WD_DIGEST_NORMAL) {
 		sqe->auth_mac_key |=
@@ -1597,13 +1763,13 @@ static int fill_aead_bd3_alg(struct wd_aead_msg *msg,
 
 	switch (msg->calg) {
 	case WD_CIPHER_SM4:
-		sqe->c_mode_alg = C_ALG_SM4 << SEC_CALG_OFFSET_V3;
-		sqe->c_icv_key = CKEY_LEN_SM4 << SEC_CKEY_OFFSET_V3;
+		sqe->c_mode_alg |= C_ALG_SM4 << SEC_CALG_OFFSET_V3;
+		sqe->c_icv_key |= CKEY_LEN_SM4 << SEC_CKEY_OFFSET_V3;
 		break;
 	case WD_CIPHER_AES:
-		sqe->c_mode_alg = C_ALG_AES << SEC_CALG_OFFSET_V3;
+		sqe->c_mode_alg |= C_ALG_AES << SEC_CALG_OFFSET_V3;
 		ret = aead_get_aes_key_len(msg, &c_key_len);
-		sqe->c_icv_key = (__u16)c_key_len << SEC_CKEY_OFFSET_V3;
+		sqe->c_icv_key |= (__u16)c_key_len << SEC_CKEY_OFFSET_V3;
 		break;
 	default:
 		WD_ERR("failed to check aead calg type!\n");
@@ -1653,16 +1819,16 @@ static int fill_aead_bd3_mode(struct wd_aead_msg *msg,
 {
 	switch (msg->cmode) {
 	case WD_CIPHER_CBC:
-		sqe->c_mode_alg = C_MODE_CBC;
+		sqe->c_mode_alg |= C_MODE_CBC;
 		break;
 	case WD_CIPHER_CCM:
-		sqe->c_mode_alg = C_MODE_CCM;
+		sqe->c_mode_alg |= C_MODE_CCM;
 		sqe->auth_mac_key &= ~(AUTH_HMAC_CALCULATE);
 		sqe->a_len_key = msg->assoc_bytes;
 		sqe->c_icv_key |= msg->auth_bytes << SEC_MAC_OFFSET_V3;
 		break;
 	case WD_CIPHER_GCM:
-		sqe->c_mode_alg = C_MODE_GCM;
+		sqe->c_mode_alg |= C_MODE_GCM;
 		sqe->auth_mac_key &= ~(AUTH_HMAC_CALCULATE);
 		sqe->a_len_key = msg->assoc_bytes;
 		sqe->c_icv_key |= msg->auth_bytes << SEC_MAC_OFFSET_V3;

--- a/include/hisi_qm_udrv.h
+++ b/include/hisi_qm_udrv.h
@@ -8,6 +8,7 @@
 
 #include "config.h"
 #include "wd.h"
+#include "wd_alg_common.h"
 
 #define WD_CAPA_PRIV_DATA_SIZE		64
 
@@ -53,6 +54,7 @@ struct hisi_qm_queue_info {
 
 struct hisi_qp {
 	struct hisi_qm_queue_info q_info;
+	handle_t h_sgl_pool;
 	handle_t h_ctx;
 };
 
@@ -90,4 +92,37 @@ int hisi_qm_recv(handle_t h_qp, void *resp, __u16 expect, __u16 *count);
 handle_t hisi_qm_alloc_qp(struct hisi_qm_priv *config, handle_t ctx);
 void hisi_qm_free_qp(handle_t h_qp);
 
+/**
+ * hisi_qm_create_sglpool - Create sgl pool in qm.
+ * @sgl_num: the sgl number.
+ * @sge_num: the sge num in every sgl num.
+ *
+ * Fixed me: the sge buff's size now is Fixed.
+ */
+handle_t hisi_qm_create_sglpool(__u32 sgl_num, __u32 sge_num);
+
+/**
+ * hisi_qm_destroy_sglpool - Destroy sgl pool in qm.
+ * @sgl_pool: Handle of the sgl pool.
+ */
+void hisi_qm_destroy_sglpool(handle_t sgl_pool);
+
+/**
+ * hisi_qm_get_hw_sgl - Get sgl pointer from sgl pool.
+ * @sgl_pool: Handle of the sgl pool.
+ * @sgl: The user sgl info's pointer.
+ *
+ * Return the hw sgl addr which can fill into the sqe.
+ */
+void *hisi_qm_get_hw_sgl(handle_t sgl_pool, struct wd_sgl *sgl);
+
+/**
+ * hisi_qm_put_hw_sgl - Reback the hw sgl to the sgl pool.
+ * @sgl_pool: Handle of the sgl pool.
+ * @hw_sgl: The pointer of the hw sgl which get from sgl pool.
+ */
+void hisi_qm_put_hw_sgl(handle_t sgl_pool, void *hw_sgl);
+handle_t hisi_qm_get_sglpool(handle_t h_qp);
+int hisi_qm_get_sqe(handle_t h_qp, void *sqe);
+void hisi_qm_dump_sgl(void *sgl);
 #endif

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -44,6 +44,11 @@ enum wd_ctx_mode {
 	CTX_MODE_ASYNC,
 };
 
+enum wd_buff_type {
+	WD_FLAT_BUF,
+	WD_SGL_BUF,
+};
+
 /**
  * struct wd_ctx - Define one ctx and related type.
  * @ctx:	The ctx itself.
@@ -116,6 +121,12 @@ struct wd_sched {
 				  const struct sched_key *key);
 	int (*poll_policy)(handle_t h_sched_ctx, __u32 expect, __u32 *count);
 	handle_t h_sched_ctx;
+};
+
+struct wd_sgl {
+	void *data;
+	__u32 len;
+	struct wd_sgl *next;
 };
 
 static inline void wd_spinlock(struct wd_lock *lock)

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -78,8 +78,14 @@ struct wd_cipher_sess {
 
 struct wd_cipher_req {
 	enum wd_cipher_op_type op_type;
-	void			*src;
-	void			*dst;
+	union {
+		struct wd_sgl *sgl_src;
+		void *src;
+	};
+	union {
+		struct wd_sgl *sgl_dst;
+		void *dst;
+	};
 	void			*iv;
 	__u32			in_bytes;
 	__u32			iv_bytes;
@@ -87,6 +93,7 @@ struct wd_cipher_req {
 	__u32			out_bytes;
 	__u16			state;
 	__u8			type;
+	__u8			data_fmt;
 	wd_alg_cipher_cb_t	*cb;
 	void			*cb_param;
 };

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -299,6 +299,7 @@ static void fill_request_msg(struct wd_cipher_msg *msg,
 	msg->key_bytes = sess->key_bytes;
 	msg->iv = req->iv;
 	msg->iv_bytes = req->iv_bytes;
+	msg->data_fmt = req->data_fmt;
 }
 
 int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)


### PR DESCRIPTION
The hw support two data mode, the pbuff and sgl. This patch add
the cipher sgl mode as follows:
1. In the wd cipher, add the sgl struct in wd_cipher_req for user.
2. In the sec diver, transform the wd sgl to hw sgl struct.
3. In the qm, add the sgl pool manage, include create, destroy, get
and put.
4. In the test sec, add the sgl mode para to test the sgl buff to BD.

Signed-off-by: Zhenkun Mi <mi_zhenkun@163.com>