### PR TITLE
drv: sec: Fixed bugs in sec sgl buffer mode

### DIFF
--- a/include/wd.h
+++ b/include/wd.h
@@ -66,6 +66,12 @@ extern FILE *flog_fd;
 #define	WD_IN_EPARA			67
 #define	WD_ENOPROC			68
 
+enum wcrypto_type {
+	WD_CIPHER,
+	WD_DIGEST,
+	WD_AEAD,
+};
+
 struct wd_dtb {
 	char *data;	/* data/buffer start address */
 	__u32 dsize;	/* data size */

--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -68,16 +68,22 @@ struct wd_aead_sess {
  */
 struct wd_aead_req {
 	enum wd_aead_op_type op_type;
-	void			*src;
-	void			*dst;
+	union {
+		struct wd_sgl *sgl_src;
+		void *src;
+	};
+	union {
+		struct wd_sgl *sgl_dst;
+		void *dst;
+	};
 	void			*iv;
-
 	__u32			in_bytes;
 	__u32			out_bytes;
 	__u32			out_buf_bytes;
 	__u16			iv_bytes;
 	__u16			assoc_bytes;
 	__u16			state;
+	__u8		    data_fmt;
 	wd_alg_aead_cb_t	*cb;
 	void			*cb_param;
 };

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -85,13 +85,17 @@ struct wd_digest_sess {
  * fix me: for hmac, seems we need *key also?
  */
 struct wd_digest_req {
-	void		*in;
+	union {
+		void *in;
+		struct wd_sgl *sgl_in;
+	};
 	void		*out;
 	__u32		in_bytes;
 	__u32		out_bytes;
 	__u32		out_buf_bytes;
 	__u16		state;
 	__u16		has_next;
+	__u8        data_fmt;
 	wd_digest_cb_t	*cb;
 	void		*cb_param;
 };

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -430,6 +430,7 @@ static void fill_request_msg(struct wd_aead_msg *msg, struct wd_aead_req *req,
 {
 	memcpy(&msg->req, req, sizeof(struct wd_aead_req));
 
+	msg->alg_type = WD_AEAD;
 	msg->calg = sess->calg;
 	msg->cmode = sess->cmode;
 	msg->dalg = sess->dalg;
@@ -447,6 +448,7 @@ static void fill_request_msg(struct wd_aead_msg *msg, struct wd_aead_req *req,
 	msg->iv_bytes = req->iv_bytes;
 	msg->assoc_bytes = req->assoc_bytes;
 	msg->auth_bytes = sess->auth_bytes;
+	msg->data_fmt = req->data_fmt;
 }
 
 int wd_do_aead_sync(handle_t h_sess, struct wd_aead_req *req)

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -288,6 +288,7 @@ static void fill_request_msg(struct wd_cipher_msg *msg,
 {
 	memcpy(&msg->req, req, sizeof(struct wd_cipher_req));
 
+	msg->alg_type = WD_CIPHER;
 	msg->alg = sess->alg;
 	msg->mode = sess->mode;
 	msg->op_type = req->op_type;

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -238,6 +238,7 @@ static void fill_request_msg(struct wd_digest_msg *msg,
 {
 	memcpy(&msg->req, req, sizeof(struct wd_digest_req));
 
+	msg->alg_type = WD_DIGEST;
 	msg->alg = sess->alg;
 	msg->mode = sess->mode;
 	msg->key = sess->key;
@@ -247,6 +248,7 @@ static void fill_request_msg(struct wd_digest_msg *msg,
 	msg->out = req->out;
 	msg->out_bytes = req->out_bytes;
 	msg->has_next = req->has_next;
+	msg->data_fmt = req->data_fmt;
 }
 
 int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)


### PR DESCRIPTION
1、The digest out buff is not support the sgl mode.
2、The aead src buff len should add the payload and head.

Signed-off-by: Zhenkun Mi <mi_zhenkun@163.com>