### PR TITLE
wd/sec: add CCM/GCM mode 0 input length for SEC

### DIFF
--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -1668,8 +1668,8 @@ int hisi_sec_aead_send(handle_t ctx, struct wd_aead_msg *msg)
 	sqe.sds_sa_type |= (__u8)(de | scene);
 	sqe.type_auth_cipher |= cipher;
 
-	if (msg->in_bytes == 0 ||
-		msg->in_bytes > MAX_INPUT_DATA_LEN) {
+	if (unlikely(msg->in_bytes == 0 ||
+		msg->in_bytes > MAX_INPUT_DATA_LEN)) {
 		WD_ERR("failed to check aead input data length!\n");
 		return -EINVAL;
 	}
@@ -1780,6 +1780,11 @@ static int fill_aead_bd3_alg(struct wd_aead_msg *msg,
 	if (msg->cmode == WD_CIPHER_CCM ||
 	    msg->cmode == WD_CIPHER_GCM)
 		return ret;
+
+	if (unlikely(!msg->in_bytes)) {
+		WD_ERR("failed to check aead in_bytes 0 length!\n");
+		return -WD_EINVAL;
+	}
 
 	if (unlikely(msg->auth_bytes & WORD_ALIGNMENT_MASK)) {
 		WD_ERR("failed to check aead auth_bytes!\n");
@@ -1904,8 +1909,7 @@ int hisi_sec_aead_send_v3(handle_t ctx, struct wd_aead_msg *msg)
 	}
 	sqe.bd_param |= (__u16)(de | scene);
 
-	if (msg->in_bytes == 0 ||
-		msg->in_bytes > MAX_INPUT_DATA_LEN) {
+	if (unlikely(msg->in_bytes > MAX_INPUT_DATA_LEN)) {
 		WD_ERR("failed to check aead input data length!\n");
 		return -EINVAL;
 	}


### PR DESCRIPTION
In the Kunpeng930, the hardware have supported 0 input length
for AEAD CCM/GCM mode algorithms.

Signed-off-by: Liulongfang <836713992@qq.com>