### PR TITLE
drv: qm: Change the wd_sgl to wd_datalist

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -617,13 +617,13 @@ void hisi_qm_put_hw_sgl(handle_t sgl_pool, void *hw_sgl)
 	return;
 }
 
-void *hisi_qm_get_hw_sgl(handle_t sgl_pool, struct wd_sgl *sgl)
+void *hisi_qm_get_hw_sgl(handle_t sgl_pool, struct wd_datalist *sgl)
 {
 	struct hisi_sgl_pool *pool = (struct hisi_sgl_pool*)sgl_pool;
 	struct hisi_sgl *head;
 	struct hisi_sgl *cur;
 	struct hisi_sgl *next;
-	struct wd_sgl *tmp = sgl;
+	struct wd_datalist *tmp = sgl;
 	int i = 0;
 
 	if (!pool || !sgl) {

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -744,13 +744,13 @@ static int hisi_sec_fill_sgl(handle_t h_qp, __u8 data_fmt, __u8 **in,
 	if (!h_sgl_pool)
 		return -ENOMEM;
 
-	hw_sgl_in = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)(*in));
+	hw_sgl_in = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_datalist*)(*in));
 	if (!hw_sgl_in) {
 		WD_ERR("failed to get hw sgl in!\n");
 		return -ENOMEM;
 	}
 
-	hw_sgl_out = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)(*out));
+	hw_sgl_out = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_datalist*)(*out));
 	if (!hw_sgl_out) {
 		WD_ERR("failed to get hw sgl out!\n");
 		hisi_qm_put_hw_sgl(h_sgl_pool, hw_sgl_in);
@@ -785,7 +785,7 @@ static int hisi_sec_fill_sgl_v3(handle_t h_qp, __u8 data_fmt, __u8 **in,
 	if (!h_sgl_pool)
 		return -ENOMEM;
 
-	hw_sgl_in = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)(*in));
+	hw_sgl_in = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_datalist*)(*in));
 	if (!hw_sgl_in) {
 		WD_ERR("failed to get hw sgl in!\n");
 		return -ENOMEM;
@@ -795,7 +795,7 @@ static int hisi_sec_fill_sgl_v3(handle_t h_qp, __u8 data_fmt, __u8 **in,
 		hw_sgl_out = *out;
 		sqe->bd_param |= 0x800;
 	} else {
-		hw_sgl_out = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_sgl*)(*out));
+		hw_sgl_out = hisi_qm_get_hw_sgl(h_sgl_pool, (struct wd_datalist*)(*out));
 		if (!hw_sgl_out) {
 			WD_ERR("failed to get hw sgl out!\n");
 			hisi_qm_put_hw_sgl(h_sgl_pool, hw_sgl_in);

--- a/include/hisi_qm_udrv.h
+++ b/include/hisi_qm_udrv.h
@@ -115,7 +115,7 @@ void hisi_qm_destroy_sglpool(handle_t sgl_pool);
  *
  * Return the hw sgl addr which can fill into the sqe.
  */
-void *hisi_qm_get_hw_sgl(handle_t sgl_pool, struct wd_sgl *sgl);
+void *hisi_qm_get_hw_sgl(handle_t sgl_pool, struct wd_datalist *sgl);
 
 /**
  * hisi_qm_put_hw_sgl - Reback the hw sgl to the sgl pool.

--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -69,11 +69,11 @@ struct wd_aead_sess {
 struct wd_aead_req {
 	enum wd_aead_op_type op_type;
 	union {
-		struct wd_sgl *sgl_src;
+		struct wd_datalist *list_src;
 		void *src;
 	};
 	union {
-		struct wd_sgl *sgl_dst;
+		struct wd_datalist *list_dst;
 		void *dst;
 	};
 	void			*iv;

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -123,10 +123,10 @@ struct wd_sched {
 	handle_t h_sched_ctx;
 };
 
-struct wd_sgl {
+struct wd_datalist {
 	void *data;
 	__u32 len;
-	struct wd_sgl *next;
+	struct wd_datalist *next;
 };
 
 static inline void wd_spinlock(struct wd_lock *lock)

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -79,11 +79,11 @@ struct wd_cipher_sess {
 struct wd_cipher_req {
 	enum wd_cipher_op_type op_type;
 	union {
-		struct wd_sgl *sgl_src;
+		struct wd_datalist *list_src;
 		void *src;
 	};
 	union {
-		struct wd_sgl *sgl_dst;
+		struct wd_datalist *list_dst;
 		void *dst;
 	};
 	void			*iv;

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -87,7 +87,7 @@ struct wd_digest_sess {
 struct wd_digest_req {
 	union {
 		void *in;
-		struct wd_sgl *sgl_in;
+		struct wd_datalist *list_in;
 	};
 	void		*out;
 	__u32		in_bytes;

--- a/test/hisi_sec_test/test_hisi_sec.c
+++ b/test/hisi_sec_test/test_hisi_sec.c
@@ -389,13 +389,13 @@ static void digest_uninit_config(void)
 
 static void test_sec_sgl_free(__u8 data_fmt, void *buff)
 {
-	struct wd_sgl *sgl;
-	struct wd_sgl *tmp;
+	struct wd_datalist *sgl;
+	struct wd_datalist *tmp;
 
 	if (!buff || data_fmt != WD_SGL_BUF)
 		return;
 
-	sgl = (struct wd_sgl*)buff;
+	sgl = (struct wd_datalist*)buff;
 	while (sgl) {
 		tmp = sgl;
 		sgl = sgl->next;
@@ -405,9 +405,9 @@ static void test_sec_sgl_free(__u8 data_fmt, void *buff)
 
 static void *test_sec_buff_create(__u8 data_fmt, void *buff, unsigned int size)
 {
-	struct wd_sgl *cur;
-	struct wd_sgl *next;
-	struct wd_sgl *head;
+	struct wd_datalist *cur;
+	struct wd_datalist *next;
+	struct wd_datalist *head;
 	int size_unit, i;
 	unsigned int tail_size;
 
@@ -418,7 +418,7 @@ static void *test_sec_buff_create(__u8 data_fmt, void *buff, unsigned int size)
 	size_unit = size / g_sgl_num;
 	tail_size = size % g_sgl_num;
 
-	head = malloc(sizeof(struct wd_sgl));
+	head = malloc(sizeof(struct wd_datalist));
 	if (!head) {
 		SEC_TST_PRT("Fail to alloc memory for sgl head!\n");
 		return NULL;
@@ -430,7 +430,7 @@ static void *test_sec_buff_create(__u8 data_fmt, void *buff, unsigned int size)
 	cur = head;
 
 	for (i = 1; i < g_sgl_num; i++) {
-		next = malloc(sizeof(struct wd_sgl));
+		next = malloc(sizeof(struct wd_datalist));
 		if (!next) {
 			SEC_TST_PRT("Fail to alloc memory for sgl!\n");
 			test_sec_sgl_free(data_fmt, head);
@@ -502,7 +502,7 @@ static int test_sec_cipher_sync_once(void)
 
 	SEC_TST_PRT("req src--------->:\n");
 	if (g_data_fmt == WD_SGL_BUF)
-		hexdump(req.sgl_src->data, g_pktlen);
+		hexdump(req.list_src->data, g_pktlen);
 	else
 		hexdump(req.src, g_pktlen);
 
@@ -568,7 +568,7 @@ static int test_sec_cipher_sync_once(void)
 
 	SEC_TST_PRT("Test cipher sync function: output dst-->\n");
 	if (g_data_fmt == WD_SGL_BUF)
-		hexdump(req.sgl_dst->data, req.out_bytes);
+		hexdump(req.list_dst->data, req.out_bytes);
 	else
 		hexdump(req.dst, req.out_bytes);
 
@@ -772,7 +772,7 @@ static int test_sec_cipher_sync(void *arg)
 	pktlen = req->in_bytes;
 	SEC_TST_PRT("cipher req src--------->:\n");
 	if (req->data_fmt == WD_SGL_BUF) {
-		hexdump(req->sgl_src->data, req->sgl_src->len);
+		hexdump(req->list_src->data, req->list_src->len);
 	} else {
 		hexdump(req->src, req->in_bytes);
 	}
@@ -2315,7 +2315,7 @@ static int sec_aead_sync_once(void)
 			(int)syscall(__NR_gettid), speed, Perf);
 
 	if (g_data_fmt == WD_SGL_BUF)
-		hexdump(req.sgl_dst->data, req.out_bytes);
+		hexdump(req.list_dst->data, req.out_bytes);
 	else
 		hexdump(req.dst, req.out_bytes);
 out:


### PR DESCRIPTION
The name wd_sgl is same with the v1 hardware sgl
struct name. In uadk, it is the datalist of user
input.

Signed-off-by: Zhenkun Mi <mi_zhenkun@163.com>