### PR TITLE
drv: qm: Add support of user space (v)SVA task resetting

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -250,6 +250,25 @@ static int his_qm_set_qp_ctx(handle_t h_ctx, struct hisi_qm_priv *config,
 	return 0;
 }
 
+static int hisi_qm_get_qfrs_offs(handle_t h_ctx,
+				 struct hisi_qm_queue_info *q_info)
+{
+	q_info->region_size[UACCE_QFRT_DUS] = wd_ctx_get_region_size(h_ctx,
+								UACCE_QFRT_DUS);
+	if (!q_info->region_size[UACCE_QFRT_DUS]) {
+		WD_ERR("fail to get DUS qfrs offset.\n");
+		return -EINVAL;
+	}
+	q_info->region_size[UACCE_QFRT_MMIO] = wd_ctx_get_region_size(h_ctx,
+								UACCE_QFRT_MMIO);
+	if (!q_info->region_size[UACCE_QFRT_MMIO]) {
+		WD_ERR("fail to get MMIO qfrs offset.\n");
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int hisi_qm_setup_info(struct hisi_qp *qp, struct hisi_qm_priv *config)
 {
 	struct hisi_qm_queue_info *q_info = NULL;
@@ -259,6 +278,12 @@ static int hisi_qm_setup_info(struct hisi_qp *qp, struct hisi_qm_priv *config)
 	ret = hisi_qm_setup_region(qp->h_ctx, q_info);
 	if (ret) {
 		WD_ERR("setup region fail\n");
+		return ret;
+	}
+
+	ret = hisi_qm_get_qfrs_offs(qp->h_ctx, q_info);
+	if (ret) {
+		WD_ERR("get dev qfrs offset fail.\n");
 		return ret;
 	}
 
@@ -277,6 +302,11 @@ static int hisi_qm_setup_info(struct hisi_qp *qp, struct hisi_qm_priv *config)
 	q_info->sqe_size = config->sqe_size;
 	q_info->cqc_phase = 1;
 	q_info->cq_base = q_info->sq_base + config->sqe_size * QM_Q_DEPTH;
+	/* The last 32 bits of DUS show device or qp statuses */
+	q_info->ds_tx_base = q_info->sq_base +
+		q_info->region_size[UACCE_QFRT_DUS] - sizeof(uint32_t);
+	q_info->ds_rx_base = q_info->ds_tx_base - sizeof(uint32_t);
+
 	pthread_spin_init(&q_info->lock, PTHREAD_PROCESS_SHARED);
 
 	return 0;
@@ -363,6 +393,11 @@ int hisi_qm_send(handle_t h_qp, void *req, __u16 expect, __u16 *count)
 
 	pthread_spin_lock(&q_info->lock);
 
+	if (wd_ioread32(q_info->ds_tx_base) == 1) {
+		WD_ERR("wd queue hw error happened before qm send!\n");
+		return -WD_HW_EACCESS;
+	}
+
 	free_num = hisi_qm_get_free_num(q_info);
 	if (!free_num) {
 		pthread_spin_unlock(&q_info->lock);
@@ -437,6 +472,10 @@ int hisi_qm_recv(handle_t h_qp, void *resp, __u16 expect, __u16 *count)
 		return -EINVAL;
 
 	q_info = &qp->q_info;
+	if (wd_ioread32(q_info->ds_rx_base) == 1) {
+		WD_ERR("wd queue hw error happened before qm receive!\n");
+		return -WD_HW_EACCESS;
+	}
 
 	for (i = 0; i < expect; i++) {
 		offset = i * q_info->sqe_size;
@@ -447,6 +486,10 @@ int hisi_qm_recv(handle_t h_qp, void *resp, __u16 expect, __u16 *count)
 	}
 
 	*count = recv_num++;
+	if (wd_ioread32(q_info->ds_rx_base) == 1) {
+		WD_ERR("wd queue hw error happened in qm receive!\n");
+		return -WD_HW_EACCESS;
+	}
 
 	return ret;
 }

--- a/include/hisi_qm_udrv.h
+++ b/include/hisi_qm_udrv.h
@@ -42,6 +42,8 @@ struct hisi_qm_queue_info {
 	void *db_base;
 	int (*db)(struct hisi_qm_queue_info *q, __u8 cmd,
 		  __u16 index, __u8 priority);
+	void *ds_tx_base;
+	void *ds_rx_base;
 	__u16 sq_tail_index;
 	__u16 sq_head_index;
 	__u16 cq_head_index;
@@ -51,6 +53,7 @@ struct hisi_qm_queue_info {
 	__u16 hw_type;
 	bool cqc_phase;
 	pthread_spinlock_t lock;
+	unsigned long region_size[UACCE_QFRT_MAX];
 };
 
 struct hisi_qp {

--- a/include/wd.h
+++ b/include/wd.h
@@ -304,4 +304,13 @@ extern void wd_free_list_accels(struct uacce_dev_list *list);
  */
 extern int wd_ctx_set_io_cmd(handle_t h_ctx, unsigned long cmd, void *arg);
 
+/**
+ * wd_ctx_get_region_size() - Get region offset size
+ * @h_ctx: The handle of context.
+ * @qfrt: Name of context region, which could be got in kernel head file
+ *        include/uapi/misc/uacce/uacce.h
+ * Return device region size.
+ */
+extern unsigned long wd_ctx_get_region_size(handle_t h_ctx, enum uacce_qfrt qfrt);
+
 #endif

--- a/wd.c
+++ b/wd.c
@@ -366,6 +366,14 @@ void wd_drv_unmap_qfr(handle_t h_ctx, enum uacce_qfrt qfrt)
 		munmap(ctx->qfrs_base[qfrt], ctx->qfrs_offs[qfrt]);
 }
 
+unsigned long wd_ctx_get_region_size(handle_t h_ctx, enum uacce_qfrt qfrt)
+{
+	struct wd_ctx_h *ctx = (struct wd_ctx_h *)h_ctx;
+	if (!ctx || qfrt >= UACCE_QFRT_MAX)
+			return 0;
+	return ctx->qfrs_offs[qfrt];
+}
+
 void *wd_ctx_get_priv(handle_t h_ctx)
 {
 	struct wd_ctx_h	*ctx = (struct wd_ctx_h *)h_ctx;

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -471,7 +471,7 @@ int wd_do_aead_sync(handle_t h_sess, struct wd_aead_req *req)
 		return -EINVAL;
 
 	index = wd_aead_setting.sched.pick_next_ctx(0, req, NULL);
-	if (index >= config->ctx_num) {
+	if (unlikely(index >= config->ctx_num)) {
 		WD_ERR("failed to pick a proper ctx!\n");
 		return -EINVAL;
 	}

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -318,7 +318,7 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 		return -EINVAL;
 	}
 
-	if (req->out_buf_bytes < req->in_bytes) {
+	if (unlikely(req->out_buf_bytes < req->in_bytes)) {
 		WD_ERR("cipher set out_buf_bytes is error!\n");
 		return -EINVAL;
 	}
@@ -327,7 +327,7 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 	key.type = 0;
 	key.numa_id = sess->numa;
 	index = wd_cipher_setting.sched.pick_next_ctx(wd_cipher_setting.sched.h_sched_ctx, req, &key);
-	if (index >= config->ctx_num) {
+	if (unlikely(index >= config->ctx_num)) {
 		WD_ERR("fail to pick a proper ctx!\n");
 		return -EINVAL;
 	}
@@ -387,7 +387,7 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req)
 		return -EINVAL;
 	}
 
-	if (req->out_buf_bytes < req->in_bytes) {
+	if (unlikely(req->out_buf_bytes < req->in_bytes)) {
 		WD_ERR("cipher set out_buf_bytes is error!\n");
 		return -EINVAL;
 	}

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -271,7 +271,7 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 
 	/* fix me: maybe wrong */
 	index = wd_digest_setting.sched.pick_next_ctx(0, req, NULL);
-	if (index >= config->ctx_num) {
+	if (unlikely(index >= config->ctx_num)) {
 		WD_ERR("fail to pick next ctx!\n");
 		return -EINVAL;
 	}


### PR DESCRIPTION
While app run on ACC PF and VF in user space including
VM (vSVA) user space, they can be notified as RAS resetting.
Afer that, app can request queue end release the old queue, and
do the task on the new queue again.

Signed-off-by: Kai Ye <yekai13@huawei.com>