### PR TITLE
wd: replace mutex lock by spin lock in ctx structure

### DIFF
--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -93,7 +93,7 @@ struct wd_ctx_internal {
 	handle_t ctx;
 	__u8 op_type;
 	__u8 ctx_mode;
-	pthread_mutex_t lock;
+	pthread_spinlock_t lock;
 };
 
 struct wd_ctx_config_internal {

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -493,11 +493,11 @@ int wd_do_aead_sync(handle_t h_sess, struct wd_aead_req *req)
 	fill_request_msg(&msg, req, sess);
 	req->state = 0;
 
-	pthread_mutex_lock(&ctx->lock);
+	pthread_spin_lock(&ctx->lock);
 	ret = wd_aead_setting.driver->aead_send(ctx->ctx, &msg);
 	if (ret < 0) {
 		WD_ERR("failed to send aead bd!\n");
-		pthread_mutex_unlock(&ctx->lock);
+		pthread_spin_unlock(&ctx->lock);
 		return ret;
 	}
 
@@ -514,14 +514,14 @@ int wd_do_aead_sync(handle_t h_sess, struct wd_aead_req *req)
 			}
 		}
 	} while (ret < 0);
-	pthread_mutex_unlock(&ctx->lock);
+	pthread_spin_unlock(&ctx->lock);
 	free(msg.aiv);
 
 	return 0;
 
 recv_err:
 	req->state = msg.result;
-	pthread_mutex_unlock(&ctx->lock);
+	pthread_spin_unlock(&ctx->lock);
 	free(msg.aiv);
 	return ret;
 }

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -341,11 +341,11 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 	fill_request_msg(&msg, req, sess);
 	req->state = 0;
 
-	pthread_mutex_lock(&ctx->lock);
+	pthread_spin_lock(&ctx->lock);
 
 	ret = wd_cipher_setting.driver->cipher_send(ctx->ctx, &msg);
 	if (ret < 0) {
-		pthread_mutex_unlock(&ctx->lock);
+		pthread_spin_unlock(&ctx->lock);
 		WD_ERR("wd cipher send err!\n");
 		return ret;
 	}
@@ -363,12 +363,12 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 			}
 		}
 	} while (ret < 0);
-	pthread_mutex_unlock(&ctx->lock);
+	pthread_spin_unlock(&ctx->lock);
 
 	return 0;
 recv_err:
 	req->state = msg.result;
-	pthread_mutex_unlock(&ctx->lock);
+	pthread_spin_unlock(&ctx->lock);
 	return ret;
 }
 

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -285,10 +285,10 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 	fill_request_msg(&msg, req, dsess);
 	req->state = 0;
 
-	pthread_mutex_lock(&ctx->lock);
+	pthread_spin_lock(&ctx->lock);
 	ret = wd_digest_setting.driver->digest_send(ctx->ctx, &msg);
 	if (ret < 0) {
-		pthread_mutex_unlock(&ctx->lock);
+		pthread_spin_unlock(&ctx->lock);
 		WD_ERR("failed to send bd!\n");
 		return ret;
 	}
@@ -307,13 +307,13 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 		}
 	} while (ret < 0);
 
-	pthread_mutex_unlock(&ctx->lock);
+	pthread_spin_unlock(&ctx->lock);
 
 	return 0;
 
 recv_err:
 	req->state = msg.result;
-	pthread_mutex_unlock(&ctx->lock);
+	pthread_spin_unlock(&ctx->lock);
 	return ret;
 }
 

--- a/wd_util.c
+++ b/wd_util.c
@@ -45,7 +45,7 @@ int wd_init_ctx_config(struct wd_ctx_config_internal *in,
 		}
 
 		clone_ctx_to_internal(cfg->ctxs + i, ctxs + i);
-		pthread_mutex_init(&ctxs[i].lock, NULL);
+		pthread_spin_init(&ctxs[i].lock, PTHREAD_PROCESS_SHARED);
 	}
 
 	in->ctxs = ctxs;
@@ -85,7 +85,7 @@ void wd_clear_ctx_config(struct wd_ctx_config_internal *in)
 	int i;
 
 	for (i = 0; i < in->ctx_num; i++)
-		pthread_mutex_destroy(&in->ctxs[i].lock);
+		pthread_spin_destroy(&in->ctxs[i].lock);
 
 	in->priv = NULL;
 	in->ctx_num = 0;


### PR DESCRIPTION
Running SEC taskes with multiple threads could gain better performance
in synchronous mode.

numactl --cpubind 1 --membind 1  test_hisi_sec --perf --sync --pktlen 1024 \
        --block 1024 --blknum 100000 --times 100000 --multi 8 --ctxnum 8

Former:

time_used:675324 us, send task num:800000
Sync mode avg Pro-168651, thread_id-168651, speed:1184616.625000 ops, Perf: 1184616 KB/s

Improved to:

time_used:359002 us, send task num:800000
Sync mode avg Pro-150288, thread_id-150288, speed:2228399.750000 ops, Perf: 2228399 KB/s

numactl --cpubind 1 --membind 1  test_hisi_sec --perf --sync --pktlen 1024 \
        --block 1024 --blknum 100000 --times 100000 --multi 16 --ctxnum 16

Former:

time_used:606475 us, send task num:1600000
Sync mode avg Pro-168662, thread_id-168662, speed:2638196.250000 ops, Perf: 2638196 KB/s

Improved to:

time_used:473707 us, send task num:1600000
Sync mode avg Pro-150299, thread_id-150299, speed:3377615.250000 ops, Perf: 3377615 KB/s

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>