### PR TITLE
test: sec: use implemented scheduler

### DIFF
--- a/test/hisi_sec_test/test_hisi_sec.c
+++ b/test/hisi_sec_test/test_hisi_sec.c
@@ -3129,7 +3129,6 @@ out:
 static void *sva_poll_func(void *arg)
 {
 	__u32 count = 0;
-	__u32 recv = 0;
 	int ret;
 
 	int expt = g_times * g_thread_num;
@@ -3140,8 +3139,7 @@ static void *sva_poll_func(void *arg)
 			SEC_TST_PRT("poll ctx error: %d\n", ret);
 			break;
 		}
-		recv += count;
-		if (expt == recv)
+		if (expt == count)
 			break;
 	}
 

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -410,7 +410,6 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req)
 	idx = wd_get_msg_from_pool(&wd_cipher_setting.pool, index,
 				   (void **)&msg);
 	if (idx < 0) {
-		WD_ERR("busy, failed to get msg from pool!\n");
 		return -EBUSY;
 	}
 
@@ -465,7 +464,7 @@ int wd_cipher_poll_ctx(__u32 index, __u32 expt, __u32* count)
 		/* free msg cache to msg_pool */
 		wd_put_msg_to_pool(&wd_cipher_setting.pool, index,
 				   resp_msg.tag);
-	} while (--expt);
+	} while (0);
 	*count = recv_count;
 
 	return ret;


### PR DESCRIPTION
Avoid to use self-defined scheduler in test case. Use common scheduler
instead.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>