### PR TITLE
Fixes and cleanup for the zip_sva_perf test

### DIFF
--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -623,7 +623,9 @@ int init_ctx_config(struct test_options *opts, void *priv,
 		ctx_conf->ctxs[i].op_type = opts->op_type;
 		ctx_conf->ctxs[i].ctx_mode = opts->sync_mode;
 	}
-	wd_comp_init(ctx_conf, *sched);
+	ret = wd_comp_init(ctx_conf, *sched);
+	if (ret)
+		goto out_ctx;
 
 	/* allocate a wd_comp session */
 	memset(&setup, 0, sizeof(struct wd_comp_sess_setup));

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -54,7 +54,7 @@ static int hizip_check_rand(unsigned char *buf, unsigned int size, void *opaque)
 	j = &rand_ctx->off;
 	for (i = 0; i < size; i += 4) {
 		if (*j) {
-			/* Somthing left from a previous run */
+			/* Something left from a previous run */
 			n = rand_ctx->last;
 		} else {
 			n = nrand48(rand_ctx->state);

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -437,7 +437,9 @@ void *send_thread_func(void *arg)
 			}
 			if (ret < 0) {
 				WD_ERR("do comp test fail with %d\n", ret);
-				return NULL;
+				return (void *)(uintptr_t)ret;
+			} else if (info->req.status) {
+				return (void *)(uintptr_t)info->req.status;
 			}
 			if (opts->op_type == WD_DIR_COMPRESS)
 				left -= src_block_size;
@@ -533,17 +535,18 @@ int create_threads(struct hizip_test_info *info)
 int attach_threads(struct hizip_test_info *info)
 {
 	int ret;
+	void *tret;
 
 	if (info->thread_attached)
 		return 0;
-	ret = pthread_join(info->threads[1], NULL);
+	ret = pthread_join(info->threads[1], &tret);
 	if (ret < 0)
 		WD_ERR("Fail on send thread with %d\n", ret);
 	ret = pthread_join(info->threads[0], NULL);
 	if (ret < 0)
 		WD_ERR("Fail on poll thread with %d\n", ret);
 	info->thread_attached = 1;
-	return 0;
+	return (int)(uintptr_t)tret;
 }
 
 /*

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -738,13 +738,13 @@ int parse_common_option(const char opt, const char *optarg,
 		break;
 	case 't':
 		opts->thread_num = strtol(optarg, NULL, 0);
-		SYS_ERR_COND(opts->total_len < 0, "invalid thread num '%s'\n",
+		SYS_ERR_COND(opts->thread_num < 0, "invalid thread num '%s'\n",
 			     optarg);
 		break;
 	case 'm':
 		opts->sync_mode = strtol(optarg, NULL, 0);
-		SYS_ERR_COND(opts->total_len < 0, "invalid sync mode '%s'\n",
-			     optarg);
+		SYS_ERR_COND(opts->sync_mode < 0 || opts->sync_mode > 1,
+			     "invalid sync mode '%s'\n", optarg);
 		break;
 	case 'V':
 		opts->verify = true;

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -664,31 +664,6 @@ void uninit_config(void *priv, struct wd_sched *sched)
 	sample_sched_release(sched);
 }
 
-int hizip_test_sched(struct wd_sched *sched,
-		     struct test_options *opts,
-		     struct hizip_test_info *info
-		     )
-{
-	handle_t h_sess = info->h_sess;
-	//struct sched_key key;
-	int ret;
-
-	//key.numa_id = 0;
-	//key.mode = opts->sync_mode;
-	//key.type = 0;
-	if (opts->sync_mode) {
-		/* async */
-		create_threads(info);
-	} else {
-		ret = wd_do_comp_sync(h_sess, &info->req);
-		if (ret < 0)
-			return ret;
-		if (info->opts->faults & INJECT_SIG_WORK)
-			kill(getpid(), SIGTERM);
-	}
-	info->total_out = info->req.dst_len;
-	return 0;
-}
 
 int parse_common_option(const char opt, const char *optarg,
 			struct test_options *opts)

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -434,6 +434,8 @@ void *send_thread_func(void *arg)
 				ret = wd_do_comp_async(h_sess, &info->req);
 			} else {
 				ret = wd_do_comp_sync(h_sess, &info->req);
+				if (info->opts->faults & INJECT_SIG_WORK)
+					kill(getpid(), SIGTERM);
 			}
 			if (ret < 0) {
 				WD_ERR("do comp test fail with %d\n", ret);

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -372,8 +372,6 @@ void *send_thread_func(void *arg)
 	int j, ret;
 	size_t left;
 
-	stat_start(info);
-
 	for (j = 0; j < opts->compact_run_num; j++) {
 		if (opts->option & TEST_ZLIB) {
 			ret = zlib_deflate(info->out_buf, info->total_len *
@@ -410,8 +408,6 @@ void *send_thread_func(void *arg)
 			info->total_out += info->req.dst_len;
 		}
 	}
-
-	stat_end(info);
 	return NULL;
 }
 
@@ -460,7 +456,6 @@ static void *poll_thread_func(void *arg)
 			usleep(10);
 		}
 	}
-	stat_end(info);
 	pthread_exit(NULL);
 }
 

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -281,24 +281,20 @@ int hw_stream_decompress(int alg_type, int blksize,
 	return ret;
 }
 
-void hizip_prepare_random_input_data(struct hizip_test_info *info)
+void hizip_prepare_random_input_data(char *buf, size_t len, size_t block_size)
 {
 	__u32 seed = 0;
 	unsigned short rand_state[3] = {(seed >> 16) & 0xffff, seed & 0xffff, 0x330e};
 
 	unsigned long remain_size;
-	__u32 block_size, size;
-	char *in_buf;
+	__u32 size;
 	size_t i, j;
 
 	/*
 	 * TODO: change state for each buffer, to make sure there is no TLB
-	 * aliasing. Can we store the seed into priv_info?
+	 * aliasing.
 	 */
-	//__u32 seed = info->state++;
-	block_size = info->opts->block_size;
-	remain_size = info->total_len;
-	in_buf = info->in_buf;
+	remain_size = len;
 
 	while (remain_size > 0) {
 		if (remain_size > block_size)
@@ -317,10 +313,10 @@ void hizip_prepare_random_input_data(struct hizip_test_info *info)
 			__u64 n = nrand48(rand_state);
 
 			for (j = 0; j < 4 && i + j < size; j++)
-				in_buf[i + j] = (n >> (8 * j)) & 0xff;
+				buf[i + j] = (n >> (8 * j)) & 0xff;
 		}
 
-		in_buf += size;
+		buf += size;
 		remain_size -= size;
 	}
 }

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -408,6 +408,7 @@ void *send_thread_func(void *arg)
 			 * combine output buffer by himself.
 			 */
 			info->req.dst += copts->block_size * EXPANSION_RATIO;
+			info->total_out += info->req.dst_len;
 		}
 	}
 

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -794,8 +794,8 @@ int hizip_check_output(void *buf, size_t size, size_t *checked,
 	stream.next_out = out_buffer;
 	stream.avail_out = out_buf_size;
 
-	/* Pass -15 to skip parsing of header, since we have raw data. */
-	ret = inflateInit2(&stream, -15);
+	/* Window size of 15, +32 for auto-decoding gzip/zlib */
+	ret = inflateInit2(&stream, 15 + 32);
 	if (ret != Z_OK) {
 		WD_ERR("zlib inflateInit: %d\n", ret);
 		ret = -EINVAL;
@@ -847,8 +847,8 @@ int zlib_deflate(void *output, unsigned int out_size,
 		.avail_out	= out_size,
 	};
 
-	/* Pass -15 to output raw deflate data */
-	ret = deflateInit2(&stream, Z_BEST_SPEED, Z_DEFLATED, -15, 9,
+	/* Window size of 15 for zlib */
+	ret = deflateInit2(&stream, Z_BEST_SPEED, Z_DEFLATED, 15, 9,
 			   Z_DEFAULT_STRATEGY);
 	if (ret != Z_OK) {
 		WD_ERR("zlib deflateInit: %d\n", ret);

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -117,7 +117,7 @@ int init_ctx_config(struct test_options *opts,
 void uninit_config(void *priv, struct wd_sched *sched);
 struct uacce_dev_list *get_dev_list(struct test_options *opts, int children);
 
-void hizip_prepare_random_input_data(struct hizip_test_info *info);
+void hizip_prepare_random_input_data(char *buf, size_t len, size_t block_size);
 int hizip_verify_random_output(char *out_buf, struct test_options *opts,
 			       struct hizip_test_info *info);
 

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -149,7 +149,8 @@ int comp_file_test(FILE *source, FILE *dest, struct test_options *opts);
 int hizip_check_output(void *buf, size_t size, size_t *checked,
 		       check_output_fn check_output, void *opaque);
 int zlib_deflate(void *output, unsigned int out_size,
-		 void *input, unsigned int in_size, unsigned long *produced);
+		 void *input, unsigned int in_size, unsigned long *produced,
+		 int alg_type);
 #else
 static inline int hizip_check_output(void *buf, size_t size, size_t *checked,
 				     check_output_fn check_output,
@@ -164,7 +165,8 @@ static inline int hizip_check_output(void *buf, size_t size, size_t *checked,
 	return -ENOSYS;
 }
 static inline int zlib_deflate(void *output, unsigned int out_size, void *input,
-			       unsigned int in_size, unsigned long *produced)
+			       unsigned int in_size, unsigned long *produced,
+			       int alg_type)
 {
 	WD_ERR("no zlib available\n");
 	return -ENOSYS;

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -57,10 +57,6 @@ struct test_options {
 	bool is_decomp;
 	bool is_stream;
 	bool is_file;
-};
-
-struct priv_options {
-	struct test_options common;
 
 	int warmup_num;
 
@@ -98,7 +94,6 @@ struct hizip_test_info {
 	int thread_attached;
 	pthread_t *threads;
 	struct hizip_stats *stats;
-	struct priv_options *popts;
 	struct {
 		struct timespec setup_time;
 		struct timespec start_time;
@@ -110,8 +105,6 @@ struct hizip_test_info {
 		struct rusage start_rusage;
 		struct rusage end_rusage;
 	} tv;
-	/* copy of faults field in struct priv_options */
-	unsigned long faults;
 };
 
 void stat_start(struct hizip_test_info *info);
@@ -128,7 +121,7 @@ int init_ctx_config(struct test_options *opts,
 		    struct wd_sched **sched
 		    );
 void uninit_config(void *priv, struct wd_sched *sched);
-struct uacce_dev_list *get_dev_list(struct priv_options *opts, int children);
+struct uacce_dev_list *get_dev_list(struct test_options *opts, int children);
 
 void hizip_prepare_random_input_data(struct hizip_test_info *info);
 int hizip_verify_random_output(char *out_buf, struct test_options *opts,
@@ -156,7 +149,7 @@ int hw_stream_decompress(int alg_type, int blksize,
 		         unsigned char *dst, __u32 *dstlen,
 		         unsigned char *src, __u32 srclen);
 
-int comp_file_test(FILE *source, FILE *dest, struct priv_options *opts);
+int comp_file_test(FILE *source, FILE *dest, struct test_options *opts);
 
 #ifdef USE_ZLIB
 int hizip_check_output(void *buf, size_t size, size_t *checked,

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -82,9 +82,8 @@ struct test_options {
 
 struct hizip_test_info {
 	struct test_options *opts;
-	char *in_buf;
-	char *out_buf;
-	unsigned long total_len;
+	char *in_buf, *out_buf;
+	size_t in_size, out_size;
 	size_t total_out;
 	struct uacce_dev_list *list;
 	handle_t h_sess;
@@ -118,7 +117,11 @@ void uninit_config(void *priv, struct wd_sched *sched);
 struct uacce_dev_list *get_dev_list(struct test_options *opts, int children);
 
 void hizip_prepare_random_input_data(char *buf, size_t len, size_t block_size);
-int hizip_verify_random_output(char *out_buf, struct test_options *opts,
+int hizip_prepare_random_compressed_data(char *buf, size_t out_len,
+					 size_t in_len, size_t *produced,
+					 struct test_options *opts);
+
+int hizip_verify_random_output(struct test_options *opts,
 			       struct hizip_test_info *info);
 
 void *mmap_alloc(size_t len);

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -89,7 +89,6 @@ struct hizip_test_info {
 	char *in_buf;
 	char *out_buf;
 	unsigned long total_len;
-	int is_nosva;
 	size_t total_out;
 	struct uacce_dev_list *list;
 	handle_t h_sess;
@@ -100,13 +99,6 @@ struct hizip_test_info {
 	pthread_t *threads;
 	struct hizip_stats *stats;
 	struct priv_options *popts;
-	/* statistic */
-	struct {
-		int send;
-		int send_retries;
-		int recv;
-		int recv_retries;
-	} *stat;
 	struct {
 		struct timespec setup_time;
 		struct timespec start_time;
@@ -118,8 +110,6 @@ struct hizip_test_info {
 		struct rusage start_rusage;
 		struct rusage end_rusage;
 	} tv;
-	/* Test is expected to fail */
-	bool faulting;
 	/* copy of faults field in struct priv_options */
 	unsigned long faults;
 };

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -110,10 +110,6 @@ struct hizip_test_info {
 void *send_thread_func(void *arg);
 int create_threads(struct hizip_test_info *info);
 int attach_threads(struct hizip_test_info *info);
-int hizip_test_sched(struct wd_sched *sched,
-		     struct test_options *opts,
-		     struct hizip_test_info *info
-		     );
 int init_ctx_config(struct test_options *opts,
 		    void *priv,
 		    struct wd_sched **sched

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -107,8 +107,6 @@ struct hizip_test_info {
 	} tv;
 };
 
-void stat_start(struct hizip_test_info *info);
-void stat_end(struct hizip_test_info *info);
 void *send_thread_func(void *arg);
 int create_threads(struct hizip_test_info *info);
 int attach_threads(struct hizip_test_info *info);

--- a/test/hisi_zip_test/test_sva_perf.c
+++ b/test/hisi_zip_test/test_sva_perf.c
@@ -601,7 +601,6 @@ static int run_one_child(struct priv_options *opts, struct uacce_dev_list *list)
 			fprintf(stderr, "NOTE: test might trash the TLB\n");
 
 		*info = save_info;
-		info->faulting = true;
 
 		ret = hizip_test_sched(sched, copts, info);
 		if (ret >= 0) {

--- a/test/hisi_zip_test/test_sva_perf.c
+++ b/test/hisi_zip_test/test_sva_perf.c
@@ -340,7 +340,8 @@ static int run_one_test(struct test_options *opts, struct hizip_stats *stats)
 
 	enable_thp(opts, &info);
 
-	hizip_prepare_random_input_data(&info);
+	hizip_prepare_random_input_data(in_buf, opts->total_len,
+					opts->block_size);
 
 	if (!event_unavailable &&
 	    perf_event_get("iommu/dev_fault", &perf_fds, &nr_fds)) {
@@ -555,7 +556,8 @@ static int run_one_child(struct test_options *opts, struct uacce_dev_list *list)
 	info.req.dst = out_buf;
 	info.req.src_len = opts->total_len;
 	info.req.dst_len = opts->total_len * EXPANSION_RATIO;
-	hizip_prepare_random_input_data(&info);
+	hizip_prepare_random_input_data(in_buf, opts->total_len,
+					opts->block_size);
 
 	ret = init_ctx_config(opts, &info, &sched);
 	if (ret < 0) {

--- a/test/hisi_zip_test/test_sva_perf.c
+++ b/test/hisi_zip_test/test_sva_perf.c
@@ -20,11 +20,6 @@
 #include "sched_sample.h"
 
 enum hizip_stats_variable {
-	ST_SEND,
-	ST_RECV,
-	ST_SEND_RETRY,
-	ST_RECV_RETRY,
-
 	ST_SETUP_TIME,
 	ST_RUN_TIME,
 	ST_CPU_TIME,
@@ -231,13 +226,6 @@ out_err:
 
 void stat_start(struct hizip_test_info *info)
 {
-	struct hizip_stats *stats = info->stats;
-
-	stats->v[ST_SEND] = 0;
-	stats->v[ST_RECV] = 0;
-	stats->v[ST_SEND_RETRY] = 0;
-	stats->v[ST_RECV_RETRY] = 0;
-
 	clock_gettime(CLOCK_MONOTONIC_RAW, &info->tv.start_time);
 	clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &info->tv.start_cputime);
 	getrusage(RUSAGE_SELF, &info->tv.start_rusage);
@@ -320,9 +308,6 @@ static int run_one_test(struct test_options *opts, struct hizip_stats *stats)
 	void *in_buf, *out_buf;
 	struct hizip_test_info info = {0};
 	struct wd_sched *sched = NULL;
-
-	stats->v[ST_SEND] = stats->v[ST_RECV] = stats->v[ST_SEND_RETRY] =
-			    stats->v[ST_RECV_RETRY] = 0;
 
 	info.stats = stats;
 	info.opts = opts;
@@ -497,8 +482,8 @@ static void output_csv_stats(struct hizip_stats *s, struct test_options *opts)
 	printf("%d;", csv_format_version);
 	printf("%lu;%u;", opts->total_len, opts->block_size);
 	printf("%u;", opts->compact_run_num);
-	printf("%.0f;%.0f;%.0f;%.0f;", s->v[ST_SEND], s->v[ST_RECV],
-	       s->v[ST_SEND_RETRY], s->v[ST_RECV_RETRY]);
+	/* Send/recv are deprecated */
+	printf("0;0;0;0;");
 	printf("%.0f;%.0f;%.0f;", s->v[ST_SETUP_TIME], s->v[ST_RUN_TIME],
 	       s->v[ST_CPU_TIME]);
 	printf("%.0f;%.0f;", s->v[ST_USER_TIME] * 1000,
@@ -765,10 +750,6 @@ static int run_test(struct test_options *opts, FILE *source, FILE *dest)
 
 	if (opts->verbose)
 		fprintf(stderr,
-		" send          %12.0f     ±%0.1f%%\n"
-		" recv          %12.0f     ±%0.1f%%\n"
-		" send retry    %12.0f     ±%0.1f%%\n"
-		" recv retry    %12.0f     ±%0.1f%%\n"
 		" setup time    %12.2f us  ±%0.1f%%\n"
 		" run time      %12.2f us  ±%0.1f%%\n"
 		" CPU time      %12.2f us  ±%0.1f%%\n"
@@ -780,10 +761,6 @@ static int run_test(struct test_options *opts, FILE *source, FILE *dest)
 		" voluntary cs  %12.0f     ±%0.1f%%\n"
 		" invol cs      %12.0f     ±%0.1f%%\n"
 		" compression   %12.0f %%   ±%0.1f%%\n",
-		avg.v[ST_SEND],			variation.v[ST_SEND],
-		avg.v[ST_RECV],			variation.v[ST_RECV],
-		avg.v[ST_SEND_RETRY],		variation.v[ST_SEND_RETRY],
-		avg.v[ST_RECV_RETRY],		variation.v[ST_RECV_RETRY],
 		avg.v[ST_SETUP_TIME] / 1000,	variation.v[ST_SETUP_TIME],
 		avg.v[ST_RUN_TIME] / 1000,	variation.v[ST_RUN_TIME],
 		avg.v[ST_CPU_TIME] / 1000,	variation.v[ST_CPU_TIME],


### PR DESCRIPTION
Several changes to the zip_sva_perf test:

* Small fixes and remove unused code.
* Restore the I/O page fault statistics.
* Most importantly, restore the TLB test (-k tlb), which allows to explicitly trigger invalid page faults with the zip device and is important to testing the kernel SVA infrastructure.
* Finish merging zip_sva_perf with test_bind. Instead of going a different path with the -r (create child processes) and -k (inject faults) options, use a single code path.

Please let me know if I should split into multiple pull requests