### PR TITLE
wd/hpre: support sm2 encrypt/decrypt

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -317,10 +317,17 @@ err_out:
 	return ret;
 }
 
-static int hisi_qm_get_free_num(struct hisi_qm_queue_info *q_info)
+static int get_free_num(struct hisi_qm_queue_info *q_info)
 {
 	/* The device should reserve one buffer. */
 	return (QM_Q_DEPTH - 1) - q_info->used_num;
+}
+
+int hisi_qm_get_free_sqe_num(handle_t h_qp)
+{
+	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
+
+	return get_free_num(&qp->q_info);
 }
 
 handle_t hisi_qm_alloc_qp(struct hisi_qm_priv *config, handle_t ctx)
@@ -399,7 +406,7 @@ int hisi_qm_send(handle_t h_qp, void *req, __u16 expect, __u16 *count)
 		return -WD_HW_EACCESS;
 	}
 
-	free_num = hisi_qm_get_free_num(q_info);
+	free_num = get_free_num(q_info);
 	if (!free_num) {
 		pthread_spin_unlock(&q_info->lock);
 		return -EBUSY;

--- a/include/drv/wd_ecc_drv.h
+++ b/include/drv/wd_ecc_drv.h
@@ -41,6 +41,7 @@
 /* ECC message format */
 struct wd_ecc_msg {
 	struct wd_ecc_req req;
+	struct wd_hash_mt hash;
 	__u64 tag; /* User-defined request identifier */
 	__u8 *key; /* Input key VA, should be DMA buffer */
 	__u16 key_bytes; /* key bytes */

--- a/include/hisi_qm_udrv.h
+++ b/include/hisi_qm_udrv.h
@@ -145,4 +145,12 @@ handle_t hisi_qm_get_sglpool(handle_t h_qp);
  */
 void hisi_qm_sgl_copy(void *dst_buff, void *hw_sgl, __u32 offset, __u32 size);
 
+/**
+ * hisi_qm_get_free_sqe_num - Get the qp's available sqe num
+ * @h_qp: Handle of the qp.
+ *
+ * This interface does not add locks, guaranteed by the caller
+ */
+int hisi_qm_get_free_sqe_num(handle_t h_qp);
+
 #endif


### PR DESCRIPTION
Add encrypt and decrypt processing when message more than 4096bits.

when message more than 4096bits, Kupeng 930 hardware has not realize
the whole process of sm2 algorithm encrypt and decrypt, so drive
realize some process.