### PR TITLE
wd/sec: modify sec driver alg parameter

### DIFF
--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -671,10 +671,16 @@ static void parse_cipher_bd2(struct hisi_sec_sqe *sqe, struct wd_cipher_msg *rec
 
 static int cipher_len_check(struct wd_cipher_msg *msg)
 {
-	if (msg->in_bytes > MAX_INPUT_DATA_LEN) {
-		WD_ERR("input cipher len is too large!\n");
+	if (msg->in_bytes > MAX_INPUT_DATA_LEN ||
+	    !msg->in_bytes) {
+		WD_ERR("input cipher length is error!\n");
 		return -WD_EINVAL;
 	}
+
+	if (msg->mode == WD_CIPHER_OFB ||
+	    msg->mode == WD_CIPHER_CFB ||
+	    msg->mode == WD_CIPHER_CTR)
+		return 0;
 
 	if (msg->mode == WD_CIPHER_XTS) {
 		if (msg->in_bytes < AES_BLOCK_SIZE) {

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -1504,10 +1504,6 @@ static int fill_aead_bd2_alg(struct wd_aead_msg *msg,
 	int ret = 0;
 
 	switch (msg->calg) {
-	case WD_CIPHER_SM4:
-		sqe->type2.c_alg = C_ALG_SM4;
-		sqe->type2.icvw_kmode = CKEY_LEN_SM4 << SEC_CKEY_OFFSET;
-		break;
 	case WD_CIPHER_AES:
 		sqe->type2.c_alg = C_ALG_AES;
 		ret = aead_get_aes_key_len(msg, &c_key_len);


### PR DESCRIPTION
1. wd/sec: modify cipher CTR mode spec
Kunpeng930's CTR mode already supports 1-Byte alignment

2. wd/sec: modify aead alg parameter
Kunpeng920 not support ccm-sm4
