### PR TITLE
uadk/sec: fixup deadlock proble in qm send process and some spelling …

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -408,6 +408,7 @@ int hisi_qm_send(handle_t h_qp, void *req, __u16 expect, __u16 *count)
 
 	if (wd_ioread32(q_info->ds_tx_base) == 1) {
 		WD_ERR("wd queue hw error happened before qm send!\n");
+		pthread_spin_unlock(&q_info->lock);
 		return -WD_HW_EACCESS;
 	}
 

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -264,7 +264,7 @@ struct hisi_sec_sqe {
 	/*
 	 * seq: 0 bits;
 	 * de: 1~2 bits;
-	 * scece: 3~6 bits;
+	 * scene: 3~6 bits;
 	 * src_addr_type: 7 bits;
 	 */
 	__u8 sds_sa_type;
@@ -844,7 +844,7 @@ int hisi_sec_cipher_send(handle_t ctx, struct wd_cipher_msg *msg)
 	memset(&sqe, 0, sizeof(struct hisi_sec_sqe));
 	/* config BD type */
 	sqe.type_auth_cipher = BD_TYPE2;
-	/* config scence */
+	/* config scene */
 	scene = SEC_IPSEC_SCENE << SEC_SCENE_OFFSET;
 	de = DATA_DST_ADDR_ENABLE << SEC_DE_OFFSET;
 	sqe.sds_sa_type = (__u8)(de | scene);
@@ -1024,7 +1024,7 @@ int hisi_sec_cipher_send_v3(handle_t ctx, struct wd_cipher_msg *msg)
 	memset(&sqe, 0, sizeof(struct hisi_sec_sqe3));
 	/* config BD type */
 	sqe.bd_param = BD_TYPE3;
-	/* config scence */
+	/* config scene */
 	scene = SEC_IPSEC_SCENE << SEC_SCENE_OFFSET_V3;
 	de = DATA_DST_ADDR_ENABLE << SEC_DE_OFFSET_V3;
 	sqe.bd_param |= (__u16)(de | scene);
@@ -1173,7 +1173,7 @@ static void qm_fill_digest_long_bd(struct wd_digest_msg *msg,
 	__u64 total_bits;
 
 	if (msg->has_next && (msg->iv_bytes == 0)) {
-		/* LOGN BD FIRST */
+		/* LONG BD FIRST */
 		sqe->ai_apd_cs = AI_GEN_INNER;
 		sqe->ai_apd_cs |= AUTHPAD_NOPAD << AUTHPAD_OFFSET;
 		msg->iv_bytes = msg->out_bytes;
@@ -1184,7 +1184,7 @@ static void qm_fill_digest_long_bd(struct wd_digest_msg *msg,
 		sqe->type2.a_ivin_addr = sqe->type2.mac_addr;
 		msg->iv_bytes = msg->out_bytes;
 	} else if (!msg->has_next && (msg->iv_bytes != 0)) {
-		/* LOGN BD END */
+		/* LONG BD END */
 		sqe->ai_apd_cs = AI_GEN_IVIN_ADDR;
 		sqe->ai_apd_cs |= AUTHPAD_PAD << AUTHPAD_OFFSET;
 		sqe->type2.a_ivin_addr = sqe->type2.mac_addr;
@@ -1236,7 +1236,7 @@ int hisi_sec_digest_send(handle_t ctx, struct wd_digest_msg *msg)
 	sqe.type_auth_cipher = BD_TYPE2;
 	sqe.type_auth_cipher |= AUTH_HMAC_CALCULATE << AUTHTYPE_OFFSET;
 
-	/* config scence */
+	/* config scene */
 	scene = SEC_IPSEC_SCENE << SEC_SCENE_OFFSET;
 	de = DATA_DST_ADDR_DISABLE << SEC_DE_OFFSET;
 
@@ -1352,7 +1352,7 @@ static void qm_fill_digest_long_bd3(struct wd_digest_msg *msg,
 	__u64 total_bits;
 
 	if (msg->has_next && (msg->iv_bytes == 0)) {
-		/* LOGN BD FIRST */
+		/* LONG BD FIRST */
 		sqe->auth_mac_key |= AI_GEN_INNER << SEC_AI_GEN_OFFSET_V3;
 		sqe->stream_scene.stream_auth_pad = AUTHPAD_NOPAD;
 		msg->iv_bytes = msg->out_bytes;
@@ -1363,7 +1363,7 @@ static void qm_fill_digest_long_bd3(struct wd_digest_msg *msg,
 		sqe->auth_ivin.a_ivin_addr = sqe->mac_addr;
 		msg->iv_bytes = msg->out_bytes;
 	} else if (!msg->has_next && (msg->iv_bytes != 0)) {
-		/* LOGN BD END */
+		/* LONG BD END */
 		sqe->auth_mac_key |= AI_GEN_IVIN_ADDR << SEC_AI_GEN_OFFSET_V3;
 		sqe->stream_scene.stream_auth_pad = AUTHPAD_PAD;
 		sqe->auth_ivin.a_ivin_addr = sqe->mac_addr;
@@ -1394,7 +1394,7 @@ int hisi_sec_digest_send_v3(handle_t ctx, struct wd_digest_msg *msg)
 	sqe.bd_param = BD_TYPE3;
 	sqe.auth_mac_key = AUTH_HMAC_CALCULATE;
 
-	/* config scence */
+	/* config scene */
 	scene = SEC_STREAM_SCENE << SEC_SCENE_OFFSET_V3;
 	de = DATA_DST_ADDR_DISABLE << SEC_DE_OFFSET_V3;
 
@@ -1675,7 +1675,7 @@ int hisi_sec_aead_send(handle_t ctx, struct wd_aead_msg *msg)
 	memset(&sqe, 0, sizeof(struct hisi_sec_sqe));
 	/* config BD type */
 	sqe.type_auth_cipher = BD_TYPE2;
-	/* config scence */
+	/* config scene */
 	scene = SEC_IPSEC_SCENE << SEC_SCENE_OFFSET;
 	de = DATA_DST_ADDR_ENABLE << SEC_DE_OFFSET;
 
@@ -1933,7 +1933,7 @@ int hisi_sec_aead_send_v3(handle_t ctx, struct wd_aead_msg *msg)
 	memset(&sqe, 0, sizeof(struct hisi_sec_sqe3));
 	/* config BD type */
 	sqe.bd_param = BD_TYPE3;
-	/* config scence */
+	/* config scene */
 	scene = SEC_IPSEC_SCENE << SEC_SCENE_OFFSET_V3;
 	de = DATA_DST_ADDR_ENABLE << SEC_DE_OFFSET_V3;
 

--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -96,7 +96,7 @@ struct wd_aead_req {
 int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched);
 
 /**
- * wd_aead_uninit() uninitialise ctx configuration and schedule.
+ * wd_aead_uninit() uninitialized ctx configuration and schedule.
  */
 void wd_aead_uninit(void);
 
@@ -164,8 +164,8 @@ int wd_aead_get_maxauthsize(handle_t h_sess);
 /**
  * wd_aead_poll_ctx() poll operation for asynchronous operation
  * @index: index of ctx which will be polled.
- * @expt: user expected num respondings
- * @count: how many respondings this poll has to get.
+ * @expt: user expected num respondences
+ * @count: how many respondences this poll has to get.
  */
 int wd_aead_poll_ctx(__u32 index, __u32 expt, __u32* count);
 
@@ -173,8 +173,8 @@ int wd_aead_poll_ctx(__u32 index, __u32 expt, __u32* count);
  * wd_aead_poll() Poll finished request.
  * this function will call poll_policy function which is registered to wd aead
  * by user.
- * @expt: user expected num respondings
- * @count: how many respondings this poll has to get.
+ * @expt: user expected num respondences
+ * @count: how many respondences this poll has to get.
  */
 int wd_aead_poll(__u32 expt, __u32 *count);
 #endif /* __WD_AEAD_H */

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -136,8 +136,8 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req);
 /**
  * wd_cipher_poll_ctx() poll operation for asynchronous operation
  * @index: index of ctx which will be polled.
- * @expt: user expected num respondings
- * @count: how many respondings this poll has to get.
+ * @expt: user expected num respondences
+ * @count: how many respondences this poll has to get.
  */
 int wd_cipher_poll_ctx(__u32 index, __u32 expt, __u32* count);
 /**

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -306,7 +306,7 @@ void wd_aead_free_sess(handle_t h_sess)
 	free(sess);
 }
 
-static int aead_param_ckeck(struct wd_aead_sess *sess,
+static int aead_param_check(struct wd_aead_sess *sess,
 	struct wd_aead_req *req)
 {
 
@@ -373,7 +373,7 @@ int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	wd_aead_set_static_drv();
 #endif
 
-	/* init sysnc request pool */
+	/* init sync request pool */
 	ret = wd_init_async_request_pool(&wd_aead_setting.pool,
 				config->ctx_num, WD_POOL_MAX_ENTRIES,
 				sizeof(struct wd_aead_msg));
@@ -466,7 +466,7 @@ int wd_do_aead_sync(handle_t h_sess, struct wd_aead_req *req)
 		return -WD_EINVAL;
 	}
 
-	ret = aead_param_ckeck(sess, req);
+	ret = aead_param_check(sess, req);
 	if (ret)
 		return -WD_EINVAL;
 
@@ -541,7 +541,7 @@ int wd_do_aead_async(handle_t h_sess, struct wd_aead_req *req)
 		return -WD_EINVAL;
 	}
 
-	ret = aead_param_ckeck(sess, req);
+	ret = aead_param_check(sess, req);
 	if (ret)
 		return -WD_EINVAL;
 

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -120,7 +120,7 @@ int wd_cipher_set_key(handle_t h_sess, const __u8 *key, __u32 key_len)
 	int ret;
 
 	if (!key || !sess || !sess->key) {
-		WD_ERR("cipher set key inpupt param err!\n");
+		WD_ERR("cipher set key input param err!\n");
 		return -WD_EINVAL;
 	}
 
@@ -129,7 +129,7 @@ int wd_cipher_set_key(handle_t h_sess, const __u8 *key, __u32 key_len)
 
 	ret = cipher_key_len_check(sess->alg, length);
 	if (ret) {
-		WD_ERR("cipher set key inpupt key length err!\n");
+		WD_ERR("cipher set key input key length err!\n");
 		return -WD_EINVAL;
 	}
 	if (sess->alg == WD_CIPHER_DES && is_des_weak_key((__u64 *)key)) {

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -215,7 +215,7 @@ void wd_digest_uninit(void)
 	wd_clear_ctx_config(&wd_digest_setting.config);
 }
 
-static int digest_param_ckeck(struct wd_digest_sess *sess,
+static int digest_param_check(struct wd_digest_sess *sess,
 	struct wd_digest_req *req)
 {
 	if (req->out_buf_bytes < req->out_bytes) {
@@ -265,7 +265,7 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 		return -WD_EINVAL;
 	}
 
-	ret = digest_param_ckeck(dsess, req);
+	ret = digest_param_check(dsess, req);
 	if (ret)
 		return -WD_EINVAL;
 
@@ -330,7 +330,7 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 		return -WD_EINVAL;
 	}
 
-	ret = digest_param_ckeck(dsess, req);
+	ret = digest_param_check(dsess, req);
 	if (ret)
 		return -WD_EINVAL;
 


### PR DESCRIPTION
…error

1. fixup deadlock problem during multi threads flr and control reset in qm send.
2. fixup spelling error on comments and function name.

Signed-off-by: Kai Ye <yekai13@huawei.com>