### PR TITLE
drv/qm: fix lock released problem in qm send

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -413,6 +413,7 @@ int hisi_qm_send(handle_t h_qp, void *req, __u16 expect, __u16 *count)
 
 	if (wd_ioread32(q_info->ds_tx_base) == 1) {
 		WD_ERR("wd queue hw error happened before qm send!\n");
+		pthread_spin_unlock(&q_info->lock);
 		return -WD_HW_EACCESS;
 	}
 


### PR DESCRIPTION
fix lock released problem in qm send during task resetting.

Signed-off-by: Kai Ye <yekai13@huawei.com>