### PR TITLE
cfg: remove uadk_v1 in configuration

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -4,16 +4,11 @@
 
 # Build UADK into static library
 COMPILE_TYPE="--disable-static --enable-shared"
-# Build UADK v2 by default
-UADK_VERSION=""
 
 # These two parameters could be in arbitary sequence
 if [[ $1 && $1 = "--static" ]] || [[ $2 && $2 = "--static" ]]; then
 	echo "Configure to static compile!"
 	COMPILE_TYPE="--enable-static --disable-shared --with-static_drv"
-fi
-if [[ $1 && $1 = "--with-uadk_v1" ]] || [[ $2 && $2 = "--with-uadk_v1" ]]; then
-	UADK_VERSION="--with-uadk_v1"
 fi
 
 
@@ -22,5 +17,4 @@ ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure \
 	--host aarch64-linux-gnu \
 	--target aarch64-linux-gnu \
 	--includedir=/usr/local/include/uadk \
-	$COMPILE_TYPE \
-	$UADK_VERSION
+	$COMPILE_TYPE


### PR DESCRIPTION
"--with-uadk_v1" configuration is unnecessary. Since both uadk v1 and v2
are built into libwd at the same time.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>