### PR TITLE
wd: v1: fix uninitialized variable in BMM

### DIFF
--- a/v1/wd_bmm.c
+++ b/v1/wd_bmm.c
@@ -92,7 +92,7 @@ static int wd_pool_pre_layout(struct wd_queue *q,
 			      struct wd_blkpool *p,
 			      struct wd_blkpool_setup *sp)
 {
-	struct q_info *qinfo;
+	struct q_info *qinfo = NULL;
 	unsigned int asz;
 	int ret;
 


### PR DESCRIPTION
v1/wd_bmm.c: In function ‘wd_blkpool_create’:
v1/wd_bmm.c:124:29: error: ‘qinfo’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  if (!sp->br.alloc && !qinfo->iommu_type)
	                     ^
v1/wd_bmm.c:95:17: note: ‘qinfo’ was declared here
  struct q_info *qinfo;
		 ^
cc1: all warnings being treated as errors
Makefile:756: recipe for target 'v1/wd_bmm.lo' failed
make[2]: *** [v1/wd_bmm.lo] Error 1

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>