### PR TITLE
wd: mem: change prefix on blkpool

### DIFF
--- a/include/wd.h
+++ b/include/wd.h
@@ -401,10 +401,10 @@ extern handle_t wd_blockpool_create(handle_t mempool, size_t block_size,
 				  size_t block_num);
 
 /**
- * wd_blockpool_destory() - Destory blkpool and release memory to the mempool.
+ * wd_blockpool_destroy() - Destory blkpool and release memory to the mempool.
  * @blkpool: The handle of blkpool.
  */
-extern void wd_blockpool_destory(handle_t blkpool);
+extern void wd_blockpool_destroy(handle_t blkpool);
 
 /**
  * wd_mempool_create() - Creat mempool.
@@ -419,10 +419,10 @@ extern void wd_blockpool_destory(handle_t blkpool);
 extern handle_t wd_mempool_create(size_t size, int node);
 
 /**
- * wd_mempool_destory() - Destory mempool.
+ * wd_mempool_destroy() - Destory mempool.
  * @mempool: The handle of mempool.
  */
-extern void wd_mempool_destory(handle_t mempool);
+extern void wd_mempool_destroy(handle_t mempool);
 
 /**
  * wd_mempool_stats() - Dump statistics information about mempool.

--- a/include/wd.h
+++ b/include/wd.h
@@ -331,9 +331,9 @@ enum wd_page_type {
  *	      this is size of each block. Currently it is 4KB fixed.
  * @blk_num: Number of blocks in mempool.
  * @free_blk_num: Number of free blocks in mempool.
- * @blk_usage_rate: In wd_pool_create function, it gets memory from
+ * @blk_usage_rate: In wd_blockpool_create function, it gets memory from
  *		    mempool by mempool blocks. As continuous blocks in mempool
- *		    may be needed, wd_pool_create may fail. blk_usage_rate
+ *		    may be needed, wd_blockpool_create may fail. blk_usage_rate
  * 		    helps to show the usage rate of mempool. It will be helpful
  *		    to show the state of memory fragmentation. e.g. 30 is 30%.
  */
@@ -348,7 +348,7 @@ struct wd_mempool_stats {
 };
 
 /*
- * struct wd_pool_stats - Use to dump statistics info about blkpool
+ * struct wd_blockpool_stats - Use to dump statistics info about blkpool
  * @block_size: Block size.
  * @block_num: Number of blocks.
  * @free_block_num: Number of free blocks.
@@ -364,7 +364,7 @@ struct wd_mempool_stats {
  *    |             |                  |     |     |     |     |
  *    +-------------+                  +-----+-----+-----+-----+
  */
-struct wd_pool_stats {
+struct wd_blockpool_stats {
 	unsigned long block_size;
 	unsigned long block_num;
 	unsigned long free_block_num;
@@ -388,7 +388,7 @@ extern void *wd_block_alloc(handle_t blkpool);
 extern void wd_block_free(handle_t blkpool, void *addr);
 
 /**
- * wd_pool_create() - Blkpool allocate memory from mempool.
+ * wd_blockpool_create() - Blkpool allocate memory from mempool.
  * @mempool: The handle of mempool.
  * @block_size: Size of every block in blkpool.
  * @block_num: Number of blocks in blkpool.
@@ -397,14 +397,14 @@ extern void wd_block_free(handle_t blkpool, void *addr);
  * the error. WD_EINVAL: An invalid value was specified for mempool、block_size
  * or block_num. WD_ENOMEM: Insufficient kernel memory was available.
  */
-extern handle_t wd_pool_create(handle_t mempool, size_t block_size,
+extern handle_t wd_blockpool_create(handle_t mempool, size_t block_size,
 				  size_t block_num);
 
 /**
- * wd_pool_destory() - Destory blkpool and release memory to the mempool.
+ * wd_blockpool_destory() - Destory blkpool and release memory to the mempool.
  * @blkpool: The handle of blkpool.
  */
-extern void wd_pool_destory(handle_t blkpool);
+extern void wd_blockpool_destory(handle_t blkpool);
 
 /**
  * wd_mempool_create() - Creat mempool.
@@ -432,10 +432,10 @@ extern void wd_mempool_destory(handle_t mempool);
 extern void wd_mempool_stats(handle_t mempool, struct wd_mempool_stats *stats);
 
 /**
- * wd_pool_stats() - Dump statistics information about blkpool.
+ * wd_blockpool_stats() - Dump statistics information about blkpool.
  * @blkpool: The handle of blkpool.
- * @stats: Pointer of struct wd_pool_stats.
+ * @stats: Pointer of struct wd_blockpool_stats.
  */
-extern void wd_pool_stats(handle_t blkpool, struct wd_pool_stats *stats);
+extern void wd_blockpool_stats(handle_t blkpool, struct wd_blockpool_stats *stats);
 
 #endif

--- a/test/wd_mempool_test.c
+++ b/test/wd_mempool_test.c
@@ -257,7 +257,7 @@ static int parse_cmd_line(int argc, char *argv[], struct test_option *opt)
 	return 0;
 }
 
-static void dump_mp_bp(struct wd_mempool_stats *mp_s, struct wd_pool_stats *bp_s)
+static void dump_mp_bp(struct wd_mempool_stats *mp_s, struct wd_blockpool_stats *bp_s)
 {
 	printf("---------------------------------------\n");
 	printf("dump mp bp info:\n");
@@ -316,7 +316,7 @@ static int test_blkpool(struct test_option *opt)
 		return -1;
 	}
 
-	bp = wd_pool_create(mp, opt->blk_size[0], opt->blk_num[0]);
+	bp = wd_blockpool_create(mp, opt->blk_size[0], opt->blk_num[0]);
 	if (WD_IS_ERR(bp)) {
 		printf("Fail to create blkpool, err(%lld)!\n", WD_HANDLE_ERR(bp));
 		return -1;
@@ -335,7 +335,7 @@ static int test_blkpool(struct test_option *opt)
 		pthread_join(threads[i], NULL);
 	}
 
-	wd_pool_destory(bp);
+	wd_blockpool_destory(bp);
 	wd_mempool_destory(mp);
 
 	return 0;
@@ -344,7 +344,7 @@ static int test_blkpool(struct test_option *opt)
 void *blk_test_thread(void *data)
 {
 	struct test_opt_per_thread *opt = data;
-	struct wd_pool_stats bp_stats = {0};
+	struct wd_blockpool_stats bp_stats = {0};
 	struct wd_mempool_stats mp_stats = {0};
 	handle_t mp, bp;
 
@@ -354,7 +354,7 @@ void *blk_test_thread(void *data)
 		return (void *)-1;
 	}
 
-	bp = wd_pool_create(mp, opt->blk_size, opt->blk_num);
+	bp = wd_blockpool_create(mp, opt->blk_size, opt->blk_num);
 	if (WD_IS_ERR(bp)) {
 		printf("Fail to create blkpool, err %lld\n", WD_HANDLE_ERR(bp));
 		return (void *)-1;
@@ -379,12 +379,12 @@ void *blk_test_thread(void *data)
 	/* fix me: need a opt? */
 	if (1) {
 		wd_mempool_stats(mp, &mp_stats);
-		wd_pool_stats(bp, &bp_stats);
+		wd_blockpool_stats(bp, &bp_stats);
 		dump_mp_bp(&mp_stats, &bp_stats);
 	}
 
 	wd_block_free(bp, block);
-	wd_pool_destory(bp);
+	wd_blockpool_destory(bp);
 	wd_mempool_destory(mp);
 
 	printf("test mempool successful!\n");
@@ -859,7 +859,7 @@ static int test_sec_perf(struct test_option *opt)
 	}
 
 	for (i = 0; i < bp_thread_num; i++) {
-		datas[i].bp = wd_pool_create(mp, opt->blk_size[i], opt->blk_num[i]);
+		datas[i].bp = wd_blockpool_create(mp, opt->blk_size[i], opt->blk_num[i]);
 		if (WD_IS_ERR(datas[i].bp)) {
 			SEC_TST_PRT("blk_size(%lu) blk_num(%lu), thread(%u) is fail to create blk_pool, err(%lld)\n",
 									opt->blk_size[i], opt->blk_num[i], i, WD_HANDLE_ERR(datas[i].bp));
@@ -925,7 +925,7 @@ dst_fail:
 src_fail:
 		free_bd_pool(&datas[i]);
 init_bd_pool_fail:
-		wd_pool_destory(datas[i].bp);
+		wd_blockpool_destory(datas[i].bp);
 		i--;
 	} while(i >= 0);
 

--- a/test/wd_mempool_test.c
+++ b/test/wd_mempool_test.c
@@ -335,8 +335,8 @@ static int test_blkpool(struct test_option *opt)
 		pthread_join(threads[i], NULL);
 	}
 
-	wd_blockpool_destory(bp);
-	wd_mempool_destory(mp);
+	wd_blockpool_destroy(bp);
+	wd_mempool_destroy(mp);
 
 	return 0;
 }
@@ -384,8 +384,8 @@ void *blk_test_thread(void *data)
 	}
 
 	wd_block_free(bp, block);
-	wd_blockpool_destory(bp);
-	wd_mempool_destory(mp);
+	wd_blockpool_destroy(bp);
+	wd_mempool_destroy(mp);
 
 	printf("test mempool successful!\n");
 	return NULL;
@@ -925,11 +925,11 @@ dst_fail:
 src_fail:
 		free_bd_pool(&datas[i]);
 init_bd_pool_fail:
-		wd_blockpool_destory(datas[i].bp);
+		wd_blockpool_destroy(datas[i].bp);
 		i--;
 	} while(i >= 0);
 
-	wd_mempool_destory(mp);
+	wd_mempool_destroy(mp);
 
 mp_fail:
 	sva_uninit_config();

--- a/wd_mempool.c
+++ b/wd_mempool.c
@@ -543,7 +543,7 @@ static int init_blkpool_elem(struct blkpool *bp)
 	return 0;
 }
 
-handle_t wd_pool_create(handle_t mempool, size_t block_size,
+handle_t wd_blockpool_create(handle_t mempool, size_t block_size,
 			     size_t block_num)
 {
 	struct mempool *mp = (struct mempool*)mempool;
@@ -591,7 +591,7 @@ err_free_bp:
 	return ret;
 }
 
-void wd_pool_destory(handle_t blkpool)
+void wd_blockpool_destory(handle_t blkpool)
 {
 	struct blkpool *bp = (struct blkpool *)blkpool;
 	struct mempool *mp;
@@ -1033,7 +1033,7 @@ void wd_mempool_stats(handle_t mempool, struct wd_mempool_stats *stats)
 	wd_unspinlock(&mp->lock);
 }
 
-void wd_pool_stats(handle_t blkpool, struct wd_pool_stats *stats)
+void wd_blockpool_stats(handle_t blkpool, struct wd_blockpool_stats *stats)
 {
 	struct blkpool *bp = (struct blkpool*)blkpool;
 	unsigned long size = 0;

--- a/wd_mempool.c
+++ b/wd_mempool.c
@@ -218,7 +218,7 @@ static struct bitmap *create_bitmap(int bits)
 	return bm;
 }
 
-static void destory_bitmap(struct bitmap *bm)
+static void destroy_bitmap(struct bitmap *bm)
 {
 	free(bm->map);
 	free(bm);
@@ -591,7 +591,7 @@ err_free_bp:
 	return ret;
 }
 
-void wd_blockpool_destory(handle_t blkpool)
+void wd_blockpool_destroy(handle_t blkpool)
 {
 	struct blkpool *bp = (struct blkpool *)blkpool;
 	struct mempool *mp;
@@ -953,7 +953,7 @@ static int init_mempool(struct mempool *mp)
 
 static void uninit_mempool(struct mempool *mp)
 {
-	destory_bitmap(mp->bitmap);
+	destroy_bitmap(mp->bitmap);
 	mp->bitmap = NULL;
 }
 
@@ -994,7 +994,7 @@ free_pool:
 	return ret;
 }
 
-void wd_mempool_destory(handle_t mempool)
+void wd_mempool_destroy(handle_t mempool)
 {
 	struct mempool *mp = (struct mempool *)mempool;
 


### PR DESCRIPTION
Change prefix on blkpool from wd_pool_ to wd_blockpool_.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>