### PR TITLE
rsa: add semaphore

### DIFF
--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -3,6 +3,7 @@
 
 #include <asm/types.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include "wd.h"
 #include "wd_common.h"
 
@@ -64,6 +65,7 @@ struct wd_ctx_internal {
 	__u8 op_type;
 	__u8 ctx_mode;
 	pthread_spinlock_t lock;
+	sem_t sem;
 };
 
 struct wd_ctx_config_internal {

--- a/test/hisi_hpre_test/test_hisi_hpre.c
+++ b/test/hisi_hpre_test/test_hisi_hpre.c
@@ -8571,11 +8571,6 @@ static int rsa_async_test(int thread_num, __u64 lcore_mask,
 
 	asyn_thread_exit = 1;
 
-	ret = pthread_join(system_test_thrds[0], NULL);
-	if (ret) {
-		HPRE_TST_PRT("Join %dth thread fail!\n", i);
-		return ret;
-	}
 
 	if (g_config.perf_test)
 		HPRE_TST_PRT("<< %s %u thread %s %s mode %u key_bits at %0.3f ops!\n",

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -398,6 +398,7 @@ int wd_do_rsa_async(handle_t sess, struct wd_rsa_req *req)
 		goto fail_with_msg;
 	}
 	pthread_spin_unlock(&ctx->lock);
+	sem_post(&ctx->sem);
 
 	return ret;
 
@@ -428,20 +429,34 @@ int wd_rsa_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	}
 
 	do {
-		pthread_spin_lock(&ctx->lock);
-		ret = wd_rsa_setting.driver->recv(ctx->ctx, &recv_msg);
-		if (ret == -WD_EAGAIN) {
-			pthread_spin_unlock(&ctx->lock);
-			break;
-		} else if (ret < 0) {
-			pthread_spin_unlock(&ctx->lock);
-			WD_ERR("failed to async recv, ret = %d!\n", ret);
-			*count = rcv_cnt;
-			wd_put_msg_to_pool(&wd_rsa_setting.pool, idx,
-					   recv_msg.tag);
-			return ret;
+		if (sem_wait(&ctx->sem) != 0) {
+			if (errno == EINTR) {
+				/* sem_wait is interrupted by interrupt, continue */
+				continue;
+			}
 		}
-		pthread_spin_unlock(&ctx->lock);
+
+		/*
+		 * get sem means send rsa_send,
+		 * but need time to receive data and EAGAIN returns
+		 */
+		do {
+			pthread_spin_lock(&ctx->lock);
+			ret = wd_rsa_setting.driver->recv(ctx->ctx, &recv_msg);
+			pthread_spin_unlock(&ctx->lock);
+
+			if (!ret) {
+				break;
+			} else if (ret != -WD_EAGAIN) {
+				WD_ERR("failed to async recv, ret = %d!\n", ret);
+				*count = rcv_cnt;
+				wd_put_msg_to_pool(&wd_rsa_setting.pool, idx,
+						recv_msg.tag);
+				return ret;
+			}
+
+		} while (ret == -EAGAIN);
+
 		rcv_cnt++;
 		msg = wd_find_msg_in_pool(&wd_rsa_setting.pool, idx,
 					  recv_msg.tag);

--- a/wd_util.c
+++ b/wd_util.c
@@ -46,6 +46,7 @@ int wd_init_ctx_config(struct wd_ctx_config_internal *in,
 
 		clone_ctx_to_internal(cfg->ctxs + i, ctxs + i);
 		pthread_spin_init(&ctxs[i].lock, PTHREAD_PROCESS_SHARED);
+		sem_init(&ctxs[i].sem, 0, 0);
 	}
 
 	in->ctxs = ctxs;
@@ -84,8 +85,10 @@ void wd_clear_ctx_config(struct wd_ctx_config_internal *in)
 {
 	int i;
 
-	for (i = 0; i < in->ctx_num; i++)
+	for (i = 0; i < in->ctx_num; i++) {
 		pthread_spin_destroy(&in->ctxs[i].lock);
+		sem_destroy(&in->ctxs[i].sem);
+	}
 
 	in->priv = NULL;
 	in->ctx_num = 0;


### PR DESCRIPTION
In poll thread, we used to keep trying recving data if return EAGAIN
However, recv fetch the lock via pthread_spin_lock, which also required
by rsa_send, causing rsa_send has little chance to process leading poor
and unstable performance.

Instead, we use semaphore, rsa_send wakeup poll thread to try recv.
Here still need keep checking whether return EAGAIN since rsa_recv
can not happen immediately after rsa_send.

Remove pthread_join poll thread, which is in sem_wait.

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>