### PR TITLE
wd: add missing header file wd_ecc.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ UADK_VERSION = -version-info 5:4:3
 include_HEADERS = include/wd.h include/wd_cipher.h include/wd_comp.h \
 		  include/wd_dh.h include/wd_digest.h include/wd_rsa.h \
 		  include/uacce.h include/wd_alg_common.h \
-		  include/wd_common.h
+		  include/wd_common.h include/wd_ecc.h
 
 lib_LTLIBRARIES=libwd.la libwd_comp.la libwd_crypto.la libhisi_zip.la \
 		libhisi_hpre.la libhisi_sec.la


### PR DESCRIPTION
Fix openssl-uadk build error.
uadk_ecc.c:8:25: fatal error: uadk/wd_ecc.h: No such file or directory

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>