### PR TITLE
wd: add wd_get_accel_dev

### DIFF
--- a/include/wd.h
+++ b/include/wd.h
@@ -291,6 +291,17 @@ extern int wd_get_avail_ctx(struct uacce_dev *dev);
 extern struct uacce_dev_list *wd_get_accel_list(char *alg_name);
 
 /**
+ * wd_get_accel_dev() - Get device supporting the algorithm with
+			smallest numa distance to current numa node.
+ * @alg_name: Algorithm name, which could be got from
+ *            /sys/class/uacce/<device>/algorithm.
+ *
+ * Return a device closest to current numa node supporting given algorithm
+ * Otherwise return NULL.
+ */
+extern struct uacce_dev *wd_get_accel_dev(char *alg_name);
+
+/**
  * wd_free_list_accels() - Free device list.
  * @list: Device list which will be free.
  */

--- a/test/hisi_hpre_test/Makefile.am
+++ b/test/hisi_hpre_test/Makefile.am
@@ -6,7 +6,7 @@ test_hisi_hpre_SOURCES=test_hisi_hpre.c test_hisi_hpre.h
 	
 if WD_STATIC_DRV
 test_hisi_hpre_LDADD=../../.libs/libwd.a ../../.libs/libwd_crypto.a \
-			../../.libs/libhisi_hpre.a -ldl
+			../../.libs/libhisi_hpre.a -ldl -lnuma
 else
 test_hisi_hpre_LDADD=-L../../.libs -l:libwd.so.2 -l:libwd_crypto.so.2
 endif

--- a/test/hisi_zip_test/Makefile.am
+++ b/test/hisi_zip_test/Makefile.am
@@ -7,7 +7,7 @@ zip_sva_perf_SOURCES=test_sva_perf.c sva_file_test.c test_lib.c	\
 
 if WD_STATIC_DRV
 zip_sva_perf_LDADD=../../.libs/libwd.a ../../.libs/libwd_comp.a \
-		    ../../.libs/libhisi_zip.a -lpthread
+		    ../../.libs/libhisi_zip.a -lpthread -lnuma
 else
 zip_sva_perf_LDADD=-L../../.libs -l:libwd.so.2 -l:libwd_comp.so.2 -lpthread
 endif


### PR DESCRIPTION
Get device supporting the algorithm with smallest numa distance
to current numa node

Example:
dev = wd_get_accel_dev("digest");

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>