### PR TITLE
wd: fix the heap buffer overflow

### DIFF
--- a/wd_aead.c
+++ b/wd_aead.c
@@ -408,11 +408,12 @@ int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	}
 
 	/* init ctx related resources in specific driver */
-	priv = malloc(sizeof(wd_aead_setting.driver->drv_ctx_size));
+	priv = malloc(wd_aead_setting.driver->drv_ctx_size);
 	if (!priv) {
 		ret = -WD_ENOMEM;
 		goto out_priv;
 	}
+	memset(priv, 0, wd_aead_setting.driver->drv_ctx_size);
 	wd_aead_setting.priv = priv;
 	/* sec init */
 	ret = wd_aead_setting.driver->init(&wd_aead_setting.config, priv);

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -165,12 +165,13 @@ int wd_digest_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	}
 
 	/* init ctx related resources in specific driver */
-	priv = malloc(sizeof(wd_digest_setting.driver->drv_ctx_size));
+	priv = malloc(wd_digest_setting.driver->drv_ctx_size);
 	if (!priv) {
 		WD_ERR("failed to alloc digest driver ctx!\n");
 		ret = -WD_ENOMEM;
 		goto out_priv;
 	}
+	memset(priv, 0, wd_digest_setting.driver->drv_ctx_size);
 	wd_digest_setting.priv = priv;
 	/* sec init */
 	ret = wd_digest_setting.driver->init(&wd_digest_setting.config, priv);


### PR DESCRIPTION
Fix the heap buffer overflow by asan checking.

Signed-off-by: Kai Ye <yekai13@huawei.com>