### PR TITLE
wd/aead - fix assoc_data parameter checking

### DIFF
--- a/v1/drv/hisi_sec_udrv.c
+++ b/v1/drv/hisi_sec_udrv.c
@@ -2073,8 +2073,7 @@ static int aead_comb_param_check(struct wcrypto_aead_msg *msg)
 	}
 
 	/* CCM/GCM support 0 in_bytes, but others not support */
-	if (unlikely(msg->in_bytes == 0 ||
-		     msg->assoc_bytes & (AES_BLOCK_SIZE - 1))) {
+	if (unlikely(msg->in_bytes == 0)) {
 		WD_ERR("Invalid aead assoc_bytes!\n");
 		return -WD_EINVAL;
 	}

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -318,8 +318,7 @@ static int aead_param_check(struct wd_aead_sess *sess,
 	}
 
 	if (sess->cmode == WD_CIPHER_CBC &&
-	   (req->in_bytes & (AES_BLOCK_SIZE - 1) ||
-	    req->assoc_bytes & (AES_BLOCK_SIZE - 1))) {
+	   (req->in_bytes & (AES_BLOCK_SIZE - 1))) {
 		WD_ERR("failed to check input data length!\n");
 		return -WD_EINVAL;
 	}


### PR DESCRIPTION
The AEAD's assoc_data not need 16-alignment, so delete the
assoc_data parameter checking.

Signed-off-by: Kai Ye <yekai13@huawei.com>