### PR TITLE
wd: v2: uadk support poll

### DIFF
--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -464,6 +464,7 @@ static int hpre_init(struct wd_ctx_config_internal *config, void *priv, const ch
 
 	for (i = 0; i < config->ctx_num; i++) {
 		h_ctx = config->ctxs[i].ctx;
+		qm_priv.qp_mode = config->ctxs[i].ctx_mode;
 		h_qp = hisi_qm_alloc_qp(&qm_priv, h_ctx);
 		if (!h_qp) {
 			WD_ERR("failed to alloc qp!\n");

--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -479,7 +479,11 @@ static int hisi_qm_recv_single(struct hisi_qm_queue_info *q_info, void *resp)
 		i++;
 	}
 
-	q_info->db(q_info, QM_DBELL_CMD_CQ, i, 0);
+	/*  enable write EQ queue flag for sync mode */
+	if (q_info->qp_mode == CTX_MODE_SYNC)
+		q_info->db(q_info, DOORBELL_CMD_CQ, i, 1);
+	else
+		q_info->db(q_info, DOORBELL_CMD_CQ, i, 0);
 
 	/* only support one thread poll one queue, so no need protect */
 	q_info->cq_head_index = i;

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -19,6 +19,9 @@
 #define DES_WEAK_KEY_NUM	4
 #define MAX_RETRY_COUNTS	200000000
 
+#define POLL_SIZE		100000
+#define POLL_TIME		1000
+
 static __u64 des_weak_key[DES_WEAK_KEY_NUM] = {
 	0x0101010101010101, 0xFEFEFEFEFEFEFEFE,
 	0xE0E0E0E0F1F1F1F1, 0x1F1F1F1F0E0E0E0E
@@ -516,9 +519,15 @@ int wd_do_aead_sync(handle_t h_sess, struct wd_aead_req *req)
 	ret = wd_aead_setting.driver->aead_send(ctx->ctx, &msg);
 	if (ret < 0) {
 		WD_ERR("failed to send aead bd!\n");
-		pthread_spin_unlock(&ctx->lock);
-		free(msg.aiv);
-		return ret;
+		goto err_out;
+	}
+
+	if (req->in_bytes >= POLL_SIZE) {
+		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+		if (ret < 0) {
+			WD_ERR("wd ctx wait fail(%d)!\n", ret);
+			goto err_out;
+		}
 	}
 
 	do {

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -19,6 +19,8 @@
 #define DES_WEAK_KEY_NUM	4
 #define MAX_RETRY_COUNTS	200000000
 
+#define POLL_SIZE		200000
+#define POLL_TIME		1000
 
 static __u64 des_weak_key[DES_WEAK_KEY_NUM] = {
 	0x0101010101010101, 0xFEFEFEFEFEFEFEFE,
@@ -389,9 +391,16 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 
 	ret = wd_cipher_setting.driver->cipher_send(ctx->ctx, &msg);
 	if (ret < 0) {
-		pthread_spin_unlock(&ctx->lock);
 		WD_ERR("wd cipher send err!\n");
-		return ret;
+		goto err_out;
+	}
+
+	if (req->in_bytes >= POLL_SIZE) {
+		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+		if (ret < 0) {
+			WD_ERR("wd ctx wait fail(%d)!\n", ret);
+			goto err_out;
+		}
 	}
 
 	do {

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -17,6 +17,9 @@
 #define HW_CTX_SIZE			(64 * 1024)
 #define STREAM_CHUNK			(128 * 1024)
 
+#define POLL_SIZE			500000
+#define POLL_TIME			1000
+
 #define swap_byte(x) \
 	((((x) & 0x000000ff) << 24) | \
 	(((x) & 0x0000ff00) <<  8) | \
@@ -396,6 +399,14 @@ int wd_do_comp_sync(handle_t h_sess, struct wd_comp_req *req)
 		goto err_out;
 	}
 
+	if (req->src_len >= POLL_SIZE) {
+		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+		if (ret < 0) {
+			WD_ERR("wd ctx wait fail(%d)!\n", ret);
+			goto err_out;
+		}
+	}
+
 	do {
 		ret = wd_comp_setting.driver->comp_recv(ctx->ctx, &msg, priv);
 		if (ret == -WD_HW_EACCESS) {
@@ -587,6 +598,14 @@ int wd_do_comp_strm(handle_t h_sess, struct wd_comp_req *req)
 	if (ret < 0) {
 		WD_ERR("wd comp send err(%d)!\n", ret);
 		goto err_out;
+	}
+
+	if (req->src_len >= POLL_SIZE) {
+		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+		if (ret < 0) {
+			WD_ERR("wd ctx wait fail(%d)!\n", ret);
+			goto err_out;
+		}
 	}
 
 	do {

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -16,6 +16,9 @@
 #define DES_WEAK_KEY_NUM	4
 #define MAX_RETRY_COUNTS	200000000
 
+#define POLL_SIZE		200000
+#define POLL_TIME		1000
+
 static int g_digest_mac_len[WD_DIGEST_TYPE_MAX] = {
 	WD_DIGEST_SM3_LEN, WD_DIGEST_MD5_LEN, WD_DIGEST_SHA1_LEN,
 	WD_DIGEST_SHA256_LEN, WD_DIGEST_SHA224_LEN,
@@ -300,9 +303,16 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 	pthread_spin_lock(&ctx->lock);
 	ret = wd_digest_setting.driver->digest_send(ctx->ctx, &msg);
 	if (ret < 0) {
-		pthread_spin_unlock(&ctx->lock);
 		WD_ERR("failed to send bd!\n");
-		return ret;
+		goto err_out;
+	}
+
+	if (req->in_bytes >= POLL_SIZE) {
+		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+		if (ret < 0) {
+			WD_ERR("wd ctx wait fail(%d)!\n", ret);
+			goto err_out;
+		}
 	}
 
 	do {


### PR DESCRIPTION
1.sync mode enable write eq flag
2.enable wait function in cipher, digest, aead, comp, stream

Signed-off-by: linwenkai <linwenkai6@hisilicon.com>