### PR TITLE
wd/sgl/v1: modify sgl chain length

### DIFF
--- a/v1/drv/hisi_qm_udrv.c
+++ b/v1/drv/hisi_qm_udrv.c
@@ -199,7 +199,7 @@ int qm_hw_sgl_merge(void *pool, struct wd_sgl *dst_sgl, struct wd_sgl *src_sgl)
 	if (!d->next_dma)
 		return -WD_ENOMEM;
 
-	d->entry_sum_in_chain += s->entry_sum_in_chain;
+	d->entry_sum_in_chain = s->entry_sum_in_sgl + d->entry_sum_in_sgl;
 
 	return WD_SUCCESS;
 }


### PR DESCRIPTION
since the HW sgl is pre-allocated, it will only be returned to the
HW sgl pool after use, and the sgl parameters will not be cleared.
After multiple consecutive multiplexing, the HW sgl parameters will
overflow, cause HW parsing error.

Therefore, it need to add the total length of the sgl chain according
to the length of the two target sgl,rather than the superpostion of the
total length.