### PR TITLE
uadk: fix Makefile subdir

### DIFF
--- a/test/hisi_sec_test/Makefile.am
+++ b/test/hisi_sec_test/Makefile.am
@@ -1,4 +1,5 @@
 AM_CFLAGS=-Wall -Werror -fno-strict-aliasing -I../../include -pthread
+AUTOMAKE_OPTIONS = subdir-objects
 
 bin_PROGRAMS=test_hisi_sec
 

--- a/test/hisi_zip_test/Makefile.am
+++ b/test/hisi_zip_test/Makefile.am
@@ -1,4 +1,5 @@
 AM_CFLAGS=-Wall -Werror -fno-strict-aliasing -I../../include
+AUTOMAKE_OPTIONS = subdir-objects
 
 bin_PROGRAMS=zip_sva_perf
 


### PR DESCRIPTION
./autogen.sh
test/hisi_sec_test/Makefile.am:5: warning: source file '../sched_sample.c' is in a subdirectory,
test/hisi_sec_test/Makefile.am:5: but option 'subdir-objects' is disabled
test/hisi_zip_test/Makefile.am:5: warning: source file '../sched_sample.c' is in a subdirectory,
test/hisi_zip_test/Makefile.am:5: but option 'subdir-objects' is disabled

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>