### PR TITLE
wd: add environment variable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,8 @@ libwd_la_SOURCES=wd.c wd_mempool.c wd.h		\
 		 v1/drv/hisi_sec_udrv.c v1/drv/hisi_sec_udrv.h \
 		 v1/drv/hisi_rng_udrv.c v1/drv/hisi_rng_udrv.h
 
-libwd_comp_la_SOURCES=wd_comp.c wd_comp.h wd_comp_drv.h wd_util.c wd_util.h
+libwd_comp_la_SOURCES=wd_comp.c wd_comp.h wd_comp_drv.h wd_util.c wd_util.h \
+		      test/sched_sample.c sched_sample.h
 
 libhisi_zip_la_SOURCES=drv/hisi_comp.c hisi_comp.h drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h wd_comp_drv.h
@@ -69,7 +70,8 @@ libwd_crypto_la_SOURCES=wd_cipher.c wd_cipher.h wd_cipher_drv.h \
 			wd_dh.c wd_dh.h wd_dh_drv.h \
 			wd_ecc.c wd_ecc.h wd_ecc_drv.h \
 			wd_digest.c wd_digest.h wd_digest_drv.h \
-			wd_util.c wd_util.h
+			wd_util.c wd_util.h \
+			test/sched_sample.c sched_sample.h
 
 libhisi_sec_la_SOURCES=drv/hisi_sec.c drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h wd_cipher_drv.h wd_aead_drv.h

--- a/docs/wd_environment_variable
+++ b/docs/wd_environment_variable
@@ -1,0 +1,60 @@
+Define WD related environment variables
+=======================================
+
+-v0.1 2021.3.29 Sherlock         Init
+-v0.2 2021.4. 1 Barry, Sherlock  Remove driver, sched, async polling env
+
+Currently WD lib offers init related APIs to init accelerator resources in
+one process. User should call libwd and libwd_comp/libwd_crypto APIs to do
+this. WD lib could help to do this by parsing a set of WD configurations
+set by user. This document defines this set of WD environment variables to
+offer process level WD configures.
+
+1. WD environment variables define
+==================================
+
+WD_<alg>_NUMA
+-------------
+
+ Define which uacce device to be used. The NUMA nodes are separated by commas.
+ For example: WD_<alg>_NUMA=0, WD_<alg>_NUMA=1,2,3
+
+WD_<alg>_SYNC_CTX_NUM
+---------------------
+
+ Define the sync ctx number in NUMA node. For example:
+ WD_<alg>_SYNC_CTX_NUM=10@0,30@2 means to configure 10 sync ctxs in node0, and
+ 30 sync ctxs in node2.
+
+WD_<alg>_ASYNC_CTX_NUM
+----------------------
+
+ Define the async ctx number in NUMA node. For example:
+ WD_<alg>_ASYNC_CTX_NUM=10@0,30@2 means to configure 10 async ctxs in node0, and
+ 30 async ctxs in node2.
+
+WD_<alg>_ASYNC_POLL_EN
+----------------------
+
+ Define if enble polling threads in WD. WD_<alg>_ASYNC_POLL_EN=1 means enable
+ polling threads in WD, otherwise caller should poll finished request by
+ WD APIs.
+
+WD_<alg>_CTX_TYPE
+-----------------
+
+ Define the algorithm operation type of a group of ctxs. For example:
+ WD_<alg>_CTX_TYPE=sync-comp:10@0,async-decomp:20@1 means 10 sync ctxs are used
+ for compression in node0, and 20 async ctxs are used for decompression in
+ node1.
+
+ currently, we only have:
+ <sync-comp|sync-decomp|async-comp|async-decomp>:<num>@<node>
+
+alg above could be COMP, CIPHER, AEAD, DIGEST, DH, RSA, ECC. alg in
+WD_<alg>_CTX_TYPE is only COMP as other algorithms do not need ctx type.
+
+2. User model
+=============
+
+ (to do: ...)

--- a/include/sched_sample.h
+++ b/include/sched_sample.h
@@ -35,7 +35,7 @@ int sample_sched_fill_data(const struct wd_sched *sched, int numa_id,
  * sample_sched_alloc - Allocate a schedule instance.
  * @sched_type: Reference sched_policy_type.
  * @type_num: The service type num of user's service. For example, the zip
- *            include comp and un comp, type nume is two.
+ *            include comp and decomp, type nume is two.
  * @numa_num: The number of numa that the user needs.
  * @func: The ctx poll function of user underlying operating.
  *

--- a/include/wd.h
+++ b/include/wd.h
@@ -70,6 +70,12 @@ extern FILE *flog_fd;
 #define WD_HANDLE_ERR(h)		((long long)(h))
 #define WD_IS_ERR(h)			((unsigned long long)(h) > \
 					(unsigned long long)(-1000))
+
+static inline void *WD_ERR_PTR(long error)
+{
+	return (void *)error;
+}
+
 enum wcrypto_type {
 	WD_CIPHER,
 	WD_DIGEST,

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -154,5 +154,17 @@ int wd_comp_poll(__u32 expt, __u32 *count);
  */
 int wd_do_comp_sync2(handle_t h_sess, struct wd_comp_req *req);
 
+/**
+ * wd_comp_env_init() - Init ctx and schedule resources according to wd comp
+ * 			environment variables.
+ *
+ * More information, please see docs/wd_environment_variable.
+ */
+int wd_comp_env_init(void);
+ 
+/**
+ * wd_comp_env_uninit() - UnInit ctx and schedule resources set by above init.
+ */
+void wd_comp_env_uninit(void);
 
 #endif /* __WD_COMP_H */

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -89,6 +89,7 @@ struct test_options {
 	bool is_decomp;
 	bool is_stream;
 	bool is_file;
+	bool use_env;
 
 	int warmup_num;
 

--- a/test/hisi_zip_test/test_sva_perf.c
+++ b/test/hisi_zip_test/test_sva_perf.c
@@ -758,6 +758,7 @@ int main(int argc, char **argv)
 		{"out",		required_argument,	0, 0 },
 		{"ilist",	required_argument,	0, 0 },
 		{"olist",	required_argument,	0, 0 },
+		{"env",		no_argument,	0, 0 },
 		{0,		0,		0, 0 },
 	};
 	int show_help = 0;
@@ -773,9 +774,9 @@ int main(int argc, char **argv)
 		switch (opt) {
 		case 0:
 			switch (option_idx) {
-			case 0:
+			case 0:		/* self */
 				return run_self_test();
-			case 1:
+			case 1:		/* in */
 				if (optarg) {
 					opts.fd_in = open(optarg, O_RDONLY);
 					if (opts.fd_in < 0) {
@@ -793,7 +794,7 @@ int main(int argc, char **argv)
 					show_help = 1;
 				}
 				break;
-			case 2:
+			case 2:		/* out */
 				if (optarg) {
 					opts.fd_out = open(optarg,
 							   O_CREAT | O_WRONLY,
@@ -814,7 +815,7 @@ int main(int argc, char **argv)
 					show_help = 1;
 				}
 				break;
-			case 3:
+			case 3:		/* ilist */
 				if (!optarg) {
 					printf("IN list file is missing!\n");
 					show_help = 1;
@@ -833,7 +834,7 @@ int main(int argc, char **argv)
 					break;
 				}
 				break;
-			case 4:
+			case 4:		/* olist */
 				if (!optarg) {
 					printf("OUT list file is missing!\n");
 					show_help = 1;
@@ -854,6 +855,10 @@ int main(int argc, char **argv)
 					show_help = 1;
 					break;
 				}
+				break;
+			case 5:		/* env */
+				opts.use_env = true;
+				break;
 			default:
 				show_help = 1;
 				break;

--- a/wd_util.c
+++ b/wd_util.c
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <stdlib.h>
+#include <numa.h>
 #include <pthread.h>
+#include <semaphore.h>
+#include <stdlib.h>
+#include <string.h>
 #include "wd_alg_common.h"
 #include "wd_util.h"
+#include "sched_sample.h"
+
+#define WD_ASYNC_DEF_POLL_NUM		1
+#define WD_ASYNC_DEF_QUEUE_DEPTH	1024
 
 struct msg_pool {
 	/* message array allocated dynamically */
@@ -12,6 +19,25 @@ struct msg_pool {
 	__u32 msg_size;
 	int head;
 	int tail;
+};
+
+/* parse wd env begin */
+struct async_task {
+	__u32 index;
+};
+
+struct async_task_queue {
+	struct async_task *head;
+	int depth;
+	int prod;
+	int cons;
+	int cur_task;
+	int left_task;
+	sem_t empty_sem;
+	sem_t full_sem;
+	pthread_mutex_t lock;
+	pthread_t tid;
+	int (*alg_poll_ctx)(__u32, __u32, __u32 *);
 };
 
 static void clone_ctx_to_internal(struct wd_ctx *ctx,
@@ -236,4 +262,764 @@ int wd_check_datalist(struct wd_datalist *head, __u32 size)
 	}
 
 	return list_size >= size ? 0 : -WD_EINVAL;
+}
+
+void dump_env_info(struct wd_env_config *config)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	struct wd_ctx_range **ctx_table;
+	int i, j, k;
+
+	for (i = 0; i < config->numa_num; config_numa++, i++) {
+		ctx_table = config_numa->ctx_table;
+		printf("-> dump_env_info: %d: sync num: %lu\n", i,
+		       config_numa->sync_ctx_num);
+		printf("-> dump_env_info: %d: async num: %lu\n", i,
+		       config_numa->async_ctx_num);
+		if (ctx_table) {
+			for (j = 0; j < 2; j++)
+				for (k = 0; k < 2; k++) {
+			printf("-> dump_env_info: %d: [%d][%d].begin: %u\n", i,
+			       j, k, ctx_table[j][k].begin);
+			printf("-> dump_env_info: %d: [%d][%d].end: %u\n", i,
+			       j, k, ctx_table[j][k].end);
+			printf("-> dump_env_info: %d: [%d][%d].size: %u\n", i,
+			       j, k, ctx_table[j][k].size);
+			}
+		}
+	}
+}
+
+int wd_parse_numa(struct wd_env_config *config, const char *s)
+{
+	struct wd_env_config_per_numa *config_numa;
+	int max = numa_max_node();
+	int nodes[max + 1], num = 0, tmp, i;
+	char *n, *p;
+
+	n = strdup(s);
+	if (!n)
+		return -ENOMEM;
+
+	while ((p = strsep(&n, ","))) {
+		/* todo: check all digits here */
+		tmp = strtol(p, NULL, 10);
+		if (tmp < 0 || tmp > max) {
+			free(n);
+			return -EINVAL;
+		}
+		/* fix me: ... */
+		nodes[num++] = tmp;
+	}
+
+	config_numa = calloc(num, sizeof(*config_numa));
+	if (!config_numa) {
+		free(n);
+		return -ENOMEM;
+	}
+
+	config->config_per_numa = config_numa;
+	config->numa_num = num;
+	for (i = 0; i < num; config_numa++, i++)
+		config_numa->node = nodes[i];
+
+	free(n);
+
+	return 0;
+}
+
+static void __attribute__((unused))
+wd_free_parse_numa(struct wd_env_config *config)
+{
+	free(config->config_per_numa);
+}
+
+/* 1 enable, 0 disable, others error */
+int wd_parse_async_poll_en(struct wd_env_config *config, const char *s)
+{
+	int tmp;
+
+	tmp = strtol(s, NULL, 10);
+	if (tmp != 0 && tmp != 1)
+		return -EINVAL;
+
+	config->enable_internal_poll = tmp;
+
+	return 0;
+}
+
+/* fix me */
+static int parse_ctx_num_on_numa(const char *s, int *ctx_num, int *node)
+{
+	char *n;
+
+	*ctx_num = strtol(s, NULL, 10);
+	n = index(s, '@');
+	n++;
+	*node = strtol(n, NULL, 10);
+
+	return 0;
+}
+
+static int wd_parse_ctx_num(struct wd_env_config *config, const char *s,
+			    bool is_sync)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	int ctx_num, node, i, ret;
+	char *n, *p;
+
+	n = strdup(s);
+	if (!n)
+		return -ENOMEM;
+
+	while ((p = strsep(&n, ","))) {
+		ret = parse_ctx_num_on_numa(p, &ctx_num, &node);
+		if (ret) {
+			free(n);
+			return -EINVAL;
+		}
+
+		for (i = 0; i < config->numa_num; config_numa++, i++)
+			if (config_numa->node == node)
+				break;
+		if (i == config->numa_num) {
+			WD_ERR("wrong numa node value: %s!\n", p);
+			free(n);
+			return -EINVAL;
+		}
+
+		if (is_sync)
+			config_numa->sync_ctx_num = ctx_num;
+		else
+			config_numa->async_ctx_num = ctx_num;
+	}
+
+	free(n);
+
+	return 0;
+}
+
+int wd_parse_sync_ctx_num(struct wd_env_config *config, const char *s)
+{
+	return wd_parse_ctx_num(config, s, 1);
+}
+
+int wd_parse_async_ctx_num(struct wd_env_config *config, const char *s)
+{
+	return wd_parse_ctx_num(config, s, 0);
+}
+
+static int get_start_ctx_index(struct wd_env_config *config,
+			       struct wd_env_config_per_numa *config_numa)
+{
+	struct wd_env_config_per_numa *config_cur = config->config_per_numa;
+	int start = 0;
+
+	for (; config_cur < config_numa; config_cur++)
+		start += config_cur->sync_ctx_num + config_cur->async_ctx_num;
+
+	return start;
+}
+
+static int comp_fill_ctx_table(struct wd_env_config *config)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	struct wd_ctx_range **ctx_table;
+	int start, size, i, j, k;
+
+	for (i = 0; i < config->numa_num; config_numa++, i++) {
+		start = get_start_ctx_index(config, config_numa);
+		ctx_table = config_numa->ctx_table;
+
+		if (ctx_table[0][0].size + ctx_table[0][1].size !=
+		    config_numa->sync_ctx_num){
+			return -EINVAL;
+		}
+
+		if (ctx_table[1][0].size + ctx_table[1][1].size !=
+		    config_numa->async_ctx_num) {
+			return -EINVAL;
+		}
+
+		for (j = 0; j < 2; j++)
+			for (k = 0; k < 2; k++) {
+				size = ctx_table[j][k].size;
+				ctx_table[j][k].begin = start;
+				ctx_table[j][k].end = start + size - 1;
+				start += size;
+		}
+	}
+
+	return 0;
+}
+
+static int comp_get_and_fill_ctx_num(struct wd_env_config_per_numa *config_numa,
+				     const char *p, int ctx_num)
+{
+	struct wd_ctx_range **ctx_table = config_numa->ctx_table;
+
+	if (!strncmp(p, "sync-comp", 9))
+		ctx_table[0][0].size = ctx_num;
+	else if (!strncmp(p, "sync-decomp", 11))
+		ctx_table[0][1].size = ctx_num;
+	else if (!strncmp(p, "async-comp", 10))
+		ctx_table[1][0].size = ctx_num;
+	else if (!strncmp(p, "async-decomp", 12))
+		ctx_table[1][1].size = ctx_num;
+	else
+		return -EINVAL;
+
+	return 0;
+}
+
+/* just pust this function in wd_util.c to avoid export more functions */
+int wd_parse_comp_ctx_type(struct wd_env_config *config, const char *s)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	struct wd_ctx_range **ctx_table;
+	int ctx_num, node, i, ret;
+	char *n, *p, *c;
+
+	n = strdup(s);
+	if (!n)
+		return -ENOMEM;
+
+	while ((p = strsep(&n, ","))) {
+		c = index(p, ':');
+		c++;
+		ret = parse_ctx_num_on_numa(c, &ctx_num, &node);
+		if (ret)
+			goto err_free_ctx_table;
+
+		for (i = 0; i < config->numa_num; config_numa++, i++)
+			if (config_numa->node == node)
+				break;
+		if (i == config->numa_num) {
+			WD_ERR("wrong numa node value in ctx type: %s!\n", p);
+			ret = -EINVAL;
+			goto err_free_ctx_table;
+		}
+
+		if (!config_numa->ctx_table) {
+			ctx_table = calloc(2, sizeof(struct wd_ctx_range *));
+			if (!ctx_table) {
+				ret = -ENOMEM;
+				goto err_free_ctx_table;
+			}
+			for (i = 0; i < 2; i++) {
+				ctx_table[i] = calloc(2, sizeof(struct wd_ctx_range));
+			}
+			config_numa->ctx_table = ctx_table;
+		}
+
+		ret = comp_get_and_fill_ctx_num(config_numa, p, ctx_num);
+		if (ret) {
+			WD_ERR("wrong comp ctx type: %s!\n", p);
+			goto err_free_ctx_table;
+		}
+	}
+
+	ret = comp_fill_ctx_table(config);
+	if (ret) {
+		WD_ERR("check uadk comp ctx failed!\n");
+		goto err_free_ctx_table;
+	}
+
+	free(n);
+
+	return 0;
+
+err_free_ctx_table:
+	for (i = 0; i < config->numa_num; config_numa++, i++)
+		if (config_numa->ctx_table)
+			free(config_numa->ctx_table);
+	free(n);
+	return ret;
+}
+
+static int wd_parse_env(struct wd_env_config *config,
+			const struct wd_config_variable *table,
+			__u32 table_size)
+{
+	const struct wd_config_variable *var;
+	const char *var_s;
+	int ret, i;
+
+	for (i = 0; i < table_size; i++) {
+		var = table + i;
+		var_s = getenv(var->name);
+		if (!var_s) {
+			var_s = var->def_val;
+			WD_ERR("No %s environment variable! Use default: %s\n",
+			       var->name, var->def_val);
+		}
+
+		ret = var->parse_fn(config, var_s);
+		if (ret) {
+			WD_ERR("fail to parse %s environment variable!\n",
+			       var->name);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+static void wd_free_env(struct wd_env_config *config)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	int i, j;
+
+	for (i = 0; i < config->numa_num; config_numa++, i++) {
+		/* hack: here */
+		for (j = 0; j < 2; j++)
+			free(config_numa->ctx_table[j]);
+		free(config_numa->ctx_table);
+		free(config_numa->async_task_queue_array);
+	}
+	free(config->config_per_numa);
+}
+
+static __u8 get_ctx_mode(struct wd_env_config_per_numa *config, int index)
+{
+	struct wd_ctx_range **ctx_table = config->ctx_table;
+
+	/* hack: here */
+	if ((index >= ctx_table[0][0].begin && index <= ctx_table[0][0].end) ||
+	    (index >= ctx_table[1][0].begin && index <= ctx_table[1][0].end))
+		return CTX_MODE_SYNC;
+	else
+		return CTX_MODE_ASYNC;
+}
+
+static int wd_get_wd_ctx(struct wd_env_config_per_numa *config,
+			 struct wd_ctx_config *ctx_config, int start)
+{
+	int ctx_num = config->sync_ctx_num + config->async_ctx_num;
+	handle_t h_ctx;
+	int i, j;
+
+	for (i = start; i < ctx_num; i++) {
+		h_ctx = wd_request_ctx(&config->dev);
+		if (!h_ctx) {
+			for (j = 0; j < i; j++)
+				wd_release_ctx(ctx_config->ctxs[j].ctx);
+			return -EBUSY;
+		}
+
+		ctx_config->ctxs[i].ctx = h_ctx;
+		/* put sync ctx in front of async ctx */
+		ctx_config->ctxs[i].ctx_mode = get_ctx_mode(config, i);
+
+		/* fix me: currently does not fill op_type */
+	}
+
+	return 0;
+}
+
+static void wd_put_wd_ctx(struct wd_ctx_config *ctx_config)
+{
+	__u32 i;
+
+	for (i = 0; i < ctx_config->ctx_num; i++)
+		wd_release_ctx(ctx_config->ctxs[i].ctx);
+
+	free(ctx_config->ctxs);
+}
+
+static int wd_get_total_ctx_num(struct wd_env_config *config)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	int i, num = 0;
+
+	for (i = 0; i < config->numa_num; config_numa++, i++)
+		num += config_numa->sync_ctx_num + config_numa->async_ctx_num;
+
+	return num;
+}
+
+static struct wd_ctx_config *wd_alloc_ctx(struct wd_env_config *config,
+					  const struct wd_alg_ops *ops)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	struct uacce_dev_list *list, *head;
+	struct wd_ctx_config *ctx_config;
+	int i, ctx_num, start = 0, ret = 0;
+
+	ctx_config = calloc(1, sizeof(*ctx_config));
+	if (!ctx_config)
+		return WD_ERR_PTR(-ENOMEM);
+
+	ctx_num = wd_get_total_ctx_num(config);
+	ctx_config->ctxs = calloc(ctx_num, sizeof(struct wd_ctx));
+	if (!ctx_config->ctxs) {
+		ret = -ENOMEM;
+		goto err_free_ctx_config;
+	}
+	ctx_config->ctx_num = ctx_num;
+
+	/* get uacce_dev */
+	head = list = wd_get_accel_list(ops->alg_name);
+	if (!list) {
+		ret = -EINVAL;
+		WD_ERR("no device to support %s\n", ops->alg_name);
+		goto err_free_ctxs;
+	}
+
+	for (i = 0; i < config->numa_num; config_numa++, i++) {
+		while (list) {
+			if (config_numa->node == list->dev->numa_id)
+				break;
+			list = list->next;
+		}
+		if (!list) {
+			WD_ERR("no match device in node %lu\n",
+			       config_numa->node);
+			ret = -EINVAL;
+			goto err_free_list;
+		}
+
+		memcpy(&config_numa->dev, list->dev, sizeof(*list->dev));
+		list = head;
+
+		/* already sort numa node from small to big in wd_parse_numa */
+		ret = wd_get_wd_ctx(config_numa, ctx_config, start);
+		if (ret) {
+			ret = -EBUSY;
+			goto err_free_list;
+		}
+		start += config_numa->sync_ctx_num + config_numa->async_ctx_num;
+	}
+
+	return ctx_config;
+
+err_free_list:
+	wd_free_list_accels(head);
+err_free_ctxs:
+	free(ctx_config->ctxs);
+err_free_ctx_config:
+	free(ctx_config);
+	return WD_ERR_PTR(ret);
+}
+
+static void wd_free_ctx(struct wd_ctx_config *ctx_config)
+{
+
+	 wd_put_wd_ctx(ctx_config);
+	 free(ctx_config);
+}
+
+static struct wd_sched *wd_init_sched_config(struct wd_env_config *config,
+					     const struct wd_alg_ops *ops)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	struct wd_ctx_range **ctx_table;
+	struct wd_sched *sched;
+	int i, j, ret;
+
+	sched = sample_sched_alloc(SCHED_POLICY_RR, ops->op_type_num,
+				   config->numa_num, NULL);
+	if (!sched)
+		return NULL;
+	sched->name = "SCHED_RR";
+
+	for (i = 0; i < config->numa_num; config_numa++, i++) {
+		ctx_table = config_numa->ctx_table;
+		/* hack: here */
+		for (j = 0; j < 2; j++) {
+			ret = sample_sched_fill_data(sched, config_numa->node,
+						     CTX_MODE_SYNC, j,
+						     ctx_table[j][0].begin,
+						     ctx_table[j][0].end);
+			if (ret)
+				goto err_release_sched;
+
+			ret = sample_sched_fill_data(sched, config_numa->node,
+						     CTX_MODE_ASYNC, j,
+						     ctx_table[j][1].begin,
+						     ctx_table[j][1].end);
+			if (ret)
+				goto err_release_sched;
+		}
+	}
+
+	return sched;
+
+err_release_sched:
+	sample_sched_release(sched);
+	return WD_ERR_PTR(ret);
+}
+
+static void wd_uninit_sched_config(struct wd_sched *sched_config)
+{
+	return sample_sched_release(sched_config);
+}
+
+static struct async_task_queue *find_async_queue(struct wd_env_config *config,
+						 __u32 index)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	int i, num = 0;
+
+	for (i = 0; i < config->numa_num; config_numa++, i++) {
+		num += config_numa->sync_ctx_num + config_numa->async_ctx_num;
+		if (index < num)
+			break;
+	}
+
+	return config_numa->async_task_queue_array;
+}
+
+/* fix me: all return value here, and no config input */
+int wd_add_task_to_async_queue(struct wd_env_config *config, __u32 index)
+{
+	struct async_task_queue *task_queue = find_async_queue(config, index);
+	struct async_task *head, *task;
+	int prod;
+
+	if (sem_wait(&task_queue->empty_sem))
+		return 0;
+
+	if (pthread_mutex_lock(&task_queue->lock))
+		return 0;
+
+	prod = task_queue->prod;
+	head = task_queue->head;
+	task = head + prod;
+	/* fix me */
+	task->index = index;
+
+	prod = (prod + 1) % task_queue->depth;
+	task_queue->prod = prod;
+	task_queue->cur_task++;
+	task_queue->left_task--;
+
+	if (pthread_mutex_unlock(&task_queue->lock))
+		return 0;
+
+	if (sem_post(&task_queue->full_sem))
+		return 0;
+
+	return 1;
+}
+
+/* fix me: return value */
+static void *async_poll_process_func(void *args)
+{
+	struct async_task_queue *task_queue = args;
+	struct async_task *head, *task;
+	__u32 count;
+	int cons;
+
+	while (1) {
+		if (sem_wait(&task_queue->full_sem)) {
+			if (errno == EINTR) {
+				continue;
+			}
+		}
+
+		if (pthread_mutex_lock(&task_queue->lock))
+			return NULL;
+
+		cons = task_queue->cons;
+		head = task_queue->head;
+		task = head + cons;
+
+		task_queue->cons = (cons + 1) % task_queue->depth;
+		task_queue->cur_task--;
+		task_queue->left_task++;
+
+		if (pthread_mutex_unlock(&task_queue->lock))
+			return NULL;
+
+		/* fix me: poll a group of ctxs */
+		task_queue->alg_poll_ctx(task->index, 1, &count);
+
+		if (sem_post(&task_queue->empty_sem))
+			return NULL;
+	}
+}
+
+static int wd_init_one_task_queue(struct async_task_queue *task_queue,
+				  int (*alg_poll_ctx)(__u32, __u32, __u32 *))
+
+{
+	struct async_task *head;
+	pthread_t thread_id;
+	int depth, ret;
+
+	task_queue->depth = depth = WD_ASYNC_DEF_QUEUE_DEPTH;
+
+	head = calloc(task_queue->depth, sizeof(*head));
+	if (!head)
+		return -ENOMEM;
+
+	task_queue->head = head;
+	task_queue->left_task = depth;
+	task_queue->alg_poll_ctx = alg_poll_ctx;
+
+	if (sem_init(&task_queue->empty_sem, 0, depth)) {
+		ret = -1;
+		goto err_free_head;
+	}
+
+	if (sem_init(&task_queue->full_sem, 0, 0)) {
+		ret = -2;
+		goto err_uninit_empty_sem;
+	}
+
+	if (pthread_mutex_init(&task_queue->lock, NULL)) {
+		ret = -3;
+		goto err_uninit_full_sem;
+	}
+
+	/* fix me: make pthread joined? */
+	if (pthread_create(&thread_id, NULL, async_poll_process_func,
+			   task_queue)) {
+		ret = -4;
+		goto err_destory_mutex;
+	}
+	task_queue->tid = thread_id;
+
+	return 0;
+
+err_destory_mutex:
+	pthread_mutex_destroy(&task_queue->lock);
+err_uninit_full_sem:
+	sem_destroy(&task_queue->full_sem);
+err_uninit_empty_sem:
+	sem_destroy(&task_queue->empty_sem);
+err_free_head:
+	free(head);
+	return ret;
+}
+
+static void wd_uninit_one_task_queue(struct async_task_queue *task_queue)
+{
+	pthread_cancel(task_queue->tid);
+	pthread_mutex_destroy(&task_queue->lock);
+	sem_destroy(&task_queue->full_sem);
+	sem_destroy(&task_queue->empty_sem);
+	free(task_queue->head);
+}
+
+static int wd_init_async_polling_thread_per_numa(struct wd_env_config *config,
+				struct wd_env_config_per_numa *config_numa)
+{
+	struct async_task_queue *task_queue, *head;
+	int i, j, ret;
+
+	config_numa->async_poll_num = WD_ASYNC_DEF_POLL_NUM;
+
+	/* make max task queues as the number of async ctxs */
+	task_queue = calloc(config_numa->async_ctx_num, sizeof(*head));
+	if (!task_queue)
+		return -ENOMEM;
+	config_numa->async_task_queue_array = head = task_queue;
+
+	for (i = 0; i < config_numa->async_poll_num; task_queue++, i++) {
+		ret = wd_init_one_task_queue(task_queue, config->alg_poll_ctx);
+		if (ret) {
+			task_queue = head;
+			for (j = 0; j < i; task_queue++, j++)
+				wd_uninit_one_task_queue(task_queue);
+			free(head);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int wd_init_async_polling_thread(struct wd_env_config *config,
+					struct wd_ctx_config *ctx_config)
+{
+	struct wd_env_config_per_numa *config_numa = config->config_per_numa;
+	int i;
+
+	if (!config->enable_internal_poll)
+		return 0;
+
+	for (i = 0; i < config->numa_num; config_numa++, i++)
+		wd_init_async_polling_thread_per_numa(config, config_numa);
+
+	return 0;
+}
+
+static void wd_uninit_async_polling_thread(struct wd_env_config *config)
+{
+}
+
+static int wd_init_resource(struct wd_env_config *config,
+			    const struct wd_alg_ops *ops)
+{
+	struct wd_ctx_config *ctx_config;
+	struct wd_sched *sched_config;
+	int ret;
+
+	ctx_config = wd_alloc_ctx(config, ops);
+	if (WD_IS_ERR(ctx_config))
+		return -EBUSY;
+	config->ctx_config = ctx_config;
+
+	sched_config = wd_init_sched_config(config, ops);
+	if (WD_IS_ERR(sched_config))
+		goto err_uninit_ctx;
+	config->sched = sched_config;
+
+	ret = ops->alg_init(ctx_config, sched_config);
+	if (ret)
+		goto err_uninit_sched;
+	config->alg_uninit = ops->alg_uninit;
+
+	config->alg_poll_ctx = ops->alg_poll_ctx;
+	ret = wd_init_async_polling_thread(config, ctx_config);
+	if (ret)
+		goto err_uninit_alg;
+
+	return 0;
+
+err_uninit_alg:
+	ops->alg_uninit();
+err_uninit_sched:
+	wd_uninit_sched_config(sched_config);
+err_uninit_ctx:
+	wd_free_ctx(ctx_config);
+	return ret;
+}
+
+static void wd_uninit_resource(struct wd_env_config *config)
+{
+	wd_uninit_async_polling_thread(config);
+	config->alg_uninit();
+	wd_uninit_sched_config(config->sched);
+	wd_free_ctx(config->ctx_config);
+}
+
+int wd_alg_env_init(struct wd_env_config *env_config,
+		    const struct wd_config_variable *table, __u32 table_size,
+		    const struct wd_alg_ops *ops)
+{
+	int ret;
+
+	if (!env_config || !table || !table_size || !ops)
+		return -EINVAL;
+
+	ret = wd_parse_env(env_config, table, table_size);
+	if (ret)
+		return ret;
+
+	ret = wd_init_resource(env_config, ops);
+	if (ret) {
+		wd_free_env(env_config);
+		return ret;
+	}
+
+	return 0;
+}
+
+void wd_alg_env_uninit(struct wd_env_config *env_config)
+{
+	wd_uninit_resource(env_config);
+	wd_free_env(env_config);
 }


### PR DESCRIPTION
Make UADK to parse environment variable to get information. The basic
goal is to make UADK easier to use.

"--env" is the parameter to enable environment variable in zip_sva_perf
test case. Up to now, the feature of environment variable is enabled in
synchronous mode.

Signed-off-by: Zhou Wang <wangzhou1@hisilicon.com>
Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>