### PR TITLE
uadk: schedule - modify schedule parameter assignments

### DIFF
--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -32,6 +32,7 @@ struct wd_aead_sess_setup {
 	enum wd_cipher_mode cmode;
 	enum wd_digest_type dalg;
 	enum wd_digest_mode dmode;
+	int numa;
 };
 
 struct wd_aead_req;
@@ -49,6 +50,7 @@ struct wd_aead_sess {
 	__u16			akey_bytes;
 	__u16			auth_bytes;
 	void			*priv;
+	int			numa;
 };
 
 /**

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -59,6 +59,7 @@ enum wd_cipher_mode {
 struct wd_cipher_sess_setup {
 	enum wd_cipher_alg alg;
 	enum wd_cipher_mode mode;
+	int numa;
 };
 
 struct wd_cipher_req;
@@ -73,7 +74,7 @@ struct wd_cipher_sess {
 	void			*priv;
 	void			*key;
 	__u32			key_bytes;
-	int				numa;
+	int			numa;
 };
 
 struct wd_cipher_req {

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -100,7 +100,7 @@ struct wd_comp_sess_setup {
 	enum wd_comp_level comp_lv; /* Denoted by enum wd_comp_level */
 	enum wd_comp_winsz_type win_sz; /* Denoted by enum wd_comp_winsz_type */
 	enum wd_comp_op_type op_type;
-	enum wd_ctx_mode mode;
+	int numa;
 };
 
 /**

--- a/include/wd_dh.h
+++ b/include/wd_dh.h
@@ -22,7 +22,7 @@ enum wd_dh_op_type {
 struct wd_dh_sess_setup {
 	__u16 key_bits; /* DH key bites */
 	bool is_g2; /* is g2 mode or not */
-	__u8 mode; /* sync or async mode, denoted by enum wd_ctx_mode */
+	int numa;
 };
 
 struct wd_dh_req {

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -55,6 +55,7 @@ enum wd_digest_mode {
 struct wd_digest_sess_setup {
 	enum wd_digest_type alg;
 	enum wd_digest_mode mode;
+	int numa;
 };
 
 typedef void *wd_digest_cb_t(void *cb_param);
@@ -66,6 +67,7 @@ struct wd_digest_sess {
 	void			*priv;
 	void			*key;
 	__u32			key_bytes;
+	int			numa;
 };
 
 /**

--- a/include/wd_ecc.h
+++ b/include/wd_ecc.h
@@ -113,7 +113,7 @@ struct wd_ecc_sess_setup {
 	struct wd_ecc_curve_cfg cv; /* curve config denoted by user */
 	struct wd_rand_mt rand; /* rand method from user */
 	struct wd_hash_mt hash; /* hash method from user */
-	__u8 mode; /* ecc sync or async mode, denoted by enum wd_ctx_mode */
+	int numa;
 };
 
 struct wd_ecc_req {

--- a/include/wd_rsa.h
+++ b/include/wd_rsa.h
@@ -54,7 +54,7 @@ enum wd_rsa_key_type {
 struct wd_rsa_sess_setup {
 	__u16 key_bits; /* RSA key bits */
 	bool is_crt; /* CRT mode or not */
-	__u8 mode; /* rsa sync or async mode, denoted by enum wd_ctx_mode */
+	int numa;
 };
 
 bool wd_rsa_is_crt(handle_t sess);

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -149,8 +149,8 @@ int hw_blk_compress(int alg_type, int blksize, __u8 data_fmt, void *priv,
 	int ret = 0;
 
 	setup.alg_type = alg_type;
-	setup.mode = CTX_MODE_SYNC;
 	setup.op_type = WD_DIR_COMPRESS;
+	setup.numa = 0;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -211,8 +211,8 @@ int hw_blk_decompress(int alg_type, int blksize, __u8 data_fmt,
 	int ret = 0;
 
 	setup.alg_type = alg_type;
-	setup.mode = CTX_MODE_SYNC;
 	setup.op_type = WD_DIR_DECOMPRESS;
+	setup.numa = 0;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -272,8 +272,8 @@ int hw_stream_compress(int alg_type, int blksize, __u8 data_fmt,
 	int ret = 0;
 
 	setup.alg_type = alg_type;
-	setup.mode = CTX_MODE_SYNC;
 	setup.op_type = WD_DIR_COMPRESS;
+	setup.numa = 0;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -324,8 +324,8 @@ int hw_stream_decompress(int alg_type, int blksize, __u8 data_fmt,
 
 
 	setup.alg_type = alg_type;
-	setup.mode = CTX_MODE_SYNC;
 	setup.op_type = WD_DIR_DECOMPRESS;
+	setup.numa = 0;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -499,8 +499,8 @@ void *send_thread_func(void *arg)
 
 	memset(&setup, 0, sizeof(struct wd_comp_sess_setup));
 	setup.alg_type = opts->alg_type;
-	setup.mode = opts->sync_mode;
 	setup.op_type = opts->op_type;
+	setup.numa = 0;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess)
 		return NULL;

--- a/test/hisi_zip_test/testsuit.c
+++ b/test/hisi_zip_test/testsuit.c
@@ -80,8 +80,8 @@ static void *sw_dfl_hw_ifl(void *arg)
 
 	/* BLOCK mode */
         setup.alg_type = opts->alg_type;
-        setup.mode = opts->sync_mode ? CTX_MODE_ASYNC : CTX_MODE_SYNC;
         setup.op_type = WD_DIR_DECOMPRESS;
+	setup.numa = 0;
 
 	h_ifl = wd_comp_alloc_sess(&setup);
 	if (!h_ifl) {
@@ -215,8 +215,8 @@ static void *hw_dfl_sw_ifl(void *arg)
 
 	/* BLOCK mode */
         setup.alg_type = opts->alg_type;
-        setup.mode = opts->sync_mode ? CTX_MODE_ASYNC : CTX_MODE_SYNC;
         setup.op_type = WD_DIR_COMPRESS;
+	setup.numa = 0;
 
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl) {
@@ -348,8 +348,8 @@ static void *hw_dfl_hw_ifl(void *arg)
 		goto out;
 	}
         setup.alg_type = opts->alg_type;
-        setup.mode = opts->sync_mode ? CTX_MODE_ASYNC : CTX_MODE_SYNC;
         setup.op_type = WD_DIR_COMPRESS;
+	setup.numa = 0;
 
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl) {
@@ -449,8 +449,8 @@ static void *hw_dfl_perf(void *arg)
 	}
 
         setup.alg_type = opts->alg_type;
-        setup.mode = opts->sync_mode ? CTX_MODE_ASYNC : CTX_MODE_SYNC;
         setup.op_type = WD_DIR_COMPRESS;
+	setup.numa = 0;
 
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl)
@@ -508,8 +508,8 @@ static void *hw_ifl_perf(void *arg)
 	}
 
         setup.alg_type = opts->alg_type;
-        setup.mode = opts->sync_mode ? CTX_MODE_ASYNC : CTX_MODE_SYNC;
         setup.op_type = WD_DIR_DECOMPRESS;
+	setup.numa = 0;
 
 	h_ifl = wd_comp_alloc_sess(&setup);
 	if (!h_ifl)
@@ -568,8 +568,8 @@ void *hw_dfl_perf3(void *arg)
 	}
 
         setup.alg_type = opts->alg_type;
-        setup.mode = opts->sync_mode ? CTX_MODE_ASYNC : CTX_MODE_SYNC;
         setup.op_type = WD_DIR_COMPRESS;
+	setup.numa = 0;
 
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl)
@@ -628,8 +628,8 @@ void *hw_ifl_perf3(void *arg)
 	}
 
         setup.alg_type = opts->alg_type;
-        setup.mode = opts->sync_mode ? CTX_MODE_ASYNC : CTX_MODE_SYNC;
         setup.op_type = WD_DIR_DECOMPRESS;
+	setup.numa = 0;
 
 	h_ifl = wd_comp_alloc_sess(&setup);
 	if (!h_ifl)

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -156,8 +156,6 @@ int wd_cipher_set_key(handle_t h_sess, const __u8 *key, __u32 key_len)
 handle_t wd_cipher_alloc_sess(struct wd_cipher_sess_setup *setup)
 {
 	struct wd_cipher_sess *sess = NULL;
-	int cpu;
-	int node;
 
 	if (!setup) {
 		WD_ERR("cipher input setup is NULL!\n");
@@ -181,10 +179,7 @@ handle_t wd_cipher_alloc_sess(struct wd_cipher_sess_setup *setup)
 
 	memset(sess->key, 0, MAX_CIPHER_KEY_SIZE);
 
-	cpu = sched_getcpu();
-	node = numa_node_of_cpu(cpu);
-
-	sess->numa = node;
+	sess->numa = setup->numa;
 
 	return (handle_t)sess;
 }
@@ -367,6 +362,7 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 	key.mode = CTX_MODE_SYNC;
 	key.type = 0;
 	key.numa_id = sess->numa;
+
 	idx = wd_cipher_setting.sched.pick_next_ctx(
 		     wd_cipher_setting.sched.h_sched_ctx, req, &key);
 	if (unlikely(idx >= config->ctx_num)) {

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -240,20 +240,17 @@ handle_t wd_comp_alloc_sess(struct wd_comp_sess_setup *setup)
 	if (!sess)
 		return (handle_t)0;
 
-	if (setup->mode == CTX_MODE_SYNC) {
-		sess->ctx_buf = calloc(1, HW_CTX_SIZE);
-		if (!sess->ctx_buf) {
-			free(sess);
-			return (handle_t)0;
-		}
+	sess->ctx_buf = calloc(1, HW_CTX_SIZE);
+	if (!sess->ctx_buf) {
+		free(sess);
+		return (handle_t)0;
 	}
 
 	sess->alg_type = setup->alg_type;
 	sess->stream_pos = WD_COMP_STREAM_NEW;
 
-	sess->key.mode = setup->mode;
 	sess->key.type = setup->op_type;
-	sess->key.numa_id = 0;
+	sess->key.numa_id = setup->numa;
 
 	return (handle_t)sess;
 }
@@ -345,6 +342,7 @@ int wd_do_comp_sync(handle_t h_sess, struct wd_comp_req *req)
 
 	memset(&msg, 0, sizeof(struct wd_comp_msg));
 
+	sess->key.mode = CTX_MODE_SYNC;
 	idx = wd_comp_setting.sched.pick_next_ctx(h_sched_ctx,
 						  req,
 						  &sess->key);
@@ -565,6 +563,7 @@ int wd_do_comp_strm(handle_t h_sess, struct wd_comp_req *req)
 	    req->last == 1 && req->src_len == 0)
 		return append_store_block(sess, req);
 
+	sess->key.mode = CTX_MODE_SYNC;
 	idx = wd_comp_setting.sched.pick_next_ctx(h_sched_ctx,
 						  req,
 						  &sess->key);
@@ -664,6 +663,7 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 		return -WD_EINVAL;
 	}
 
+	sess->key.mode = CTX_MODE_ASYNC;
 	idx = wd_comp_setting.sched.pick_next_ctx(h_sched_ctx,
 						  req,
 						  &sess->key);

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -266,6 +266,7 @@ int wd_do_dh_sync(handle_t sess, struct wd_dh_req *req)
 		return -WD_EINVAL;
 	}
 
+	sess_t->key.mode = CTX_MODE_SYNC;
 	idx = wd_dh_setting.sched.pick_next_ctx(h_sched_ctx, req, &sess_t->key);
 	if (unlikely(idx >= config->ctx_num)) {
 		WD_ERR("failed to pick ctx, idx = %u!\n", idx);
@@ -310,6 +311,7 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 		return -WD_EINVAL;
 	}
 
+	sess_t->key.mode = CTX_MODE_ASYNC;
 	idx = wd_dh_setting.sched.pick_next_ctx(h_sched_ctx, req,
 						  &sess_t->key);
 	if (unlikely(idx >= config->ctx_num)) {
@@ -501,8 +503,7 @@ handle_t wd_dh_alloc_sess(struct wd_dh_sess_setup *setup)
 	}
 	sess->g.bsize = sess->key_size;
 
-	sess->key.mode = setup->mode;
-	sess->key.numa_id = 0;
+	sess->key.numa_id = setup->numa;
 
 	return (handle_t)sess;
 }

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -98,7 +98,6 @@ handle_t wd_digest_alloc_sess(struct wd_digest_sess_setup *setup)
 	memset(sess, 0, sizeof(struct wd_digest_sess));
 
 	sess->alg = setup->alg;
-	sess->mode = setup->mode;
 	sess->key = malloc(MAX_HMAC_KEY_SIZE);
 	if (!sess->key) {
 		free(sess);
@@ -106,6 +105,8 @@ handle_t wd_digest_alloc_sess(struct wd_digest_sess_setup *setup)
 		return (handle_t)0;
 	}
 	memset(sess->key, 0, MAX_HMAC_KEY_SIZE);
+
+	sess->numa = setup->numa;
 
 	return (handle_t)sess;
 }
@@ -270,6 +271,7 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 	struct wd_digest_sess *dsess = (struct wd_digest_sess *)h_sess;
 	struct wd_ctx_internal *ctx;
 	struct wd_digest_msg msg;
+	struct sched_key key;
 	__u64 recv_cnt = 0;
 	__u32 idx;
 	int ret;
@@ -278,8 +280,11 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 	if (ret)
 		return -WD_EINVAL;
 
-	/* fix me: maybe wrong */
-	idx = wd_digest_setting.sched.pick_next_ctx(0, req, NULL);
+	key.mode = CTX_MODE_SYNC;
+	key.type = 0;
+	key.numa_id = dsess->numa;
+
+	idx = wd_digest_setting.sched.pick_next_ctx(0, req, &key);
 	if (unlikely(idx >= config->ctx_num)) {
 		WD_ERR("fail to pick next ctx!\n");
 		return -WD_EINVAL;
@@ -339,6 +344,7 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 	struct wd_digest_sess *dsess = (struct wd_digest_sess *)h_sess;
 	struct wd_ctx_internal *ctx;
 	struct wd_digest_msg *msg;
+	struct sched_key key;
 	int msg_id, ret;
 	__u32 idx;
 
@@ -351,7 +357,11 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 		return -WD_EINVAL;
 	}
 
-	idx = wd_digest_setting.sched.pick_next_ctx(0, req, NULL);
+	key.mode = CTX_MODE_SYNC;
+	key.type = 0;
+	key.numa_id = dsess->numa;
+
+	idx = wd_digest_setting.sched.pick_next_ctx(0, req, &key);
 	if (unlikely(idx >= config->ctx_num)) {
 		WD_ERR("fail to pick next ctx!\n");
 		return -WD_EINVAL;

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -1026,8 +1026,7 @@ handle_t wd_ecc_alloc_sess(struct wd_ecc_sess_setup *setup)
 
 	memcpy(&sess->setup, setup, sizeof(*setup));
 	sess->key_size = BITS_TO_BYTES(setup->key_bits);
-	sess->s_key.mode = setup->mode;
-	sess->s_key.numa_id = 0;
+	sess->s_key.numa_id = setup->numa;
 
 	ret = create_sess_key(setup, sess);
 	if (ret) {
@@ -1453,6 +1452,7 @@ int wd_do_ecc_sync(handle_t h_sess, struct wd_ecc_req *req)
 		return -WD_EINVAL;
 	}
 
+	sess->s_key.mode = CTX_MODE_SYNC;
 	idx = wd_ecc_setting.sched.pick_next_ctx(h_sched_ctx, req, &sess->s_key);
 	if (unlikely(idx >= config->ctx_num)) {
 		WD_ERR("failed to pick ctx, idx = %u!\n", idx);
@@ -2143,6 +2143,7 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
 		return -WD_EINVAL;
 	}
 
+	sess_t->s_key.mode = CTX_MODE_ASYNC;
 	idx = wd_ecc_setting.sched.pick_next_ctx(h_sched_ctx, req,
 						   &sess_t->s_key);
 	if (unlikely(idx >= config->ctx_num)) {

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -326,6 +326,7 @@ int wd_do_rsa_sync(handle_t h_sess, struct wd_rsa_req *req)
 		return -WD_EINVAL;
 	}
 
+	sess->key.mode = CTX_MODE_SYNC;
 	idx = wd_rsa_setting.sched.pick_next_ctx(h_sched_ctx, req, &sess->key);
 	if (unlikely(idx >= config->ctx_num)) {
 		WD_ERR("failed to pick ctx, idx = %u!\n", idx);
@@ -367,6 +368,7 @@ int wd_do_rsa_async(handle_t sess, struct wd_rsa_req *req)
 		return -WD_EINVAL;
 	}
 
+	sess_t->key.mode = CTX_MODE_ASYNC;
 	idx = wd_rsa_setting.sched.pick_next_ctx(h_sched_ctx, req,
 						   &sess_t->key);
 	if (unlikely(idx >= config->ctx_num)) {
@@ -828,8 +830,7 @@ handle_t wd_rsa_alloc_sess(struct wd_rsa_sess_setup *setup)
 		return (handle_t)0;
 	}
 
-	sess->key.mode = setup->mode;
-	sess->key.numa_id = 0;
+	sess->key.numa_id = setup->numa;
 
 	return (handle_t)(uintptr_t)sess;
 }


### PR DESCRIPTION
Now the schedule design three patameters. 'type' is not a common setting.
'numa_id' is a patameter decided by users. So assign it in create 'sess'.
'mode' shouldn't be unchangeable, so assign it according to the interface
calling by user than than in create 'sess'.

Signed-off-by: Yang Shen <youngershen@foxmail.com>