### PR TITLE
wd: add cipher environment variable

### DIFF
--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -146,4 +146,16 @@ int wd_cipher_poll_ctx(__u32 index, __u32 expt, __u32* count);
  * by user.
  */
 int wd_cipher_poll(__u32 expt, __u32 *count);
+/**
+ * wd_cipher_env_init() - Init ctx and schedule resources according to wd cipher
+ * environment variables.
+ *
+ * More information, please see docs/wd_environment_variable.
+ */
+int wd_cipher_env_init(void);
+
+/**
+ * wd_cipher_env_uninit() - UnInit ctx and schedule resources set by above init.
+ */
+void wd_cipher_env_uninit(void);
 #endif /* __WD_CIPHER_H */

--- a/test/sched_sample.c
+++ b/test/sched_sample.c
@@ -424,11 +424,6 @@ struct wd_sched *sample_sched_alloc(__u8 sched_type, __u8 type_num, __u8 numa_nu
 		return NULL;
 	}
 
-	if (!func) {
-		WD_ERR("Error: %s poll_func is null!\n", __FUNCTION__);
-		return NULL;
-	}
-
 	if (!numa_num) {
 		WD_ERR("Warning: %s set numa number as %d!\n", __FUNCTION__,
 		       MAX_NUMA_NUM);


### PR DESCRIPTION
1.Adapt cipher to init ctx with environment variable
2."--use_env" for test_hisi_sec to enable environment variable.
3.Fix some problem under default scenario.

More algorithm modules will be adapted to use environment variable  later.
