### PR TITLE
uadk: test/hisi_zip_test - fix build error

### DIFF
--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -1320,6 +1320,7 @@ int create_poll_tdata(struct test_options *opts,
 		ret = -ENOMEM;
 		goto out;
 	}
+	tdatas = info->p_tdatas;
 	for (i = 0; i < poll_num; i++) {
 		tdatas[i].tid = i;
 		tdatas[i].info = info;

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -280,8 +280,6 @@ int hw_stream_decompress(int alg_type, int blksize, __u8 data_fmt,
 		         unsigned char *dst, __u32 *dstlen,
 		         unsigned char *src, __u32 srclen);
 
-int comp_file_test(FILE *source, FILE *dest, struct test_options *opts);
-
 #ifdef USE_ZLIB
 int hizip_check_output(void *buf, size_t size, size_t *checked,
 		       check_output_fn check_output, void *opaque);

--- a/test/hisi_zip_test/test_sva_perf.c
+++ b/test/hisi_zip_test/test_sva_perf.c
@@ -642,9 +642,6 @@ static int run_test(struct test_options *opts, FILE *source, FILE *dest)
 	struct hizip_stats variation;
 	struct hizip_stats stats[n];
 
-	if(opts->is_file) {
-		return comp_file_test(source, dest, opts);
-	}
 	memset(&avg , 0, sizeof(avg));
 	memset(&std , 0, sizeof(std));
 	memset(&variation , 0, sizeof(variation));


### PR DESCRIPTION
fix build error:
	test_lib.c:1324:9: error: 'tdatas' may be used uninitialized in this function
	test_sva_perf.c:646: undefined reference to `comp_file_test'

Signed-off-by: Yang Shen <youngershen@foxmail.com>