### PR TITLE
wd: env: support digest and aead

### DIFF
--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -179,4 +179,17 @@ int wd_aead_poll_ctx(__u32 index, __u32 expt, __u32* count);
  * @count: how many respondences this poll has to get.
  */
 int wd_aead_poll(__u32 expt, __u32 *count);
+
+/**
+ * wd_aead_env_init() - Init ctx and schedule resources according to wd aead
+ * environment variables.
+ *
+ * More information, please see docs/wd_environment_variable.
+ */
+int wd_aead_env_init(void);
+
+/**
+ *   wd_aead_env_uninit() - UnInit ctx and schedule resources set by above init.
+ */
+void wd_aead_env_uninit(void);
 #endif /* __WD_AEAD_H */

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -169,4 +169,16 @@ int wd_digest_poll_ctx(__u32 index, __u32 expt, __u32 *count);
  */
 int wd_digest_poll(__u32 expt, __u32 *count);
 
+/**
+ * wd_digest_env_init() - Init ctx and schedule resources according to wd digest
+ * environment variables.
+ *
+ * More information, please see docs/wd_environment_variable.
+ */
+int wd_digest_env_init(void);
+
+/**
+ * wd_digest_env_uninit() - UnInit ctx and schedule resources set by above init.
+ */
+void wd_digest_env_uninit(void);
 #endif /* __WD_DIGEST_H */

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -19,6 +19,7 @@ struct wd_ctx_range {
 struct wd_env_config_per_numa {
 	/* Config begin */
 	unsigned long node;
+	__u8 numa_disable;
 	unsigned long sync_ctx_num;
 	unsigned long async_ctx_num;
 	/*
@@ -60,6 +61,8 @@ struct wd_env_config {
 	/* resource config */
 	struct wd_sched *sched;
 	struct wd_ctx_config *ctx_config;
+	const struct wd_config_variable *table;
+	__u32 table_size;
 };
 
 struct wd_config_variable {
@@ -184,15 +187,6 @@ void *wd_find_msg_in_pool(struct wd_async_msg_pool *pool, int index, __u32 tag);
  */
 int wd_check_datalist(struct wd_datalist *head, __u32 size);
 
-/*
- * wd_parse_numa() - Parse NUMA environment variable and store it.
- * @config: Pointer of wd_env_config which is used to store environment
- *          variable information.
- * @s: Related environment variable string.
- *
- * More information, please see docs/wd_environment_variable.
- */
-int wd_parse_numa(struct wd_env_config *config, const char *s);
 
 /*
  * wd_parse_sync_ctx_num() - Parse sync ctx related environment variables and
@@ -247,13 +241,14 @@ int wd_parse_async_poll_en(struct wd_env_config *config, const char *s);
  *          variable information.
  * @table: Table which is used to define specific environment variable、its
  * 	   default value and related parsing operations.
- * @table_size: Size of above table.
  * @ops: Define functions which will be used by specific wd algorithm
  * 	 environment init.
+ * @table_size: Size of above table.
  */
 int wd_alg_env_init(struct wd_env_config *config,
-		    const struct wd_config_variable *table, __u32 table_size,
-		    const struct wd_alg_ops *ops);
+		    const struct wd_config_variable *table,
+		    const struct wd_alg_ops *ops,
+		    __u32 table_size);
 
 /*
  * wd_alg_env_uninit() - uninit specific wd algorithm environment configuration.
@@ -271,4 +266,10 @@ void wd_alg_env_uninit(struct wd_env_config *env_config);
  */
 int wd_add_task_to_async_queue(struct wd_env_config *config, __u32 index);
 
+/*
+ * dump_env_var() - dump wd algorithm environment from system.
+ * @config: Pointer of wd_env_config which is used to store environment
+ *          variable information.
+ */
+void dump_env_var(struct wd_env_config *config);
 #endif /* __WD_UTIL_H */

--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -357,7 +357,7 @@ run_zip_test_v2()
 	export WD_COMP_SYNC_CTX_NUM="8@0"
 	export WD_COMP_ASYNC_CTX_NUM="8@0"
 	export WD_COMP_CTX_TYPE="sync-comp:4@0,sync-decomp:4@0,async-comp:4@0,async-decomp:4@0"
-	export WD_COMP_ASYNC_POLL_EN=1
+	export WD_COMP_ASYNC_POLL_EN=0
 	sw_dfl_hw_ifl /var/log/syslog
 	hw_dfl_sw_ifl /var/log/syslog
 	hw_dfl_hw_ifl /var/log/syslog

--- a/wd.c
+++ b/wd.c
@@ -350,8 +350,7 @@ void *wd_ctx_mmap_qfr(handle_t h_ctx, enum uacce_qfrt qfrt)
 	size_t size;
 	void *addr;
 
-	if (!ctx || !ctx->qfrs_offs[qfrt] ||
-	    qfrt >= UACCE_QFRT_MAX)
+	if (!ctx || qfrt >= UACCE_QFRT_MAX || !ctx->qfrs_offs[qfrt])
 		return NULL;
 
 	size = ctx->qfrs_offs[qfrt];

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -18,7 +18,6 @@
 #define WD_POOL_MAX_ENTRIES	1024
 #define DES_WEAK_KEY_NUM	4
 #define MAX_RETRY_COUNTS	200000000
-#define WD_CIPHER_ENV_NUM	4
 
 #define POLL_SIZE		1000000
 #define POLL_TIME		1000
@@ -450,7 +449,7 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req)
 	if (ctx->ctx_mode != CTX_MODE_ASYNC) {
 		WD_ERR("failed to check ctx mode!\n");
 		return -WD_EINVAL;
-    }
+	}
 
 	msg_id = wd_get_msg_from_pool(&wd_cipher_setting.pool, idx,
 				   (void **)&msg);
@@ -531,21 +530,18 @@ int wd_cipher_poll(__u32 expt, __u32 *count)
 
 	return sched->poll_policy(h_ctx, expt, count);
 }
-static const struct wd_config_variable table[WD_CIPHER_ENV_NUM] = {
-	{ .name = "WD_CIPHER_NUMA",
-	  .def_val = "0",
-	  .parse_fn = wd_parse_numa
-	},
+
+static const struct wd_config_variable table[] = {
 	{ .name = "WD_CIPHER_SYNC_CTX_NUM",
-	  .def_val = "6@0",
+	  .def_val = "6@0,6@2",
 	  .parse_fn = wd_parse_sync_ctx_num
 	},
 	{ .name = "WD_CIPHER_ASYNC_CTX_NUM",
-	  .def_val = "6@0",
+	  .def_val = "6@0,6@2",
 	  .parse_fn = wd_parse_async_ctx_num
 	},
 	{ .name = "WD_CIPHER_ASYNC_POLL_EN",
-	  .def_val = "1",
+	  .def_val = "0",
 	  .parse_fn = wd_parse_async_poll_en
 	}
 };
@@ -560,8 +556,8 @@ static const struct wd_alg_ops wd_cipher_ops = {
 
 int wd_cipher_env_init(void)
 {
-	return wd_alg_env_init(&wd_cipher_env_config, table, WD_CIPHER_ENV_NUM,
-				&wd_cipher_ops);
+	return wd_alg_env_init(&wd_cipher_env_config, table,
+				&wd_cipher_ops, ARRAY_SIZE(table));
 }
 
 void wd_cipher_env_uninit(void)

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -713,16 +713,12 @@ int wd_comp_poll(__u32 expt, __u32 *count)
 }
 
 static const struct wd_config_variable table[] = {
-	{ .name = "WD_COMP_NUMA",
-	  .def_val = "0",
-	  .parse_fn = wd_parse_numa
-	},
 	{ .name = "WD_COMP_SYNC_CTX_NUM",
-	  .def_val = "6@0",
+	  .def_val = "6@0,6@2",
 	  .parse_fn = wd_parse_sync_ctx_num
 	},
 	{ .name = "WD_COMP_ASYNC_CTX_NUM",
-	  .def_val = "6@0",
+	  .def_val = "6@0,6@2",
 	  .parse_fn = wd_parse_async_ctx_num
 	},
 	{ .name = "WD_COMP_CTX_TYPE",
@@ -730,7 +726,7 @@ static const struct wd_config_variable table[] = {
 	  .parse_fn = wd_parse_comp_ctx_type
 	},
 	{ .name = "WD_COMP_ASYNC_POLL_EN",
-	  .def_val = "1",
+	  .def_val = "0",
 	  .parse_fn = wd_parse_async_poll_en
 	}
 };
@@ -745,8 +741,8 @@ static const struct wd_alg_ops wd_comp_ops = {
 
 int wd_comp_env_init(void)
 {
-	return wd_alg_env_init(&wd_comp_env_config, table, ARRAY_SIZE(table),
-			       &wd_comp_ops);
+	return wd_alg_env_init(&wd_comp_env_config, table,
+			       &wd_comp_ops, ARRAY_SIZE(table));
 }
 
 void wd_comp_env_uninit(void)


### PR DESCRIPTION
1.Adapt cipher to init ctx with environment variable
2.Fix some bug
3.modify default value
4.Remove WD_ALG_NUMA

Signed-off-by: Wenkai Lin <linwenkai6@hisilicon.com>