### PR TITLE
wd/sec: modify the synchronization mode poll

### DIFF
--- a/wd_aead.c
+++ b/wd_aead.c
@@ -18,7 +18,7 @@
 #define WD_POOL_MAX_ENTRIES	1024
 #define MAX_RETRY_COUNTS	200000000
 
-#define POLL_SIZE		700000
+#define POLL_SIZE		70000
 #define POLL_TIME		1000
 
 static int g_aead_mac_len[WD_DIGEST_TYPE_MAX] = {
@@ -501,15 +501,12 @@ int wd_do_aead_sync(handle_t h_sess, struct wd_aead_req *req)
 		goto err_out;
 	}
 
-	if (req->in_bytes >= POLL_SIZE) {
-		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
-		if (unlikely(ret < 0)) {
-			WD_ERR("wd ctx wait fail(%d)!\n", ret);
-			goto err_out;
-		}
-	}
-
 	do {
+		if (req->in_bytes >= POLL_SIZE) {
+			ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+			if (unlikely(ret < 0))
+				WD_ERR("wd ctx wait timeout(%d)!\n", ret);
+		}
 		ret = wd_aead_setting.driver->aead_recv(ctx->ctx, &msg);
 		req->state = msg.result;
 		if (ret == -WD_HW_EACCESS) {

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -19,7 +19,7 @@
 #define DES_WEAK_KEY_NUM	4
 #define MAX_RETRY_COUNTS	200000000
 
-#define POLL_SIZE		1000000
+#define POLL_SIZE		100000
 #define POLL_TIME		1000
 
 static __u64 des_weak_key[DES_WEAK_KEY_NUM] = {
@@ -394,15 +394,12 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 		goto err_out;
 	}
 
-	if (req->in_bytes >= POLL_SIZE) {
-		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
-		if (unlikely(ret < 0)) {
-			WD_ERR("wd ctx wait fail(%d)!\n", ret);
-			goto err_out;
-		}
-	}
-
 	do {
+		if (req->in_bytes >= POLL_SIZE) {
+			ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+			if (unlikely(ret < 0))
+				WD_ERR("wd ctx wait timeout(%d)!\n", ret);
+		}
 		ret = wd_cipher_setting.driver->cipher_recv(ctx->ctx, &msg);
 		req->state = msg.result;
 		if (ret == -WD_HW_EACCESS) {

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -17,7 +17,7 @@
 #define HW_CTX_SIZE			(64 * 1024)
 #define STREAM_CHUNK			(128 * 1024)
 
-#define POLL_SIZE			2500000
+#define POLL_SIZE			250000
 #define POLL_TIME			1000
 
 #define WD_ARRAY_SIZE(array)           (sizeof(array) / sizeof(array[0]))
@@ -418,16 +418,12 @@ int wd_do_comp_sync(handle_t h_sess, struct wd_comp_req *req)
 		return ret;
 	}
 
-	if (req->src_len >= POLL_SIZE) {
-		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
-		if (ret < 0) {
-			pthread_spin_unlock(&ctx->lock);
-			WD_ERR("wd ctx wait fail(%d)!\n", ret);
-			return ret;
-		}
-	}
-
 	do {
+		if (req->src_len >= POLL_SIZE) {
+			ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+			if (ret < 0)
+				WD_ERR("wd ctx wait timeout(%d)!\n", ret);
+		}
 		ret = wd_comp_setting.driver->comp_recv(ctx->ctx, &msg, priv);
 		if (ret == -WD_HW_EACCESS) {
 			pthread_spin_unlock(&ctx->lock);
@@ -646,16 +642,12 @@ int wd_do_comp_strm(handle_t h_sess, struct wd_comp_req *req)
 		return ret;
 	}
 
-	if (req->src_len >= POLL_SIZE) {
-		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
-		if (ret < 0) {
-			pthread_spin_unlock(&ctx->lock);
-			WD_ERR("wd ctx wait fail(%d)!\n", ret);
-			return ret;
-		}
-	}
-
 	do {
+		if (req->src_len >= POLL_SIZE) {
+			ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+			if (ret < 0)
+				WD_ERR("wd ctx wait timeout(%d)!\n", ret);
+		}
 		ret = wd_comp_setting.driver->comp_recv(ctx->ctx, &msg, priv);
 		if (ret == -WD_HW_EACCESS) {
 			pthread_spin_unlock(&ctx->lock);

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -15,7 +15,7 @@
 #define DES_WEAK_KEY_NUM	4
 #define MAX_RETRY_COUNTS	200000000
 
-#define POLL_SIZE		1000000
+#define POLL_SIZE		100000
 #define POLL_TIME		1000
 
 static int g_digest_mac_len[WD_DIGEST_TYPE_MAX] = {
@@ -313,15 +313,12 @@ int wd_do_digest_sync(handle_t h_sess, struct wd_digest_req *req)
 		goto err_out;
 	}
 
-	if (req->in_bytes >= POLL_SIZE) {
-		ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
-		if (unlikely(ret < 0)) {
-			WD_ERR("wd ctx wait fail(%d)!\n", ret);
-			goto err_out;
-		}
-	}
-
 	do {
+		if (req->in_bytes >= POLL_SIZE) {
+			ret = wd_ctx_wait(ctx->ctx, POLL_TIME);
+			if (unlikely(ret < 0))
+				WD_ERR("wd ctx wait timeout(%d)!\n", ret);
+		}
 		ret = wd_digest_setting.driver->digest_recv(ctx->ctx, &msg);
 		req->state = msg.result;
 		if (ret == -WD_HW_EACCESS) {


### PR DESCRIPTION
when long packages and short packages are mixedly
sent, short packages will cause the waiter of the
long packages wake up early, resulting in an
increase in CPU usage.

Signed-off-by: Liulongfang <836713992@qq.com>