### PR TITLE
test/v1: cleanup makefile's expression

### DIFF
--- a/v1/test/bmm_test/Makefile.am
+++ b/v1/test/bmm_test/Makefile.am
@@ -4,6 +4,9 @@ if WITH_OPENSSL_DIR
 bin_PROGRAMS=bmm_test
 
 bmm_test_SOURCES=bmm_test.c bmm_test.h
-
+if WD_STATIC_DRV
 bmm_test_LDADD=../../../.libs/libwd.la
+else
+bmm_test_LDADD=../../../.libs/libwd.so
+endif
 endif

--- a/v1/test/hisi_hpre_test/Makefile.am
+++ b/v1/test/hisi_hpre_test/Makefile.am
@@ -7,8 +7,14 @@ test_hisi_hpre_SOURCES=test_hisi_hpre.c test_hisi_hpre.h
 hpre_test_tools_SOURCES=hpre_test_tools.c
 test_hisi_hpre_times_SOURCES=test_hisi_hpre_times.c test_hisi_hpre.h hpre_test_sample.h
 
+if WD_STATIC_DRV
 test_hisi_hpre_LDADD=../../../.libs/libwd.la $(with_openssl_dir)/libcrypto.so
 hpre_test_tools_LDADD=../../../.libs/libwd.la $(with_openssl_dir)/libcrypto.so
 test_hisi_hpre_times_LDADD=../../../.libs/libwd.la $(with_openssl_dir)/libcrypto.so
+else
+test_hisi_hpre_LDADD=../../../.libs/libwd.so $(with_openssl_dir)/libcrypto.so
+hpre_test_tools_LDADD=../../../.libs/libwd.so $(with_openssl_dir)/libcrypto.so
+test_hisi_hpre_times_LDADD=../../../.libs/libwd.so $(with_openssl_dir)/libcrypto.so
+endif
 
 endif

--- a/v1/test/hisi_trng_test/Makefile.am
+++ b/v1/test/hisi_trng_test/Makefile.am
@@ -1,11 +1,20 @@
 AM_CFLAGS=-Wall -Werror -O0 -fno-strict-aliasing -I$(top_srcdir)/include -I$(srcdir) -pthread
 
+if WITH_OPENSSL_DIR
 bin_PROGRAMS=test_hisi_trngu test_hisi_trngk test_hisi_trngp
 
 test_hisi_trngu_SOURCES=test_hisi_trngu.c
 test_hisi_trngk_SOURCES=test_hisi_trngk.c
 test_hisi_trngp_SOURCES=test_hisi_trngp.c
 
+if WD_STATIC_DRV
 test_hisi_trngu_LDADD=../../../.libs/libwd.la
 test_hisi_trngk_LDADD=../../../.libs/libwd.la
 test_hisi_trngp_LDADD=../../../.libs/libwd.la
+else
+test_hisi_trngu_LDADD=../../../.libs/libwd.so
+test_hisi_trngk_LDADD=../../../.libs/libwd.so
+test_hisi_trngp_LDADD=../../../.libs/libwd.so
+endif
+
+endif

--- a/v1/test/hisi_zip_test/Makefile.am
+++ b/v1/test/hisi_zip_test/Makefile.am
@@ -6,33 +6,33 @@ test_hisi_zip_SOURCES=test_hisi_zip.c ../wd_sched.c ../smm.c
 if WD_STATIC_DRV
 test_hisi_zip_LDADD=../../../.libs/libwd.a
 else
-test_hisi_zip_LDADD=-L../../../.libs -lwd
+test_hisi_zip_LDADD=../../../.libs/libwd.so
 endif	# WD_STATIC_DRV
 
 test_hisi_zlib_SOURCES=test_hisi_zlib.c zip_alg.c ../wd_sched.c ../smm.c
 if WD_STATIC_DRV
 test_hisi_zlib_LDADD=../../../.libs/libwd.a
 else
-test_hisi_zlib_LDADD=-L../../../.libs -lwd
+test_hisi_zlib_LDADD=../../../.libs/libwd.so
 endif	# WD_STATIC_DRV
 
 wd_zip_test_SOURCES=wd_zip_test.c zip_alg.c ../wd_sched.c ../smm.c
 if WD_STATIC_DRV
 wd_zip_test_LDADD=../../../.libs/libwd.a -lz
 else
-wd_zip_test_LDADD=-L../../../.libs -lwd -lz
+wd_zip_test_LDADD=../../../.libs/libwd.so -lz
 endif	# WD_STATIC_DRV
 
 wd_zip_test_1630_SOURCES=wd_zip_test_1630.c
 if WD_STATIC_DRV
 wd_zip_test_1630_LDADD=../../../.libs/libwd.a -lz
 else
-wd_zip_test_1630_LDADD=-L../../../.libs -lwd -lz
+wd_zip_test_1630_LDADD=../../../.libs/libwd.so -lz
 endif	# WD_STATIC_DRV
 
 test_hisi_zip_perf_SOURCES=test_hisi_zip_perf.c zip_alg.c ../wd_sched.c ../smm.c
 if WD_STATIC_DRV
 test_hisi_zip_perf_LDADD=../../../.libs/libwd.a
 else
-test_hisi_zip_perf_LDADD=-L../../../.libs -lwd -lz
+test_hisi_zip_perf_LDADD=../../../.libs/libwd.so -lz
 endif	# WD_STATIC_DRV

--- a/v1/test/hisi_zip_test_sgl/Makefile.am
+++ b/v1/test/hisi_zip_test_sgl/Makefile.am
@@ -9,6 +9,6 @@ if WD_STATIC_DRV
 wd_zip_test_sgl_LDADD=../../../.libs/libwd.a
 sgl_test_LDADD=../../../.libs/libwd.a
 else
-wd_zip_test_sgl_LDADD=-L../../../.libs -lwd
-sgl_test_LDADD=-L../../../.libs -lwd
+wd_zip_test_sgl_LDADD=../../../.libs/libwd.so
+sgl_test_LDADD=../../../.libs/libwd.so
 endif

--- a/v1/test/test_mm/Makefile.am
+++ b/v1/test/test_mm/Makefile.am
@@ -4,4 +4,8 @@ bin_PROGRAMS=test_wd_mem
 
 test_wd_mem_SOURCES=test_wd_mem.c test_wd_mem.h
 
+if WD_STATIC_DRV
 test_wd_mem_LDADD=../../../.libs/libwd.la -ldl
+else
+test_wd_mem_LDADD=../../../.libs/libwd.so -ldl
+endif


### PR DESCRIPTION
The makefile expression of the test tools in v1 are not uniform.
this patch is used to correct this difference.

Signed-off-by: Longfang Liu <longfang.liu@foxmail.com>