### PR TITLE
test: sec: fix on mutex releasing

### DIFF
--- a/test/hisi_sec_test/test_hisi_sec.c
+++ b/test/hisi_sec_test/test_hisi_sec.c
@@ -1063,6 +1063,7 @@ try_do_again:
 			goto try_do_again;
 		} else if (ret) {
 			SEC_TST_PRT("test sec cipher send req is error!\n");
+			pthread_mutex_unlock(&test_sec_mutex);
 			goto out;
 		}
 		cnt--;


### PR DESCRIPTION
While error occurs, program finishes without releasing mutex. Fix it.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>