### PR TITLE
cipher/v2 - fix some tiny bugs of SEC

### DIFF
--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -1854,7 +1854,6 @@ static void parse_aead_bd2(struct hisi_sec_sqe *sqe,
 		recv_msg->result = WD_SUCCESS;
 	}
 
-	recv_msg->aiv = (__u8 *)(uintptr_t)sqe->type2.a_ivin_addr;
 	recv_msg->tag = sqe->type2.tag;
 
 	recv_msg->data_fmt = hisi_sec_get_data_fmt_v2(sqe->sds_sa_type);
@@ -2125,7 +2124,6 @@ static void parse_aead_bd3(struct hisi_sec_sqe3 *sqe,
 		recv_msg->result = WD_SUCCESS;
 	}
 
-	recv_msg->aiv = (__u8 *)(uintptr_t)sqe->auth_ivin.a_ivin_addr;
 	recv_msg->tag = sqe->tag;
 
 	recv_msg->data_fmt = hisi_sec_get_data_fmt_v3(sqe->bd_param);

--- a/include/drv/wd_aead_drv.h
+++ b/include/drv/wd_aead_drv.h
@@ -50,7 +50,7 @@ struct wd_aead_msg {
 	/* input iv pointer */
 	__u8 *iv;
 	/* input auth iv pointer */
-	__u8 *aiv;
+	__u8 aiv[MAX_IV_SIZE];
 	/* input data pointer */
 	__u8 *in;
 	/* output data pointer */

--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -49,8 +49,8 @@ struct wd_aead_sess {
 	enum wd_cipher_mode	cmode;
 	enum wd_digest_type	dalg;
 	enum wd_digest_mode	dmode;
-	void			*ckey;
-	void			*akey;
+	unsigned char	ckey[MAX_CIPHER_KEY_SIZE];
+	unsigned char	akey[MAX_CIPHER_KEY_SIZE];
 	__u16			ckey_bytes;
 	__u16			akey_bytes;
 	__u16			auth_bytes;

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -11,12 +11,14 @@
 #include "wd.h"
 #include "wd_alg_common.h"
 
-#define AES_KEYSIZE_128 16
-#define AES_KEYSIZE_192 24
-#define AES_KEYSIZE_256 32
-#define AES_BLOCK_SIZE 16
-#define GCM_BLOCK_SIZE 12
-#define DES3_BLOCK_SIZE 8
+#define AES_KEYSIZE_128	16
+#define AES_KEYSIZE_192	24
+#define AES_KEYSIZE_256	32
+#define AES_BLOCK_SIZE	16
+#define GCM_BLOCK_SIZE	12
+#define DES3_BLOCK_SIZE	8
+#define MAX_CIPHER_KEY_SIZE	64
+#define MAX_IV_SIZE	AES_BLOCK_SIZE
 
 /**
  * config ctx operation type and task mode.
@@ -77,7 +79,7 @@ struct wd_cipher_sess {
 	wd_dev_mask_t		*dev_mask;
 	struct wd_alg_cipher	*drv;
 	void			*priv;
-	void			*key;
+	unsigned char	key[MAX_CIPHER_KEY_SIZE];
 	__u32			key_bytes;
 	int			numa;
 };

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -11,6 +11,8 @@
 #include "wd_alg_common.h"
 #include "wd.h"
 
+#define MAX_HMAC_KEY_SIZE	128U
+
 /**
  * wd_digest_type - Algorithm type of digest
  * algorithm should be offered by struct wd_digest_arg
@@ -70,7 +72,7 @@ struct wd_digest_sess {
 	enum wd_digest_type	alg;
 	enum wd_digest_mode	mode;
 	void			*priv;
-	void			*key;
+	unsigned char	key[MAX_HMAC_KEY_SIZE];
 	__u32			key_bytes;
 	int			numa;
 };

--- a/test/hisi_sec_test/test_hisi_sec.c
+++ b/test/hisi_sec_test/test_hisi_sec.c
@@ -242,7 +242,7 @@ static inline void copy_mem(int dst_sgl, void *dst, int src_sgl, void *src,
 		SEC_TST_PRT("Not supported memory type for copy.\n");
 }
 
-static void dump_mem(int sgl, char *buf, size_t len)
+static void dump_mem(int sgl, unsigned char *buf, size_t len)
 {
 	struct wd_datalist *p;
 	size_t i, tmp;

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -18,7 +18,6 @@
 #define DES_KEY_SIZE		8
 #define DES3_2KEY_SIZE		(2 * DES_KEY_SIZE)
 #define DES3_3KEY_SIZE		(3 * DES_KEY_SIZE)
-#define MAX_CIPHER_KEY_SIZE	64
 
 #define WD_POOL_MAX_ENTRIES	1024
 #define DES_WEAK_KEY_NUM	4
@@ -164,7 +163,7 @@ handle_t wd_cipher_alloc_sess(struct wd_cipher_sess_setup *setup)
 {
 	struct wd_cipher_sess *sess = NULL;
 
-	if (!setup) {
+	if (unlikely(!setup)) {
 		WD_ERR("cipher input setup is NULL!\n");
 		return (handle_t)0;
 	}
@@ -177,15 +176,6 @@ handle_t wd_cipher_alloc_sess(struct wd_cipher_sess_setup *setup)
 	memset(sess, 0, sizeof(struct wd_cipher_sess));
 	sess->alg = setup->alg;
 	sess->mode = setup->mode;
-	sess->key = malloc(MAX_CIPHER_KEY_SIZE);
-	if (!sess->key) {
-		WD_ERR("fail to alloc key memory!\n");
-		free(sess);
-		return (handle_t)0;
-	}
-
-	memset(sess->key, 0, MAX_CIPHER_KEY_SIZE);
-
 	sess->numa = setup->numa;
 
 	return (handle_t)sess;
@@ -193,16 +183,14 @@ handle_t wd_cipher_alloc_sess(struct wd_cipher_sess_setup *setup)
 
 void wd_cipher_free_sess(handle_t h_sess)
 {
-	if (!h_sess) {
+	if (unlikely(!h_sess)) {
 		WD_ERR("cipher input h_sess is NULL!\n");
 		return;
 	}
 	struct wd_cipher_sess *sess = (struct wd_cipher_sess *)h_sess;
 
-	if (sess->key) {
-		wd_memset_zero(sess->key, MAX_CIPHER_KEY_SIZE);
-		free(sess->key);
-	}
+	wd_memset_zero(sess->key, MAX_CIPHER_KEY_SIZE);
+
 	free(sess);
 }
 

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -15,7 +15,6 @@
 #define DES_KEY_SIZE		8
 #define DES3_3KEY_SIZE		(3 * DES_KEY_SIZE)
 
-#define MAX_HMAC_KEY_SIZE	128
 #define WD_POOL_MAX_ENTRIES	1024
 #define DES_WEAK_KEY_NUM	4
 #define MAX_RETRY_COUNTS	200000000
@@ -93,7 +92,7 @@ handle_t wd_digest_alloc_sess(struct wd_digest_sess_setup *setup)
 {
 	struct wd_digest_sess *sess = NULL;
 
-	if (!setup) {
+	if (unlikely(!setup)) {
 		WD_ERR("failed to check alloc sess param!\n");
 		return (handle_t)0;
 	}
@@ -106,13 +105,6 @@ handle_t wd_digest_alloc_sess(struct wd_digest_sess_setup *setup)
 	sess->alg = setup->alg;
 	sess->mode = setup->mode;
 	sess->numa = setup->numa;
-	sess->key = malloc(MAX_HMAC_KEY_SIZE);
-	if (!sess->key) {
-		free(sess);
-		WD_ERR("failed to alloc sess key!\n");
-		return (handle_t)0;
-	}
-	memset(sess->key, 0, MAX_HMAC_KEY_SIZE);
 
 	return (handle_t)sess;
 }
@@ -121,15 +113,12 @@ void wd_digest_free_sess(handle_t h_sess)
 {
 	struct wd_digest_sess *sess = (struct wd_digest_sess *)h_sess;
 
-	if (!sess) {
+	if (unlikely(!sess)) {
 		WD_ERR("failed to check free sess param!\n");
 		return;
 	}
 
-	if (sess->key) {
-		wd_memset_zero(sess->key, MAX_HMAC_KEY_SIZE);
-		free(sess->key);
-	}
+	wd_memset_zero(sess->key, MAX_HMAC_KEY_SIZE);
 	free(sess);
 }
 


### PR DESCRIPTION
1. Fix iv bytes align checking for skcipher.
2. Optimize the digest length checking. Combine the two jugement
   branchs into one.
3. Modify the dfx message.

Signed-off-by: Kai Ye <yekai13@huawei.com>