### PR TITLE
uadk/digest - add stream mode for digest sync mode

### DIFF
--- a/include/drv/wd_digest_drv.h
+++ b/include/drv/wd_digest_drv.h
@@ -44,6 +44,8 @@ struct wd_digest_msg {
 	__u8 *in;
 	/* output data pointer */
 	__u8 *out;
+	/* total of data for stream mode */
+	__u64 *long_data_len;
 };
 
 struct wd_digest_driver {

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -77,6 +77,14 @@ struct wd_digest_sess {
 	int			numa;
 };
 
+enum sec_digest_state {
+	SEC_DIGEST_INIT = 0,
+	SEC_DIGEST_FIRST_UPDATING,
+	SEC_DIGEST_DOING,
+	SEC_DIGEST_FINAL,
+	SEC_DIGEST_NO_STREAM
+};
+
 /**
  * struct wd_digest_arg - Parameters for per digest operation
  * @in: input data address


### PR DESCRIPTION
Add the sec digest state for steam mode. User can use it to
notify the digest state. Using the digest out memory to store the
total of packet, So user should allocated the memory with at
least twice the digest length.

Signed-off-by: Kai Ye <yekai13@huawei.com>