### PR TITLE
uadk/benchmark: modify test tools data cal

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -422,14 +422,12 @@ int hisi_qm_send(handle_t h_qp, void *req, __u16 expect, __u16 *count)
 
 	q_info = &qp->q_info;
 
-	pthread_spin_lock(&q_info->lock);
-
 	if (wd_ioread32(q_info->ds_tx_base) == 1) {
 		WD_ERR("wd queue hw error happened before qm send!\n");
-		pthread_spin_unlock(&q_info->lock);
 		return -WD_HW_EACCESS;
 	}
 
+	pthread_spin_lock(&q_info->lock);
 	free_num = get_free_num(q_info);
 	if (!free_num) {
 		pthread_spin_unlock(&q_info->lock);

--- a/include/wd.h
+++ b/include/wd.h
@@ -130,12 +130,26 @@ struct wd_dev_mask {
 typedef unsigned long long int handle_t;
 typedef struct wd_dev_mask wd_dev_mask_t;
 
+#if defined(__AARCH64_CMODEL_SMALL__) && __AARCH64_CMODEL_SMALL__
+#define dsb(opt)        { asm volatile("dsb " #opt : : : "memory"); }
+#define rmb()           dsb(ld) /* read fence */
+#define wmb()           dsb(st) /* write fence */
+#define mb()            dsb(sy) /* rw fence */
+#else
+#define rmb()   /* read fence */
+#define wmb()   /* write fence */
+#define mb()    /* rw fence */
+#ifndef __UT__
+#error "no platform mb, define one before compiling"
+#endif
+#endif
+
 static inline uint32_t wd_ioread32(void *addr)
 {
 	uint32_t ret;
 
 	ret = *((volatile uint32_t *)addr);
-	__sync_synchronize();
+	rmb();
 	return ret;
 }
 
@@ -144,19 +158,19 @@ static inline uint64_t wd_ioread64(void *addr)
 	uint64_t ret;
 
 	ret = *((volatile uint64_t *)addr);
-	__sync_synchronize();
+	rmb();
 	return ret;
 }
 
 static inline void wd_iowrite32(void *addr, uint32_t value)
 {
-	__sync_synchronize();
+	wmb();
 	*((volatile uint32_t *)addr) = value;
 }
 
 static inline void wd_iowrite64(void *addr, uint64_t value)
 {
-	__sync_synchronize();
+	wmb();
 	*((volatile uint64_t *)addr) = value;
 }
 

--- a/uadk_benchmark/Makefile.am
+++ b/uadk_benchmark/Makefile.am
@@ -16,7 +16,7 @@ uadk_benchmark_LDADD=$(libwd_la_OBJECTS) \
 			../.libs/libhisi_sec.a \
 			../.libs/libhisi_hpre.a \
 			../.libs/libhisi_zip.a \
-			include/libcrypto.so.1.1 -lnuma
+			include/libcrypto.a -ldl -lnuma
 else
 uadk_benchmark_LDADD=-L../.libs -l:libwd.so.2 -l:libwd_crypto.so.2 \
 			-L$(top_srcdir)/uadk_benchmark/include -l:libcrypto.so.1.1 -lnuma

--- a/uadk_benchmark/uadk_benchmark.c
+++ b/uadk_benchmark/uadk_benchmark.c
@@ -131,27 +131,12 @@ void add_send_complete(void)
 	__atomic_add_fetch(&g_recv_data.send_times, 1, __ATOMIC_RELAXED);
 }
 
-void add_send_data(u32 cnt)
-{
-	__atomic_add_fetch(&g_recv_data.send_cnt, cnt, __ATOMIC_RELAXED);
-}
-
 void add_recv_data(u32 cnt)
 {
 	pthread_mutex_lock(&acc_mutex);
 	g_recv_data.recv_cnt += cnt;
 	g_recv_data.recv_times++;
 	pthread_mutex_unlock(&acc_mutex);
-}
-
-u64 get_send_data(void)
-{
-	return g_recv_data.send_cnt;
-}
-
-u32 get_send_time(void)
-{
-	return g_recv_data.send_times;
 }
 
 u32 get_recv_time(void)
@@ -233,7 +218,7 @@ int get_pid_cpu_time(u32 *ptime)
 	}
 	close(fd);
 
-	bgidx = 13; // process time data begin with index 14
+	bgidx = 13; // process time data begin with index 13
 	for (i = 0; i < ret; i++) {
 		if (buf[i] == ' ') {
 			bgidx--;
@@ -244,7 +229,6 @@ int get_pid_cpu_time(u32 *ptime)
 	ret = sscanf(&buf[i], "%llu %llu %llu %llu", &caltime[0], &caltime[1],
 		&caltime[2], &caltime[3]);
 	*ptime = caltime[0] + caltime[1] + caltime[2] + caltime[3];
-	// printf("read process time: %u\n", *ptime);
 
 	return 0;
 }

--- a/uadk_benchmark/uadk_benchmark.h
+++ b/uadk_benchmark/uadk_benchmark.h
@@ -27,6 +27,7 @@
 #define MAX_OPT_TYPE	5
 #define MAX_DATA_SIZE	(15 * 1024 * 1024)
 #define MAX_ALG_NAME 64
+#define ACC_QUEUE_SIZE	1024
 
 typedef unsigned char u8;
 typedef unsigned int u32;
@@ -166,10 +167,7 @@ extern void set_run_state(int state);
 extern int get_rand_int(int range);
 extern void get_rand_data(u8 *addr, int size);
 extern void add_recv_data(u32 cnt);
-extern void add_send_data(u32 cnt);
 extern void add_send_complete(void);
-extern u64 get_send_data(void);
-extern u32 get_send_time(void);
 extern u32 get_recv_time(void);
 
 #endif /* UADK_BENCHMARK_H */


### PR DESCRIPTION
Remove the alignment operation of the number of received and
send packets in the uadk benchmark, and calculate the performance
according to the time stop method.

Reduce the impact of test tool code on performance by optimizing
the statistical method of test tools.

Signed-off-by: Liulongfang <longfang.liu@foxmail.com>