### PR TITLE
wd: bugfix QM's barriers and spin lock

### DIFF
--- a/drv/hisi_qm_udrv.c
+++ b/drv/hisi_qm_udrv.c
@@ -422,14 +422,12 @@ int hisi_qm_send(handle_t h_qp, void *req, __u16 expect, __u16 *count)
 
 	q_info = &qp->q_info;
 
-	pthread_spin_lock(&q_info->lock);
-
 	if (wd_ioread32(q_info->ds_tx_base) == 1) {
 		WD_ERR("wd queue hw error happened before qm send!\n");
-		pthread_spin_unlock(&q_info->lock);
 		return -WD_HW_EACCESS;
 	}
 
+	pthread_spin_lock(&q_info->lock);
 	free_num = get_free_num(q_info);
 	if (!free_num) {
 		pthread_spin_unlock(&q_info->lock);


### PR DESCRIPTION
the original __sync_synchronize() is a general memory synchronization
operation, and rmb()/wmb() will be distinguished according to the type
of operation, thereby reducing the blocking time and improving
performance

the range of the spin lock should be as small as possible to reduce the
performance impact.

Signed-off-by: Liulongfang <longfang.liu@foxmail.com>