### PR TITLE
cipher: fix wrong iv length check

### DIFF
--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -309,7 +309,7 @@ static int cipher_iv_len_check(struct wd_cipher_req *req,
 {
 	int ret = 0;
 
-	if (sess->mode == WD_CIPHER_ECB)
+	if (sess->mode == WD_CIPHER_ECB || sess->mode == WD_CIPHER_XTS)
 		return 0;
 
 	switch (sess->alg) {


### PR DESCRIPTION
There is no 'iv' in XTS mode, so there is no need to verify
the 'iv' length for XTS mode.

Signed-off-by: Yang Shen <shenyang39@huawei.com>