### PR TITLE
wd: bugfix msg pool idx

### DIFF
--- a/wd_util.c
+++ b/wd_util.c
@@ -23,7 +23,6 @@ struct msg_pool {
 	int *used;
 	__u32 msg_num;
 	__u32 msg_size;
-	int head;
 	int tail;
 };
 
@@ -161,7 +160,6 @@ static int init_msg_pool(struct msg_pool *pool, __u32 msg_num, __u32 msg_size)
 
 	pool->msg_size = msg_size;
 	pool->msg_num = msg_num;
-	pool->head = 0;
 	pool->tail = 0;
 
 	return 0;
@@ -214,8 +212,8 @@ void wd_uninit_async_request_pool(struct wd_async_msg_pool *pool)
 /* fix me: this is old wd_get_req_from_pool */
 void *wd_find_msg_in_pool(struct wd_async_msg_pool *pool, int index, __u32 tag)
 {
-	struct msg_pool *p;
-	__u32 msg_num = pool->pools[index].msg_num;
+	struct msg_pool *p = &pool->pools[index];
+	__u32 msg_num = p->msg_num;
 
 	/* tag value start from 1 */
 	if (tag == 0 || tag > msg_num) {
@@ -223,21 +221,16 @@ void *wd_find_msg_in_pool(struct wd_async_msg_pool *pool, int index, __u32 tag)
 		return NULL;
 	}
 
-	p = &pool->pools[index];
-
 	return p->msgs + p->msg_size * (tag - 1);
 }
 
 int wd_get_msg_from_pool(struct wd_async_msg_pool *pool, int index, void **msg)
 {
-	struct msg_pool *p;
-	__u32 msg_num = pool->pools[index].msg_num;
-	__u32 msg_size;
+	struct msg_pool *p = &pool->pools[index];
+	__u32 msg_size = p->msg_size;
+	__u32 msg_num = p->msg_num;
+	int idx = p->tail;
 	int cnt = 0;
-	int idx = 0;
-
-	p = &pool->pools[index];
-	msg_size = p->msg_size;
 
 	while (__atomic_test_and_set(&p->used[idx], __ATOMIC_ACQUIRE)) {
 		idx = (idx + 1) % msg_num;
@@ -246,6 +239,7 @@ int wd_get_msg_from_pool(struct wd_async_msg_pool *pool, int index, void **msg)
 			return -WD_EBUSY;
 	}
 
+	p->tail = (idx + 1) % msg_num;
 	*msg = p->msgs + msg_size * idx;
 
 	return idx + 1;
@@ -253,16 +247,14 @@ int wd_get_msg_from_pool(struct wd_async_msg_pool *pool, int index, void **msg)
 
 void wd_put_msg_to_pool(struct wd_async_msg_pool *pool, int index, __u32 tag)
 {
-	struct msg_pool *p;
-	__u32 msg_num = pool->pools[index].msg_num;
+	struct msg_pool *p = &pool->pools[index];
+	__u32 msg_num = p->msg_num;
 
 	/* tag value start from 1 */
 	if (!tag || tag > msg_num) {
 		WD_ERR("invalid message cache idx(%u)\n", tag);
 		return;
 	}
-
-	p = &pool->pools[index];
 
 	__atomic_clear(&p->used[tag - 1], __ATOMIC_RELEASE);
 }


### PR DESCRIPTION
1.reduce the number of queries to find effective resources from the
resource pool by retaining the index of the effective resource
obtained last time.
2.bugfix some coding style

Signed-off-by: Liulongfang <longfang.liu@foxmail.com>