### PR TITLE
wd: sec: change init entry limitation per pid

### DIFF
--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -81,6 +81,7 @@ struct wd_ctx_config_internal {
 	__u32 ctx_num;
 	struct wd_ctx_internal *ctxs;
 	void *priv;
+	int pid;
 };
 
 /**

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -199,7 +199,8 @@ int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	void *priv;
 	int ret;
 
-	if (wd_cipher_setting.config.ctx_num) {
+	if (wd_cipher_setting.config.ctx_num &&
+	    wd_cipher_setting.config.pid == getpid()) {
 		WD_ERR("cipher have initialized.\n");
 		return -WD_EEXIST;
 	}
@@ -219,6 +220,8 @@ int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 		WD_ERR("failed to set config, ret = %d!\n", ret);
 		return ret;
 	}
+
+	wd_cipher_setting.config.pid = getpid();
 
 	ret = wd_init_sched(&wd_cipher_setting.sched, sched);
 	if (ret < 0) {

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -127,7 +127,8 @@ int wd_digest_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	void *priv;
 	int ret;
 
-	if (wd_digest_setting.config.ctx_num) {
+	if (wd_digest_setting.config.ctx_num &&
+	    wd_digest_setting.config.pid == getpid()) {
 		WD_ERR("digest have initialized.\n");
 		return -WD_EEXIST;
 	}
@@ -147,6 +148,8 @@ int wd_digest_init(struct wd_ctx_config *config, struct wd_sched *sched)
 		WD_ERR("failed to set config, ret = %d!\n", ret);
 		return ret;
 	}
+
+	wd_digest_setting.config.pid = getpid();
 
 	ret = wd_init_sched(&wd_digest_setting.sched, sched);
 	if (ret < 0) {


### PR DESCRIPTION
Nginx master process do the init, then fork worker
processes do the real transaction. So change the
entry limitaiton according to pid.

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>