### PR TITLE
wd: bugfix multi-process initialization function

### DIFF
--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -81,6 +81,7 @@ struct wd_ctx_config_internal {
 	__u32 ctx_num;
 	struct wd_ctx_internal *ctxs;
 	void *priv;
+	int pid;
 };
 
 /**

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -38,7 +38,7 @@ struct wd_aead_setting {
 	struct wd_async_msg_pool pool;
 	void *sched_ctx;
 	void *priv;
-}wd_aead_setting;
+} wd_aead_setting;
 
 struct wd_env_config wd_aead_env_config;
 
@@ -323,7 +323,9 @@ int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	void *priv;
 	int ret;
 
-	if (wd_aead_setting.config.ctx_num) {
+	/* wd_aead_init() could only be invoked once for one process. */
+	if (wd_aead_setting.config.ctx_num &&
+	    wd_aead_setting.config.pid == getpid()) {
 		WD_ERR("aead have initialized.\n");
 		return -WD_EEXIST;
 	}

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -38,7 +38,7 @@ struct wd_cipher_setting {
 	struct wd_cipher_driver *driver;
 	void *priv;
 	struct wd_async_msg_pool pool;
-}wd_cipher_setting;
+} wd_cipher_setting;
 
 struct wd_env_config wd_cipher_env_config;
 
@@ -199,7 +199,9 @@ int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	void *priv;
 	int ret;
 
-	if (wd_cipher_setting.config.ctx_num) {
+	/* wd_cipher_init() could only be invoked once for one process. */
+	if (wd_cipher_setting.config.ctx_num &&
+	    wd_cipher_setting.config.pid == getpid()) {
 		WD_ERR("cipher have initialized.\n");
 		return -WD_EEXIST;
 	}

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -86,7 +86,8 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	int ret;
 
 	/* wd_comp_init() could only be invoked once for one process. */
-	if (wd_comp_setting.config.ctx_num) {
+	if (wd_comp_setting.config.ctx_num &&
+	    wd_comp_setting.config.pid == getpid()) {
 		WD_ERR("comp have initialized.!\n");
 		return -WD_EEXIST;
 	}

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -75,7 +75,8 @@ void wd_dh_set_driver(struct wd_dh_driver *drv)
 static int param_check(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	/* wd_dh_init() could only be invoked once for one process. */
-	if (wd_dh_setting.config.ctx_num) {
+	if (wd_dh_setting.config.ctx_num &&
+	    wd_dh_setting.config.pid == getpid()) {
 		WD_ERR("dh have initialized.\n");
 		return -WD_EEXIST;
 	}

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -35,7 +35,7 @@ struct wd_digest_setting {
 	struct wd_async_msg_pool pool;
 	void *sched_ctx;
 	void *priv;
-}wd_digest_setting;
+} wd_digest_setting;
 
 struct wd_env_config wd_digest_env_config;
 
@@ -127,7 +127,9 @@ int wd_digest_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	void *priv;
 	int ret;
 
-	if (wd_digest_setting.config.ctx_num) {
+	/* wd_digest_init() could only be invoked once for one process. */
+	if (wd_digest_setting.config.ctx_num &&
+	    wd_digest_setting.config.pid == getpid()) {
 		WD_ERR("digest have initialized.\n");
 		return -WD_EEXIST;
 	}

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -129,7 +129,8 @@ void wd_ecc_set_driver(struct wd_ecc_driver *drv)
 static int init_param_check(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	/* wd_ecc_init() could only be invoked once for one process. */
-	if (wd_ecc_setting.config.ctx_num) {
+	if (wd_ecc_setting.config.ctx_num &&
+	    wd_ecc_setting.config.pid == getpid()) {
 		WD_ERR("ecc have initialized.\n");
 		return -WD_EEXIST;
 	}

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -115,7 +115,8 @@ void wd_rsa_set_driver(struct wd_rsa_driver *drv)
 static int param_check(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	/* wd_rsa_init() could only be invoked once for one process. */
-	if (wd_rsa_setting.config.ctx_num) {
+	if (wd_rsa_setting.config.ctx_num &&
+	    wd_rsa_setting.config.pid == getpid()) {
 		WD_ERR("rsa have initialized.\n");
 		return -WD_EEXIST;
 	}

--- a/wd_util.c
+++ b/wd_util.c
@@ -91,6 +91,7 @@ int wd_init_ctx_config(struct wd_ctx_config_internal *in,
 	}
 
 	in->ctxs = ctxs;
+	in->pid = getpid();
 	in->priv = cfg->priv;
 	in->ctx_num = cfg->ctx_num;
 
@@ -131,6 +132,7 @@ void wd_clear_ctx_config(struct wd_ctx_config_internal *in)
 
 	in->priv = NULL;
 	in->ctx_num = 0;
+	in->pid = 0;
 	if (in->ctxs)
 		free(in->ctxs);
 }


### PR DESCRIPTION
UADK device initialization is based on the process. if multiple
initialization occur in a process, it will cause resource leakage.
when Nginx master creates a new process through the fork process,
some parameters will be copied, but the real device resource are not
initialized.
Therefore, It need to distinguish based on pid whethre device
initialization is required.

Signed-off-by: Liulongfang <longfang.liu@foxmail.com>