### PR TITLE
wd/v1: fix get_dev_info return value

### DIFF
--- a/v1/wd.c
+++ b/v1/wd.c
@@ -258,8 +258,11 @@ static int get_int_attr_all(struct dev_info *dinfo)
 	dinfo->node_id = get_int_attr(dinfo, "node_id");
 
 	ret = get_int_attr(dinfo, "flags");
-	if (ret < 0 || (unsigned int)ret & WD_UACCE_DEV_SVA)
+	if (ret < 0)
 		return ret;
+	else if ((unsigned int)ret & WD_UACCE_DEV_SVA)
+		return -ENODEV;
+
 	dinfo->flags = ret;
 
 	return 0;

--- a/v1/wd_aead.c
+++ b/v1/wd_aead.c
@@ -431,10 +431,12 @@ static int check_op_data(struct wcrypto_aead_op_data **op,
 		return -WD_EINVAL;
 	}
 
-	if (unlikely(ctx->setup.cmode == WCRYPTO_CIPHER_CBC &&
+	if (unlikely(op[idx]->in_bytes == 0 ||
 	    (op[idx]->in_bytes & (AES_BLOCK_SIZE - 1)))) {
-		WD_ERR("failed to check aead input data length!\n");
-		return -WD_EINVAL;
+		if (ctx->setup.cmode == WCRYPTO_CIPHER_CBC) {
+			WD_ERR("failed to check aead input data length!\n");
+			return -WD_EINVAL;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
get_dev_info should not return flags, it is meaningless.

Signed-off-by: Wenkai Lin <linwenkai6@hisilicon.com>