### PR TITLE
wd/sched: update the RR scheduler inside UADK

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@ AM_CFLAGS+= -DUADK_VERSION_NUMBER="\"libwd version: ${MAJOR}.${MINOR}.${REVISION
 include_HEADERS = include/wd.h include/wd_cipher.h include/wd_comp.h \
 		  include/wd_dh.h include/wd_digest.h include/wd_rsa.h \
 		  include/uacce.h include/wd_alg_common.h \
-		  include/wd_common.h include/wd_ecc.h
+		  include/wd_common.h include/wd_ecc.h include/wd_sched.h
 
 nobase_include_HEADERS = v1/wd.h v1/wd_cipher.h v1/uacce.h v1/wd_dh.h v1/wd_digest.h \
 			 v1/wd_rsa.h v1/wd_bmm.h

--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -37,7 +37,7 @@ struct wd_aead_sess_setup {
 	enum wd_cipher_mode cmode;
 	enum wd_digest_type dalg;
 	enum wd_digest_mode dmode;
-	int numa;
+	void *sched_param;
 };
 
 struct wd_aead_req;
@@ -173,10 +173,10 @@ int wd_aead_poll(__u32 expt, __u32 *count);
 /**
  * wd_aead_env_init() - Init ctx and schedule resources according to wd aead
  * environment variables.
- *
+ * @sched: user's custom scheduler.
  * More information, please see docs/wd_environment_variable.
  */
-int wd_aead_env_init(void);
+int wd_aead_env_init(struct wd_sched *sched);
 
 /**
  *   wd_aead_env_uninit() - UnInit ctx and schedule resources set by above init.

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -58,18 +58,6 @@ struct wd_ctx_config {
 	void *priv;
 };
 
-/**
- * sched_key - The key if schedule region.
- * @numa_id: The numa_id map the hardware.
- * @mode: Sync mode:0, async_mode:1
- * @type: Service type , the value must smaller than type_num.
- */
-struct sched_key {
-	int numa_id;
-	__u8 mode;
-	__u8 type;
-};
-
 struct wd_ctx_internal {
 	handle_t ctx;
 	__u8 op_type;
@@ -87,6 +75,8 @@ struct wd_ctx_config_internal {
 /**
  * struct wd_comp_sched - Define a scheduler.
  * @name:		Name of this scheduler.
+ * @sched_policy:	Method for scheduler to perform scheduling
+ * @sched_init:		inited the scheduler input parameters.
  * @pick_next_ctx:	Pick the proper ctx which a request will be sent to.
  *			config points to the ctx config; sched_ctx points to
  *			scheduler context; req points to the request. Return
@@ -98,9 +88,11 @@ struct wd_ctx_config_internal {
  */
 struct wd_sched {
 	const char *name;
+	int sched_policy;
+	handle_t (*sched_init)(handle_t h_sched_ctx, void *sched_param);
 	__u32 (*pick_next_ctx)(handle_t h_sched_ctx,
-				  const void *req,
-				  const struct sched_key *key);
+				  void *sched_key,
+				  const int sched_mode);
 	int (*poll_policy)(handle_t h_sched_ctx, __u32 expect, __u32 *count);
 	handle_t h_sched_ctx;
 };

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -66,7 +66,7 @@ enum wd_cipher_mode {
 struct wd_cipher_sess_setup {
 	enum wd_cipher_alg alg;
 	enum wd_cipher_mode mode;
-	int numa;
+	void *sched_param;
 };
 
 struct wd_cipher_req;
@@ -146,9 +146,10 @@ int wd_cipher_poll(__u32 expt, __u32 *count);
  * wd_cipher_env_init() - Init ctx and schedule resources according to wd cipher
  * environment variables.
  *
+ * @sched: user's custom scheduler.
  * More information, please see docs/wd_environment_variable.
  */
-int wd_cipher_env_init(void);
+int wd_cipher_env_init(struct wd_sched *sched);
 
 /**
  * wd_cipher_env_uninit() - UnInit ctx and schedule resources set by above init.

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -116,7 +116,7 @@ struct wd_comp_sess_setup {
 	enum wd_comp_level comp_lv;     /* Denoted by enum wd_comp_level */
 	enum wd_comp_winsz_type win_sz; /* Denoted by enum wd_comp_winsz_type */
 	enum wd_comp_op_type op_type;   /* Denoted by enum wd_comp_op_type */
-	int numa;
+	void *sched_param;
 };
 
 /**
@@ -172,11 +172,12 @@ int wd_do_comp_sync2(handle_t h_sess, struct wd_comp_req *req);
 
 /**
  * wd_comp_env_init() - Init ctx and schedule resources according to wd comp
- * 			environment variables.
+ * environment variables.
  *
+ * @sched: user's custom scheduler.
  * More information, please see docs/wd_environment_variable.
  */
-int wd_comp_env_init(void);
+int wd_comp_env_init(struct wd_sched *sched);
 
 /**
  * wd_comp_env_uninit() - UnInit ctx and schedule resources set by above init.

--- a/include/wd_dh.h
+++ b/include/wd_dh.h
@@ -27,7 +27,7 @@ enum wd_dh_op_type {
 struct wd_dh_sess_setup {
 	__u16 key_bits; /* DH key bites */
 	bool is_g2; /* is g2 mode or not */
-	int numa;
+	void *sched_param;
 };
 
 struct wd_dh_req {
@@ -62,7 +62,7 @@ int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
 int wd_dh_poll(__u32 expt, __u32 *count);
 int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched);
 void wd_dh_uninit(void);
-int wd_dh_env_init(void);
+int wd_dh_env_init(struct wd_sched *sched);
 void wd_dh_env_uninit(void);
 int wd_dh_ctx_num_init(__u32 node, __u32 type, __u32 num, __u8 mode);
 void wd_dh_ctx_num_uninit(void);

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -62,7 +62,7 @@ enum wd_digest_mode {
 struct wd_digest_sess_setup {
 	enum wd_digest_type alg;
 	enum wd_digest_mode mode;
-	int numa;
+	void *sched_param;
 };
 
 typedef void *wd_digest_cb_t(void *cb_param);
@@ -170,9 +170,10 @@ int wd_digest_poll(__u32 expt, __u32 *count);
  * wd_digest_env_init() - Init ctx and schedule resources according to wd digest
  * environment variables.
  *
+ * @sched: user's custom scheduler.
  * More information, please see docs/wd_environment_variable.
  */
-int wd_digest_env_init(void);
+int wd_digest_env_init(struct wd_sched *sched);
 
 /**
  * wd_digest_env_uninit() - UnInit ctx and schedule resources set by above init.

--- a/include/wd_ecc.h
+++ b/include/wd_ecc.h
@@ -118,7 +118,7 @@ struct wd_ecc_sess_setup {
 	struct wd_ecc_curve_cfg cv; /* curve config denoted by user */
 	struct wd_rand_mt rand; /* rand method from user */
 	struct wd_hash_mt hash; /* hash method from user */
-	int numa;
+	void *sched_param;
 };
 
 struct wd_ecc_req {
@@ -489,9 +489,10 @@ int wd_ecc_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
  * wd_ecc_env_init() - Init ctx and schedule resources according to wd ecc
  * environment variables.
  *
+ * @sched:       user's custom scheduler.
  * More information, please see docs/wd_environment_variable.
  */
-int wd_ecc_env_init(void);
+int wd_ecc_env_init(struct wd_sched *sched);
 
 /**
  * wd_ecc_env_uninit() - UnInit ctx and schedule resources set by above init.

--- a/include/wd_rsa.h
+++ b/include/wd_rsa.h
@@ -59,7 +59,7 @@ enum wd_rsa_key_type {
 struct wd_rsa_sess_setup {
 	__u16 key_bits; /* RSA key bits */
 	bool is_crt; /* CRT mode or not */
-	int numa;
+	void *sched_param;
 };
 
 bool wd_rsa_is_crt(handle_t sess);
@@ -179,9 +179,10 @@ int wd_rsa_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
  * wd_rsa_env_init() - Init ctx and schedule resources according to wd rsa
  * environment variables.
  *
+ * @sched:       user's custom scheduler.
  * More information, please see docs/wd_environment_variable.
  */
-int wd_rsa_env_init(void);
+int wd_rsa_env_init(struct wd_sched *sched);
 
 /**
  * wd_rsa_env_uninit() - UnInit ctx and schedule resources set by above init.

--- a/include/wd_sched.h
+++ b/include/wd_sched.h
@@ -11,7 +11,6 @@
 #define MAX_NUMA_NUM	4
 #define INVALID_POS	0xFFFFFFFF
 
-
 /* The global policy type */
 enum sched_policy_type {
 	/* requests will be sent to ctxs one by one */
@@ -19,25 +18,29 @@ enum sched_policy_type {
 	SCHED_POLICY_BUTT
 };
 
+struct sched_params {
+	int numa_id;
+	__u8 type;
+	__u8 mode;
+	__u32 begin;
+	__u32 end;
+};
+
 typedef int (*user_poll_func)(__u32 pos, __u32 expect, __u32 *count);
 
 /*
- * sample_sched_fill_data - Fill the schedule min region.
- * @sched: The schdule instance
- * @numa_id: NUMA ID
- * @mode: Sync or async mode. sync: 0, async: 1
- * @type: Service type, the value must smaller than type_num.
- * @begin: The begig ctx resource index for the region
- * @end:  The end ctx resource index for the region.
+ * wd_sched_rr_instance - Instante the schedule min region.
+ * @sched: The schedule instance
+ * @param: input schedule parameters
  *
  * The shedule indexed mode is NUMA -> MODE -> TYPE -> [BEGIN : END],
  * then select one index from begin to end.
  */
-int sample_sched_fill_data(const struct wd_sched *sched, int numa_id,
-			   __u8 mode, __u8 type, __u32 begin, __u32 end);
+int wd_sched_rr_instance(const struct wd_sched *sched,
+				       struct sched_params *param);
 
 /**
- * sample_sched_alloc - Allocate a schedule instance.
+ * wd_sched_rr_alloc - Allocate a schedule instance.
  * @sched_type: Reference sched_policy_type.
  * @type_num: The service type num of user's service. For example, the zip
  *            include comp and decomp, type nume is two.
@@ -45,13 +48,13 @@ int sample_sched_fill_data(const struct wd_sched *sched, int numa_id,
  * @func: The ctx poll function of user underlying operating.
  *
  */
-struct wd_sched *sample_sched_alloc(__u8 sched_type, __u8 type_num, __u8 numa_num,
+struct wd_sched *wd_sched_rr_alloc(__u8 sched_type, __u8 type_num, __u8 numa_num,
 				    user_poll_func func);
 
 /**
- * sample_sched_release - Release schedule memory.
- * &sched: The schedule which will be released.
+ * wd_sched_rr_release - Release schedule memory.
+ * @sched: The schedule which will be released.
  */
-void sample_sched_release(struct wd_sched *sched);
+void wd_sched_rr_release(struct wd_sched *sched);
 
 #endif

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -70,6 +70,7 @@ struct wd_env_config {
 
 	/* resource config */
 	struct wd_sched *sched;
+	bool internal_sched;
 	struct wd_ctx_config *ctx_config;
 	const struct wd_config_variable *table;
 	__u32 table_size;

--- a/sample/uadk_sample.c
+++ b/sample/uadk_sample.c
@@ -11,7 +11,7 @@ int operation(int op_type, void *src, int src_sz, void *dst, int *dst_sz)
 
         if (!src || !dst || !dst_sz || (*dst_sz <= 0))
                 return -EINVAL;
-        ret = wd_comp_env_init();
+        ret = wd_comp_env_init(NULL);
         if (ret < 0)
                 goto out;
 
@@ -19,8 +19,7 @@ int operation(int op_type, void *src, int src_sz, void *dst, int *dst_sz)
         setup.win_sz = WD_COMP_WS_32K;
         setup.comp_lv = WD_COMP_L8;
         setup.op_type = op_type;
-        setup.numa = 0;
-        h_dfl = wd_comp_alloc_sess(&setup);
+	h_dfl = wd_comp_alloc_sess(&setup);
         if (!h_dfl) {
                 ret = -EINVAL;
                 goto out_sess;

--- a/test/hisi_hpre_test/test_hisi_hpre.c
+++ b/test/hisi_hpre_test/test_hisi_hpre.c
@@ -1769,9 +1769,13 @@ static int evp_to_wd_crypto(char *evp, size_t *evp_size, __u32 ksz, __u8 op_type
         return total_len;
 }
 
-__u32 hpre_pick_next_ctx(handle_t sched_ctx,
-				const void *req,
-				const struct sched_key *key)
+static handle_t hpre_sched_init(handle_t h_sched_ctx, void *sched_param)
+{
+	return (handle_t)0;
+}
+
+static __u32 hpre_pick_next_ctx(handle_t sched_ctx,
+	void *sched_key, const int sched_mode)
 {
 	static int last_ctx = 0;
 
@@ -1897,15 +1901,15 @@ static struct uacce_dev_list *get_uacce_dev_by_alg(struct uacce_dev_list *list,
 static int env_init(__u32 op_type)
 {
 	if (op_type > HPRE_ALG_INVLD_TYPE && op_type < MAX_RSA_ASYNC_TYPE)
-		return wd_rsa_env_init();
+		return wd_rsa_env_init(NULL);
 	else if (op_type > MAX_RSA_ASYNC_TYPE && op_type < MAX_DH_TYPE)
-		return wd_dh_env_init();
+		return wd_dh_env_init(NULL);
 	else if (op_type > MAX_DH_TYPE && op_type < MAX_ECDH_TYPE)
-		return wd_ecc_env_init();
+		return wd_ecc_env_init(NULL);
 	else if (op_type > MAX_ECDH_TYPE && op_type < MAX_ECDSA_TYPE)
-		return wd_ecc_env_init();
+		return wd_ecc_env_init(NULL);
 	else if (op_type >= SM2_SIGN && op_type <= SM2_ASYNC_KG)
-		return wd_ecc_env_init();
+		return wd_ecc_env_init(NULL);
 	else {
 		HPRE_TST_PRT("op_type = %u error\n", op_type);
 		return -ENODEV;
@@ -1971,6 +1975,7 @@ static int init_hpre_global_config(__u32 op_type)
 	g_ctx_cfg.ctxs = ctx_attr;
 	sched.name = "hpre-sched-0";
 	sched.pick_next_ctx = hpre_pick_next_ctx;
+	sched.sched_init = hpre_sched_init;
 	if (op_type > HPRE_ALG_INVLD_TYPE && op_type < MAX_RSA_ASYNC_TYPE) {
 		sched.poll_policy = rsa_poll_policy;
 		ret = wd_rsa_init(&g_ctx_cfg, &sched);

--- a/test/hisi_sec_test/test_hisi_sec.c
+++ b/test/hisi_sec_test/test_hisi_sec.c
@@ -476,17 +476,41 @@ static int sched_single_poll_policy(handle_t h_sched_ctx,
 static int init_ctx_config(int type, int mode)
 {
 	struct uacce_dev_list *list;
+	struct sched_params param;
 	int ret = 0;
 	int i;
-
-	if (g_use_env)
-		return wd_cipher_env_init();
 
 	list = wd_get_accel_list("cipher");
 	if (!list) {
 		printf("Fail to get cipher device\n");
 		return -ENODEV;
 	}
+
+	/* If there is no numa, we default config to zero */
+	if (list->dev->numa_id < 0)
+		list->dev->numa_id = 0;
+
+	g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, MAX_NUMA_NUM, wd_cipher_poll_ctx);
+	if (!g_sched) {
+		printf("Fail to alloc sched!\n");
+		goto out;
+	}
+
+	g_sched->name = SCHED_SINGLE;
+	param.numa_id = list->dev->numa_id;
+	param.mode = mode;
+	param.type = 0;
+	param.begin = 0;
+	param.end = g_ctxnum - 1;
+	ret = wd_sched_rr_instance(g_sched, &param);
+	if (ret) {
+		printf("Fail to fill sched data!\n");
+		goto out;
+	}
+
+	if (g_use_env)
+		return wd_cipher_env_init(g_sched);
+
 	memset(&g_ctx_cfg, 0, sizeof(struct wd_ctx_config));
 	g_ctx_cfg.ctx_num = g_ctxnum;
 	g_ctx_cfg.ctxs = calloc(g_ctxnum, sizeof(struct wd_ctx));
@@ -497,23 +521,6 @@ static int init_ctx_config(int type, int mode)
 		g_ctx_cfg.ctxs[i].ctx = wd_request_ctx(list->dev);
 		g_ctx_cfg.ctxs[i].op_type = type;
 		g_ctx_cfg.ctxs[i].ctx_mode = (__u8)mode;
-	}
-
-	g_sched = sample_sched_alloc(SCHED_POLICY_RR, 1, MAX_NUMA_NUM, wd_cipher_poll_ctx);
-	if (!g_sched) {
-		printf("Fail to alloc sched!\n");
-		goto out;
-	}
-
-	/* If there is no numa, we defualt config to zero */
-	if (list->dev->numa_id < 0)
-		list->dev->numa_id = 0;
-
-	g_sched->name = SCHED_SINGLE;
-	ret = sample_sched_fill_data(g_sched, list->dev->numa_id, mode, 0, 0, g_ctxnum - 1);
-	if (ret) {
-		printf("Fail to fill sched data!\n");
-		goto out;
 	}
 
 	/*cipher init*/
@@ -528,7 +535,7 @@ static int init_ctx_config(int type, int mode)
 	return 0;
 out:
 	free(g_ctx_cfg.ctxs);
-	sample_sched_release(g_sched);
+	wd_sched_rr_release(g_sched);
 
 	return ret;
 }
@@ -546,7 +553,7 @@ static void uninit_config(void)
 	for (i = 0; i < g_ctx_cfg.ctx_num; i++)
 		wd_release_ctx(g_ctx_cfg.ctxs[i].ctx);
 	free(g_ctx_cfg.ctxs);
-	sample_sched_release(g_sched);
+	wd_sched_rr_release(g_sched);
 }
 
 static void digest_uninit_config(void)
@@ -1282,8 +1289,13 @@ out_iv:
 }
 
 /* ------------------digest alg, nomal mode and hmac mode------------------ */
-static __u32 sched_digest_pick_next_ctx(handle_t h_sched_ctx, const void *req,
-					const struct sched_key *key)
+static handle_t sched_digest_init(handle_t h_sched_ctx, void *sched_param)
+{
+	return (handle_t)0;
+}
+
+static __u32 sched_digest_pick_next_ctx(handle_t h_sched_ctx,
+	void *sched_key, const int sched_mode)
 {
 	/* alway return first ctx */
 	return 0;
@@ -1296,7 +1308,7 @@ static int init_digest_ctx_config(int type, int mode)
 	int ret;
 
 	if (g_use_env)
-		return wd_digest_env_init();
+		return wd_digest_env_init(NULL);
 
 	list = wd_get_accel_list("digest");
 	if (!list)
@@ -1322,6 +1334,7 @@ static int init_digest_ctx_config(int type, int mode)
 	sched.name = SCHED_SINGLE;
 	sched.pick_next_ctx = sched_digest_pick_next_ctx;
 	sched.poll_policy = sched_single_poll_policy;
+	sched.sched_init = sched_digest_init;
 	/* digest init */
 	ret = wd_digest_init(&g_ctx_cfg, &sched);
 	if (ret) {
@@ -2043,8 +2056,13 @@ out:
 }
 
 /* ------------------------------aead alg, ccm mode and gcm mode------------------ */
-static __u32 sched_aead_pick_next_ctx(handle_t h_sched_ctx, const void *req,
-	const struct sched_key *key)
+static handle_t sched_aead_init(handle_t h_sched_ctx, void *sched_param)
+{
+	return (handle_t)0;
+}
+
+static __u32 sched_aead_pick_next_ctx(handle_t h_sched_ctx,
+	void *sched_key, const int sched_mode)
 {
 	return 0;
 }
@@ -2056,7 +2074,7 @@ static int init_aead_ctx_config(int type, int mode)
 	int ret;
 
 	if (g_use_env)
-		return wd_aead_env_init();
+		return wd_aead_env_init(NULL);
 
 	list = wd_get_accel_list("aead");
 	if (!list)
@@ -2082,6 +2100,7 @@ static int init_aead_ctx_config(int type, int mode)
 	sched.name = SCHED_SINGLE;
 	sched.pick_next_ctx = sched_aead_pick_next_ctx;
 	sched.poll_policy = sched_single_poll_policy;
+	sched.sched_init = sched_aead_init;
 	/* aead init*/
 	ret = wd_aead_init(&g_ctx_cfg, &sched);
 	if (ret) {

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -11,7 +11,6 @@
 #include <zlib.h>
 
 #include "hisi_qm_udrv.h"
-#include "wd_sched.h"
 #include "test_lib.h"
 
 #define SCHED_RR_NAME	"sched_rr"
@@ -148,6 +147,7 @@ int hw_blk_compress(int alg_type, int blksize, __u8 data_fmt, void *priv,
 {
 	handle_t h_sess;
 	struct wd_comp_sess_setup setup;
+	struct sched_params param = {0};
 	struct wd_datalist *list;
 	struct wd_comp_req req;
 	int ret = 0;
@@ -156,7 +156,9 @@ int hw_blk_compress(int alg_type, int blksize, __u8 data_fmt, void *priv,
 	setup.op_type = WD_DIR_COMPRESS;
 	setup.comp_lv = WD_COMP_L8;
 	setup.win_sz = WD_COMP_WS_8K;
-	setup.numa = 0;
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -212,13 +214,16 @@ int hw_blk_decompress(int alg_type, int blksize, __u8 data_fmt,
 {
 	handle_t h_sess;
 	struct wd_comp_sess_setup setup;
+	struct sched_params param = {0};
 	struct wd_datalist *list;
 	struct wd_comp_req req;
 	int ret = 0;
 
 	setup.alg_type = alg_type;
 	setup.op_type = WD_DIR_DECOMPRESS;
-	setup.numa = 0;
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -274,6 +279,7 @@ int hw_stream_compress(int alg_type, int blksize, __u8 data_fmt,
 {
 	handle_t h_sess;
 	struct wd_comp_sess_setup setup;
+	struct sched_params param = {0};
 	struct wd_comp_req req;
 	int ret = 0;
 
@@ -281,7 +287,9 @@ int hw_stream_compress(int alg_type, int blksize, __u8 data_fmt,
 	setup.op_type = WD_DIR_COMPRESS;
 	setup.comp_lv = WD_COMP_L8;
 	setup.win_sz = WD_COMP_WS_8K;
-	setup.numa = 0;
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -327,13 +335,16 @@ int hw_stream_decompress(int alg_type, int blksize, __u8 data_fmt,
 {
 	handle_t h_sess;
 	struct wd_comp_sess_setup setup;
+	struct sched_params param = {0};
 	struct wd_comp_req req;
 	int ret = 0;
 
 
 	setup.alg_type = alg_type;
 	setup.op_type = WD_DIR_DECOMPRESS;
-	setup.numa = 0;
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess) {
 		fprintf(stderr,"fail to alloc comp sess!\n");
@@ -493,6 +504,7 @@ void *send_thread_func(void *arg)
 	struct test_options *opts = info->opts;
 	size_t src_block_size, dst_block_size;
 	struct wd_comp_sess_setup setup;
+	struct sched_params param = {0};
 	handle_t h_sess;
 	int j, ret;
 	size_t left;
@@ -508,9 +520,11 @@ void *send_thread_func(void *arg)
 	memset(&setup, 0, sizeof(struct wd_comp_sess_setup));
 	setup.alg_type = opts->alg_type;
 	setup.op_type = opts->op_type;
-	setup.numa = 0;
 	setup.comp_lv = WD_COMP_L8;
 	setup.win_sz = WD_COMP_WS_8K;
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_sess = wd_comp_alloc_sess(&setup);
 	if (!h_sess)
 		return NULL;
@@ -1534,15 +1548,16 @@ int init_ctx_config(struct test_options *opts, void *priv,
 {
 	struct hizip_test_info *info = priv;
 	struct wd_ctx_config *ctx_conf = &info->ctx_conf;
+	struct sched_params param;
 	int i, j, ret = -EINVAL;
 	int q_num = opts->q_num;
 
 
 	__atomic_store_n(&sum_pend, 0, __ATOMIC_RELEASE);
 	__atomic_store_n(&sum_thread_end, 0, __ATOMIC_RELEASE);
-	*sched = sample_sched_alloc(SCHED_POLICY_RR, 2, 2, lib_poll_func);
+	*sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 2, 2, lib_poll_func);
 	if (!*sched) {
-		WD_ERR("sample_sched_alloc fail\n");
+		WD_ERR("wd_sched_rr_alloc fail\n");
 		goto out_sched;
 	}
 
@@ -1572,8 +1587,12 @@ int init_ctx_config(struct test_options *opts, void *priv,
 		ctx_conf->ctxs[i].ctx_mode = 0;
 		ctx_conf->ctxs[i].op_type = 0;
 	}
-	ret = sample_sched_fill_data((const struct wd_sched*)*sched, 0, 0, 0,
-				     0, q_num - 1);
+	param.numa_id = 0;
+	param.mode = 0;
+	param.type = 0;
+	param.begin = 0;
+	param.end = q_num - 1;
+	ret = wd_sched_rr_instance((const struct wd_sched *)*sched, &param);
 	if (ret < 0) {
 		WD_ERR("Fail to fill sched region.\n");
 		goto out_fill;
@@ -1582,8 +1601,11 @@ int init_ctx_config(struct test_options *opts, void *priv,
 		ctx_conf->ctxs[i].ctx_mode = 0;
 		ctx_conf->ctxs[i].op_type = 1;
 	}
-	ret = sample_sched_fill_data((const struct wd_sched*)*sched, 0, 0, 1,
-				     q_num, q_num * 2 - 1);
+	param.mode = 0;
+	param.type = 1;
+	param.begin = q_num;
+	param.end = q_num * 2 - 1;
+	ret = wd_sched_rr_instance((const struct wd_sched *)*sched, &param);
 	if (ret < 0) {
 		WD_ERR("Fail to fill sched region.\n");
 		goto out_fill;
@@ -1592,8 +1614,11 @@ int init_ctx_config(struct test_options *opts, void *priv,
 		ctx_conf->ctxs[i].ctx_mode = 1;
 		ctx_conf->ctxs[i].op_type = 0;
 	}
-	ret = sample_sched_fill_data((const struct wd_sched*)*sched, 0, 1, 0,
-				     q_num * 2, q_num * 3 - 1);
+	param.mode = 1;
+	param.type = 0;
+	param.begin = q_num * 2;
+	param.end = q_num * 3 - 1;
+	ret = wd_sched_rr_instance((const struct wd_sched *)*sched, &param);
 	if (ret < 0) {
 		WD_ERR("Fail to fill sched region.\n");
 		goto out_fill;
@@ -1602,8 +1627,11 @@ int init_ctx_config(struct test_options *opts, void *priv,
 		ctx_conf->ctxs[i].ctx_mode = 1;
 		ctx_conf->ctxs[i].op_type = 1;
 	}
-	ret = sample_sched_fill_data((const struct wd_sched*)*sched, 0, 1, 1,
-				     q_num * 3, q_num * 4 - 1);
+	param.mode = 1;
+	param.type = 1;
+	param.begin = q_num * 3;
+	param.end = q_num * 4 - 1;
+	ret = wd_sched_rr_instance((const struct wd_sched *)*sched, &param);
 	if (ret < 0) {
 		WD_ERR("Fail to fill sched region.\n");
 		goto out_fill;
@@ -1620,7 +1648,7 @@ out_fill:
 out_req:
 	free(ctx_conf->ctxs);
 out_ctx:
-	sample_sched_release(*sched);
+	wd_sched_rr_release(*sched);
 out_sched:
 	return ret;
 }
@@ -1635,7 +1663,7 @@ void uninit_config(void *priv, struct wd_sched *sched)
 	for (i = 0; i < ctx_conf->ctx_num; i++)
 		wd_release_ctx(ctx_conf->ctxs[i].ctx);
 	free(ctx_conf->ctxs);
-	sample_sched_release(sched);
+	wd_sched_rr_release(sched);
 }
 
 

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -19,6 +19,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include "wd_comp.h"
+#include "wd_sched.h"
 
 #define SYS_ERR_COND(cond, msg, ...) \
 do { \

--- a/test/hisi_zip_test/testsuit.c
+++ b/test/hisi_zip_test/testsuit.c
@@ -73,6 +73,7 @@ static void *sw_dfl_hw_ifl(void *arg)
 	struct hizip_test_info *info = tdata->info;
 	struct test_options *opts = info->opts;
 	struct wd_comp_sess_setup setup = {0};
+	struct sched_params param = {0};
 	handle_t h_ifl;
 	void *tbuf;
 	size_t tbuf_sz;
@@ -152,8 +153,10 @@ static void *sw_dfl_hw_ifl(void *arg)
 	/* BLOCK mode */
         setup.alg_type = opts->alg_type;
         setup.op_type = WD_DIR_DECOMPRESS;
-	setup.numa = 0;
 
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_ifl = wd_comp_alloc_sess(&setup);
 	if (!h_ifl) {
 		ret = -EINVAL;
@@ -216,6 +219,7 @@ static void *hw_dfl_sw_ifl(void *arg)
 	struct hizip_test_info *info = tdata->info;
 	struct test_options *opts = info->opts;
 	struct wd_comp_sess_setup setup = {0};
+	struct sched_params param = {0};
 	handle_t h_dfl;
 	void *tbuf;
 	size_t tbuf_sz;
@@ -296,8 +300,9 @@ static void *hw_dfl_sw_ifl(void *arg)
 	/* BLOCK mode */
         setup.alg_type = opts->alg_type;
         setup.op_type = WD_DIR_COMPRESS;
-	setup.numa = 0;
-
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl) {
 		ret = -EINVAL;
@@ -360,6 +365,7 @@ static void *hw_dfl_hw_ifl(void *arg)
 	struct hizip_test_info *info = tdata->info;
 	struct test_options *opts = info->opts;
 	struct wd_comp_sess_setup setup = {0};
+	struct sched_params param = {0};
 	handle_t h_dfl, h_ifl;
 	void *tbuf;
 	size_t tbuf_sz;
@@ -436,10 +442,12 @@ static void *hw_dfl_hw_ifl(void *arg)
 		ret = -ENOMEM;
 		goto out;
 	}
+
         setup.alg_type = opts->alg_type;
         setup.op_type = WD_DIR_COMPRESS;
-	setup.numa = 0;
-
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl) {
 		ret = -EINVAL;
@@ -447,6 +455,8 @@ static void *hw_dfl_hw_ifl(void *arg)
 	}
 
 	setup.op_type = WD_DIR_DECOMPRESS;
+	param.type = setup.op_type;
+	setup.sched_param = &param;
 	h_ifl = wd_comp_alloc_sess(&setup);
 	if (!h_ifl) {
 		ret = -EINVAL;
@@ -512,6 +522,7 @@ static void *hw_dfl_perf(void *arg)
 	struct hizip_test_info *info = tdata->info;
 	struct test_options *opts = info->opts;
 	struct wd_comp_sess_setup setup = {0};
+	struct sched_params param = {0};
 	handle_t h_dfl;
 	int i, ret;
 	uint32_t tout_sz;
@@ -539,8 +550,9 @@ static void *hw_dfl_perf(void *arg)
 
         setup.alg_type = opts->alg_type;
         setup.op_type = WD_DIR_COMPRESS;
-	setup.numa = 0;
-
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl)
 		return (void *)(uintptr_t)(-EINVAL);
@@ -571,6 +583,7 @@ static void *hw_ifl_perf(void *arg)
 	struct hizip_test_info *info = tdata->info;
 	struct test_options *opts = info->opts;
 	struct wd_comp_sess_setup setup = {0};
+	struct sched_params param = {0};
 	handle_t h_ifl;
 	int i, ret;
 	uint32_t tout_sz;
@@ -598,8 +611,9 @@ static void *hw_ifl_perf(void *arg)
 
         setup.alg_type = opts->alg_type;
         setup.op_type = WD_DIR_DECOMPRESS;
-	setup.numa = 0;
-
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_ifl = wd_comp_alloc_sess(&setup);
 	if (!h_ifl)
 		return (void *)(uintptr_t)(-EINVAL);
@@ -631,6 +645,7 @@ void *hw_dfl_perf3(void *arg)
 	struct hizip_test_info *info = tdata->info;
 	struct test_options *opts = info->opts;
 	struct wd_comp_sess_setup setup = {0};
+	struct sched_params param = {0};
 	handle_t h_dfl;
 	int i, ret;
 	uint32_t tout_sz;
@@ -658,8 +673,9 @@ void *hw_dfl_perf3(void *arg)
 
         setup.alg_type = opts->alg_type;
         setup.op_type = WD_DIR_COMPRESS;
-	setup.numa = 0;
-
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_dfl = wd_comp_alloc_sess(&setup);
 	if (!h_dfl)
 		return (void *)(uintptr_t)(-EINVAL);
@@ -691,6 +707,7 @@ void *hw_ifl_perf3(void *arg)
 	struct hizip_test_info *info = tdata->info;
 	struct test_options *opts = info->opts;
 	struct wd_comp_sess_setup setup = {0};
+	struct sched_params param = {0};
 	handle_t h_ifl;
 	int i, ret;
 	uint32_t tout_sz;
@@ -718,8 +735,9 @@ void *hw_ifl_perf3(void *arg)
 
         setup.alg_type = opts->alg_type;
         setup.op_type = WD_DIR_DECOMPRESS;
-	setup.numa = 0;
-
+	param.type = setup.op_type;
+	param.numa_id = 0;
+	setup.sched_param = &param;
 	h_ifl = wd_comp_alloc_sess(&setup);
 	if (!h_ifl)
 		return (void *)(uintptr_t)(-EINVAL);
@@ -991,7 +1009,7 @@ int test_hw(struct test_options *opts, char *model)
 	}
 
 	if (opts->use_env)
-		ret = wd_comp_env_init();
+		ret = wd_comp_env_init(NULL);
 	else
 		ret = nonenv_resource_init(opts, &info, &sched);
 	if (ret < 0)

--- a/test/wd_mempool_test.c
+++ b/test/wd_mempool_test.c
@@ -417,8 +417,13 @@ static int test_mempool(struct test_option *opt)
 	return 0;
 }
 
-static __u32 sva_sched_pick_next_ctx(handle_t h_sched_ctx, const void *req,
-                                        const struct sched_key *key)
+static handle_t sva_sched_init(handle_t h_sched_ctx, void *sched_param)
+{
+	return (handle_t)0;
+}
+
+static __u32 sva_sched_pick_next_ctx(handle_t h_sched_ctx,
+	void *sched_key, const int sched_mode)
 {
         __u32 index;
 
@@ -500,6 +505,7 @@ static int sva_init_ctx_config(int type, int mode)
 	sched.name = "sched_multi";
 	sched.pick_next_ctx = sva_sched_pick_next_ctx;
 	sched.poll_policy = sva_sched_poll_policy;
+	sched.sched_init = sva_sched_init;
 	/*cipher init*/
 	ret = wd_cipher_init(&g_ctx_cfg, &sched);
 	if (ret) {


### PR DESCRIPTION
Since the current default scheduling method will have a serious
performance bottleneck under multi-threading, it is necessary
to update the scheduling implementation method.

1.Update the interface of the RR scheduler
2.Update the usage of scheduler in ALG API
3.Update the uadk test tools

Signed-off-by: Liulongfang <longfang.liu@foxmail.com>