### PR TITLE
cipher: repair ALG interface mode check

### DIFF
--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -463,6 +463,7 @@ int wd_do_cipher_sync(handle_t h_sess, struct wd_cipher_req *req)
 	idx = wd_cipher_setting.sched.pick_next_ctx(
 		     wd_cipher_setting.sched.h_sched_ctx,
 		     sess->sched_key, CTX_MODE_SYNC);
+	ret = wd_check_ctx(config, CTX_MODE_SYNC, idx);
 	if (unlikely(ret))
 		return ret;
 


### PR DESCRIPTION
Due to the modification of the decoupling of the scheduler
and the ALG API, the interface mode check function was mistakenly
deleted.

Signed-off-by: Liulongfang <liulongfang@foxmail.com>