### PR TITLE
uadk/tools: modify NO-SVA test scenario

### DIFF
--- a/uadk_tool/Makefile.am
+++ b/uadk_tool/Makefile.am
@@ -16,7 +16,7 @@ uadk_tool_LDADD=$(libwd_la_OBJECTS) \
 			../.libs/libhisi_sec.a \
 			../.libs/libhisi_hpre.a \
 			../.libs/libhisi_zip.a \
-			include/libcrypto.a -ldl -lnuma
+			$(top_srcdir)/uadk_tool/include/libcrypto.a -ldl -lnuma
 else
 uadk_tool_LDADD=-L../.libs -l:libwd.so.2 -l:libwd_crypto.so.2 \
 			-L$(top_srcdir)/uadk_tool/include -l:libcrypto.so.1.1 -lnuma

--- a/uadk_tool/uadk_benchmark.c
+++ b/uadk_tool/uadk_benchmark.c
@@ -551,7 +551,7 @@ static void print_help(void)
 	ACC_TST_PRT("    [--seconds]:\n");
 	ACC_TST_PRT("        set the test times\n");
 	ACC_TST_PRT("    [--multi]:\n");
-	ACC_TST_PRT("        set the number of threads\n");
+	ACC_TST_PRT("        set the number of process\n");
 	ACC_TST_PRT("    [--thread]:\n");
 	ACC_TST_PRT("        set the number of threads\n");
 	ACC_TST_PRT("    [--ctxnum]:\n");


### PR DESCRIPTION
In the No-SVA scenario, the user's business data needs to be copied
from the user memory to the block memory allocated by the user mode
through the copy method.
After the business execution is completed, it needs to be copied back.
The test tool should truly reflect the copy operation process.

Signed-off-by: Liulongfang <liulongfang@foxmail.com>