### PR TITLE
uadk_tool: fix build warning of sec_wd_benchmark

### DIFF
--- a/uadk_tool/sec_wd_benchmark.c
+++ b/uadk_tool/sec_wd_benchmark.c
@@ -610,7 +610,7 @@ static void *sec_wd_async_run(void *arg)
 	if (!src_data_buf)
 		return NULL;
 
-	get_rand_data(src_data_buf, g_pktlen);
+	get_rand_data((u8 *)src_data_buf, g_pktlen);
 	out_data_buf = malloc(g_pktlen * sizeof(char));
 	if (!out_data_buf) {
 		free(src_data_buf);
@@ -910,7 +910,7 @@ static void *sec_wd_sync_run(void *arg)
 	if (!src_data_buf)
 		return NULL;
 
-	get_rand_data(src_data_buf, g_pktlen);
+	get_rand_data((u8 *)src_data_buf, g_pktlen);
 	out_data_buf = malloc(g_pktlen * sizeof(char));
 	if (!out_data_buf) {
 		free(src_data_buf);


### PR DESCRIPTION
Fix build warning:
In file included from sec_wd_benchmark.c:3:
uadk_benchmark.h:168:31: note: expected ‘u8 *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
  168 | extern void get_rand_data(u8 *addr, int size);
        |                           ~~~~^~~~

sec_wd_benchmark.c: In function ‘sec_wd_async_run’:
sec_wd_benchmark.c:613:16: warning: pointer targets in passing argument 1 of ‘get_rand_data’ differ in signedness [-Wpointer-sign]
  613 |  get_rand_data(src_data_buf, g_pktlen);
        |                ^~~~~~~~~~~~
	      |                |
	            |                char *

sec_wd_benchmark.c: In function ‘sec_wd_sync_run’:
sec_wd_benchmark.c:913:16: warning: pointer targets in passing argument 1 of ‘get_rand_data’ differ in signedness [-Wpointer-sign]
  913 |  get_rand_data(src_data_buf, g_pktlen);
        |                ^~~~~~~~~~~~
	      |                |
	            |                char *

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>