### PR TITLE
uadk: v1: fix for cookie initialization

### DIFF
--- a/v1/wd_util.c
+++ b/v1/wd_util.c
@@ -85,12 +85,13 @@ void wd_free_id(__u8 *buf, __u32 size, __u32 id, __u32 id_max)
 int wd_init_cookie_pool(struct wd_cookie_pool *pool,
 			__u32 cookies_size, __u32 cookies_num)
 {
-	pool->cookies = calloc(1, cookies_size * cookies_num + cookies_num);
+	__u64 total_size = cookies_size * cookies_num;
+
+	pool->cookies = malloc(total_size + cookies_num);
 	if (!pool->cookies)
 		return -WD_ENOMEM;
 
-	pool->cstatus = (void *)((uintptr_t)pool->cookies +
-			cookies_num * cookies_size);
+	pool->cstatus = (void *)((uintptr_t)pool->cookies + total_size);
 	pool->cookies_num = cookies_num;
 	pool->cookies_size = cookies_size;
 	pool->cid = 0;

--- a/v1/wd_util.h
+++ b/v1/wd_util.h
@@ -36,7 +36,7 @@
 #include "v1/wd_ecc.h"
 #include "v1/wd_adapter.h"
 
-#define WD_CTX_MSG_NUM		1024
+#define WD_CTX_MSG_NUM		64
 #define WD_HPRE_CTX_MSG_NUM	64
 #define WD_RNG_CTX_MSG_NUM	256
 #define WD_MAX_CTX_NUM			256


### PR DESCRIPTION
If ctx message number is too big, it takes a lot of time
to initialize each cookies and drag performance, so this
patch reduce it from 1024 to 64.
We also found calloc in wd_init_cookie_pool use to much cpu
when it does memset zero, which is not unnecessary, so
replace it with malloc is better.

Signed-off-by: Wenkai Lin <linwenkai6@hisilicon.com>