### PR TITLE
uadk: v1: fix pool cstatus memset problem

### DIFF
--- a/v1/wd_util.c
+++ b/v1/wd_util.c
@@ -92,6 +92,8 @@ int wd_init_cookie_pool(struct wd_cookie_pool *pool,
 		return -WD_ENOMEM;
 
 	pool->cstatus = (void *)((uintptr_t)pool->cookies + total_size);
+	memset(pool->cstatus, 0, cookies_num);
+
 	pool->cookies_num = cookies_num;
 	pool->cookies_size = cookies_size;
 	pool->cid = 0;


### PR DESCRIPTION
wd_alloc_id use __atomic_test_and_set to find
an available cookie with zero status,
it may not find a zero cookie with dirty memory,
so cookie status region should be set to zero.

Signed-off-by: Wenkai Lin <linwenkai6@hisilicon.com>