### PR TITLE
uadk: bugfix segment fault when uninitializing

### DIFF
--- a/wd_aead.c
+++ b/wd_aead.c
@@ -458,6 +458,7 @@ int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 
 out_init:
 	free(priv);
+	wd_aead_setting.priv = NULL;
 out_priv:
 	wd_uninit_async_request_pool(&wd_aead_setting.pool);
 out_sched:

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -299,6 +299,7 @@ int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 
 out_init:
 	free(priv);
+	wd_cipher_setting.priv = NULL;
 out_priv:
 	wd_uninit_async_request_pool(&wd_cipher_setting.pool);
 out_sched:

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -145,6 +145,7 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 
 out_init:
 	free(priv);
+	wd_comp_setting.priv = NULL;
 out_priv:
 	wd_uninit_async_request_pool(&wd_comp_setting.pool);
 out_sched:

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -145,6 +145,7 @@ int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 
 out_init:
 	free(priv);
+	wd_dh_setting.priv = NULL;
 out_priv:
 	wd_uninit_async_request_pool(&wd_dh_setting.pool);
 out_sched:

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -220,6 +220,7 @@ int wd_digest_init(struct wd_ctx_config *config, struct wd_sched *sched)
 
 out_init:
 	free(priv);
+	wd_digest_setting.priv = NULL;
 out_priv:
 	wd_uninit_async_request_pool(&wd_digest_setting.pool);
 out_sched:

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -199,6 +199,7 @@ int wd_ecc_init(struct wd_ctx_config *config, struct wd_sched *sched)
 
 out_init:
 	free(priv);
+	wd_ecc_setting.priv = NULL;
 out_priv:
 	wd_uninit_async_request_pool(&wd_ecc_setting.pool);
 out_sched:

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -185,6 +185,7 @@ int wd_rsa_init(struct wd_ctx_config *config, struct wd_sched *sched)
 
 out_init:
 	free(priv);
+	wd_rsa_setting.priv = NULL;
 out_priv:
 	wd_uninit_async_request_pool(&wd_rsa_setting.pool);
 out_sched:


### PR DESCRIPTION
When the initialization of each alg driver failed,
the wd_<alg>_setting.priv should be set to NULL.
Otherwise there will be segment fault when
uninitializing the alg driver.

Signed-off-by: Zhiqi Song <songzhiqi1@huawei.com>