### PR TITLE
hisi_hpre: modify the return value of function

### DIFF
--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -221,8 +221,7 @@ static int fill_rsa_crt_prikey2(struct wd_rsa_prikey *prikey,
 
 	*data = wd_dq->data;
 
-	return (int)(wd_dq->bsize + wd_qinv->bsize + wd_p->bsize +
-			wd_q->bsize + wd_dp->bsize);
+	return WD_SUCCESS;
 }
 
 static int fill_rsa_prikey1(struct wd_rsa_prikey *prikey, void **data)
@@ -243,7 +242,7 @@ static int fill_rsa_prikey1(struct wd_rsa_prikey *prikey, void **data)
 
 	*data = wd_d->data;
 
-	return (int)(wd_n->bsize + wd_d->bsize);
+	return WD_SUCCESS;
 }
 
 static int fill_rsa_pubkey(struct wd_rsa_pubkey *pubkey, void **data)
@@ -263,7 +262,8 @@ static int fill_rsa_pubkey(struct wd_rsa_pubkey *pubkey, void **data)
 		return ret;
 
 	*data = wd_e->data;
-	return (int)(wd_n->bsize + wd_e->bsize);
+
+	return WD_SUCCESS;
 }
 
 static int fill_rsa_genkey_in(struct wd_rsa_kg_in *genkey)
@@ -382,17 +382,17 @@ static int rsa_prepare_key(struct wd_rsa_msg *msg,
 	if (req->op_type == WD_RSA_SIGN) {
 		if (hw_msg->alg == HPRE_ALG_NC_CRT) {
 			ret = fill_rsa_crt_prikey2((void *)msg->key, &data);
-			if (ret <= 0)
+			if (ret)
 				return ret;
 		} else {
 			ret = fill_rsa_prikey1((void *)msg->key, &data);
-			if (ret < 0)
+			if (ret)
 				return ret;
 			hw_msg->alg = HPRE_ALG_NC_NCRT;
 		}
 	} else if (req->op_type == WD_RSA_VERIFY) {
 		ret = fill_rsa_pubkey((void *)msg->key, &data);
-		if (ret < 0)
+		if (ret)
 			return ret;
 		hw_msg->alg = HPRE_ALG_NC_NCRT;
 	} else if (req->op_type == WD_RSA_GENKEY) {


### PR DESCRIPTION
When these functions are executed successfully,
the caller of these functions will not care about
the value of the data size, so there is no need
to return the data size, just returning a "WD_SUCCESS"
will be fine.

Signed-off-by: Weili Qian <qianweili@huawei.com>