### PR TITLE
add BD id check for sync mode

### DIFF
--- a/README
+++ b/README
@@ -31,6 +31,24 @@ include/*
 docs/*
 	Documentations.
 
+Build UADK in native environment
+
+    $ ./cleanup.sh
+
+    Make sure that all generated files could be removed.
+
+    $ ./autogen.sh
+    $ ./conf.sh
+
+    UADK could be configured as either static or dynamic library by conf.sh.
+    By default, it's configured as dynamic library.
+
+    $ make
+    $ sudo make install
+
+    Both dynamic and static libraries would be installed in /usr/local/lib
+    directory. And all head files would be installed in /usr/local/include/uadk
+    directory.
 
 ======================================
 

--- a/include/drv/wd_dh_drv.h
+++ b/include/drv/wd_dh_drv.h
@@ -13,7 +13,7 @@ extern "C" {
 /* DH message format */
 struct wd_dh_msg {
 	struct wd_dh_req req;
-	__u64 tag; /* User-defined request identifier */
+	__u32 tag; /* User-defined request identifier */
 	void *g;
 	__u16 gbytes;
 	__u16 key_bytes; /* Input key bytes */

--- a/include/drv/wd_ecc_drv.h
+++ b/include/drv/wd_ecc_drv.h
@@ -48,7 +48,7 @@ extern "C" {
 struct wd_ecc_msg {
 	struct wd_ecc_req req;
 	struct wd_hash_mt hash;
-	__u64 tag; /* User-defined request identifier */
+	__u32 tag; /* User-defined request identifier */
 	__u8 *key; /* Input key VA, should be DMA buffer */
 	__u16 key_bytes; /* key bytes */
 	__u8 curve_id; /* Ec curve denoted by enum wd_ecc_curve_type */

--- a/include/drv/wd_rsa_drv.h
+++ b/include/drv/wd_rsa_drv.h
@@ -39,7 +39,7 @@ struct wd_rsa_kg_out {
 /* RSA message format */
 struct wd_rsa_msg {
 	struct wd_rsa_req req;
-	__u64 tag; /* User-defined request identifier */
+	__u32 tag; /* User-defined request identifier */
 	__u16 key_bytes; /* Input key bytes */
 	__u8 key_type; /* Denoted by enum wd_rsa_key_type */
 	__u8 result; /* Data format, denoted by WD error code */

--- a/include/hisi_qm_udrv.h
+++ b/include/hisi_qm_udrv.h
@@ -117,6 +117,21 @@ handle_t hisi_qm_alloc_qp(struct hisi_qm_priv *config, handle_t ctx);
 void hisi_qm_free_qp(handle_t h_qp);
 
 /**
+ * hisi_check_bd_id - Check the SQE BD's id and send msg id.
+ * @h_qp: Handle of the qp.
+ * @mid: send message id.
+ * @bid: recv BD id.
+ */
+int hisi_check_bd_id(handle_t h_qp, __u32 mid, __u32 bid);
+
+/**
+ * hisi_set_msg_id - set the message tag id.
+ * @h_qp: Handle of the qp.
+ * @tag: the message tag id.
+ */
+void hisi_set_msg_id(handle_t h_qp, __u32 *tag);
+
+/**
  * hisi_qm_create_sglpool - Create sgl pool in qm.
  * @sgl_num: the sgl number.
  * @sge_num: the sge num in every sgl num.


### PR DESCRIPTION
1. modify README
2. In synchronous mode, when multiple threads in a single queue send and
receive messages, if one thread exits the message overtime, other threads
may receive the overtime message, resulting in message misalignment.

Therefore, we need to add the message sequence number check. if it is
not our own sequence number, it means that the message is received
incorrectly and needs to exit.