### PR TITLE
uadk: some misc fixes

### DIFF
--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -865,9 +865,10 @@ static int fill_zip_comp_sqe(struct hisi_qp *qp, struct wd_comp_msg *msg,
 	return 0;
 }
 
-static int hisi_zip_comp_send(handle_t ctx, struct wd_comp_msg *msg)
+static int hisi_zip_comp_send(handle_t ctx, void *comp_msg)
 {
 	struct hisi_qp *qp = wd_ctx_get_priv(ctx);
+	struct wd_comp_msg *msg = comp_msg;
 	handle_t h_qp = (handle_t)qp;
 	struct hisi_zip_sqe sqe = {0};
 	__u16 count = 0;
@@ -1020,9 +1021,10 @@ static int parse_zip_sqe(struct hisi_qp *qp, struct hisi_zip_sqe *sqe,
 	return 0;
 }
 
-static int hisi_zip_comp_recv(handle_t ctx, struct wd_comp_msg *recv_msg)
+static int hisi_zip_comp_recv(handle_t ctx, void *comp_msg)
 {
 	struct hisi_qp *qp = wd_ctx_get_priv(ctx);
+	struct wd_comp_msg *recv_msg = comp_msg;
 	handle_t h_qp = (handle_t)qp;
 	struct hisi_zip_sqe sqe = {0};
 	__u16 count = 0;

--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -865,7 +865,7 @@ static int fill_zip_comp_sqe(struct hisi_qp *qp, struct wd_comp_msg *msg,
 	return 0;
 }
 
-static int hisi_zip_comp_send(handle_t ctx, struct wd_comp_msg *msg, void *priv)
+static int hisi_zip_comp_send(handle_t ctx, struct wd_comp_msg *msg)
 {
 	struct hisi_qp *qp = wd_ctx_get_priv(ctx);
 	handle_t h_qp = (handle_t)qp;
@@ -1020,8 +1020,7 @@ static int parse_zip_sqe(struct hisi_qp *qp, struct hisi_zip_sqe *sqe,
 	return 0;
 }
 
-static int hisi_zip_comp_recv(handle_t ctx, struct wd_comp_msg *recv_msg,
-			      void *priv)
+static int hisi_zip_comp_recv(handle_t ctx, struct wd_comp_msg *recv_msg)
 {
 	struct hisi_qp *qp = wd_ctx_get_priv(ctx);
 	handle_t h_qp = (handle_t)qp;

--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -499,9 +499,10 @@ static void hpre_exit(void *priv)
 	}
 }
 
-static int rsa_send(handle_t ctx, struct wd_rsa_msg *msg)
+static int rsa_send(handle_t ctx, void *rsa_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_rsa_msg *msg = rsa_msg;
 	struct hisi_hpre_sqe hw_msg;
 	__u16 send_cnt = 0;
 	int ret;
@@ -535,10 +536,11 @@ static int rsa_send(handle_t ctx, struct wd_rsa_msg *msg)
 	return hisi_qm_send(h_qp, &hw_msg, 1, &send_cnt);
 }
 
-static int rsa_recv(handle_t ctx, struct wd_rsa_msg *msg)
+static int rsa_recv(handle_t ctx, void *rsa_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct hisi_hpre_sqe hw_msg = {0};
+	struct wd_rsa_msg *msg = rsa_msg;
 	__u16 recv_cnt = 0;
 	int ret;
 
@@ -638,9 +640,10 @@ static int dh_out_transfer(struct wd_dh_msg *msg,
 	return WD_SUCCESS;
 }
 
-static int dh_send(handle_t ctx, struct wd_dh_msg *msg)
+static int dh_send(handle_t ctx, void *dh_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_dh_msg *msg = dh_msg;
 	struct wd_dh_req *req = &msg->req;
 	struct hisi_hpre_sqe hw_msg;
 	__u16 send_cnt = 0;
@@ -682,9 +685,10 @@ static int dh_send(handle_t ctx, struct wd_dh_msg *msg)
 	return hisi_qm_send(h_qp, &hw_msg, 1, &send_cnt);
 }
 
-static int dh_recv(handle_t ctx, struct wd_dh_msg *msg)
+static int dh_recv(handle_t ctx, void *dh_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_dh_msg *msg = dh_msg;
 	struct hisi_hpre_sqe hw_msg = {0};
 	__u16 recv_cnt = 0;
 	int ret;
@@ -1774,9 +1778,10 @@ free_dst:
 	return ret;
 }
 
-static int ecc_send(handle_t ctx, struct wd_ecc_msg *msg)
+static int ecc_send(handle_t ctx, void *ecc_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_ecc_msg *msg = ecc_msg;
 
 	hisi_set_msg_id(h_qp, &msg->tag);
 	if (msg->req.op_type == WD_SM2_ENCRYPT)
@@ -2336,9 +2341,10 @@ fail:
 	return ret;
 }
 
-static int ecc_recv(handle_t ctx, struct wd_ecc_msg *msg)
+static int ecc_recv(handle_t ctx, void *ecc_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_ecc_msg *msg = ecc_msg;
 	struct hisi_hpre_sqe hw_msg;
 	__u16 recv_cnt = 0;
 	int ret;

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -906,9 +906,10 @@ static int fill_cipher_bd2(struct wd_cipher_msg *msg, struct hisi_sec_sqe *sqe)
 	return 0;
 }
 
-int hisi_sec_cipher_send(handle_t ctx, struct wd_cipher_msg *msg)
+int hisi_sec_cipher_send(handle_t ctx, void *cipher_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_cipher_msg *msg = cipher_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -950,10 +951,11 @@ int hisi_sec_cipher_send(handle_t ctx, struct wd_cipher_msg *msg)
 	return 0;
 }
 
-int hisi_sec_cipher_recv(handle_t ctx, struct wd_cipher_msg *recv_msg)
+int hisi_sec_cipher_recv(handle_t ctx, void *cipher_msg)
 {
-	struct hisi_sec_sqe sqe;
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_cipher_msg *recv_msg = cipher_msg;
+	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
 
@@ -1112,9 +1114,10 @@ static int fill_cipher_bd3(struct wd_cipher_msg *msg, struct hisi_sec_sqe3 *sqe)
 	return 0;
 }
 
-int hisi_sec_cipher_send_v3(handle_t ctx, struct wd_cipher_msg *msg)
+int hisi_sec_cipher_send_v3(handle_t ctx, void *cipher_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_cipher_msg *msg = cipher_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -1183,10 +1186,11 @@ static void parse_cipher_bd3(struct hisi_sec_sqe3 *sqe,
 	recv_msg->out = rmsg->out;
 }
 
-int hisi_sec_cipher_recv_v3(handle_t ctx, struct wd_cipher_msg *recv_msg)
+int hisi_sec_cipher_recv_v3(handle_t ctx, void *cipher_msg)
 {
-	struct hisi_sec_sqe3 sqe;
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_cipher_msg *recv_msg = cipher_msg;
+	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
 
@@ -1332,9 +1336,10 @@ static int digest_len_check(struct wd_digest_msg *msg,  enum sec_bd_type type)
 	return 0;
 }
 
-int hisi_sec_digest_send(handle_t ctx, struct wd_digest_msg *msg)
+int hisi_sec_digest_send(handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_digest_msg *msg = digest_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	__u8 scene;
@@ -1396,9 +1401,10 @@ put_sgl:
 	return ret;
 }
 
-int hisi_sec_digest_recv(handle_t ctx, struct wd_digest_msg *recv_msg)
+int hisi_sec_digest_recv(handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_digest_msg *recv_msg = digest_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -1486,9 +1492,10 @@ static void qm_fill_digest_long_bd3(struct wd_digest_msg *msg,
 	}
 }
 
-int hisi_sec_digest_send_v3(handle_t ctx, struct wd_digest_msg *msg)
+int hisi_sec_digest_send_v3(handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_digest_msg *msg = digest_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	__u16 scene;
@@ -1572,9 +1579,10 @@ static void parse_digest_bd3(struct hisi_sec_sqe3 *sqe,
 	recv_msg->alg_type = WD_DIGEST;
 }
 
-int hisi_sec_digest_recv_v3(handle_t ctx, struct wd_digest_msg *recv_msg)
+int hisi_sec_digest_recv_v3(handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_digest_msg *recv_msg = digest_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -1838,9 +1846,10 @@ static int fill_aead_bd2(struct wd_aead_msg *msg, struct hisi_sec_sqe *sqe)
 	return 0;
 }
 
-int hisi_sec_aead_send(handle_t ctx, struct wd_aead_msg *msg)
+int hisi_sec_aead_send(handle_t ctx, void *aead_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_aead_msg *msg = aead_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -1922,10 +1931,11 @@ static void parse_aead_bd2(struct hisi_sec_sqe *sqe,
 			      sqe->type2.cipher_src_offset;
 }
 
-int hisi_sec_aead_recv(handle_t ctx, struct wd_aead_msg *recv_msg)
+int hisi_sec_aead_recv(handle_t ctx, void *aead_msg)
 {
-	struct hisi_sec_sqe sqe;
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_aead_msg *recv_msg = aead_msg;
+	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
 
@@ -2103,9 +2113,10 @@ static int fill_aead_bd3(struct wd_aead_msg *msg, struct hisi_sec_sqe3 *sqe)
 	return 0;
 }
 
-int hisi_sec_aead_send_v3(handle_t ctx, struct wd_aead_msg *msg)
+int hisi_sec_aead_send_v3(handle_t ctx, void *aead_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_aead_msg *msg = aead_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -2181,10 +2192,11 @@ static void parse_aead_bd3(struct hisi_sec_sqe3 *sqe,
 			      sqe->cipher_src_offset;
 }
 
-int hisi_sec_aead_recv_v3(handle_t ctx, struct wd_aead_msg *recv_msg)
+int hisi_sec_aead_recv_v3(handle_t ctx, void *aead_msg)
 {
-	struct hisi_sec_sqe3 sqe;
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct wd_aead_msg *recv_msg = aead_msg;
+	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
 

--- a/include/drv/wd_aead_drv.h
+++ b/include/drv/wd_aead_drv.h
@@ -70,8 +70,8 @@ struct wd_aead_driver {
 	__u32	drv_ctx_size;
 	int	(*init)(struct wd_ctx_config_internal *config, void *priv);
 	void	(*exit)(void *priv);
-	int	(*aead_send)(handle_t ctx, struct wd_aead_msg *msg);
-	int	(*aead_recv)(handle_t ctx, struct wd_aead_msg *msg);
+	int	(*aead_send)(handle_t ctx, void *aead_msg);
+	int	(*aead_recv)(handle_t ctx, void *aead_msg);
 };
 
 void wd_aead_set_driver(struct wd_aead_driver *drv);

--- a/include/drv/wd_cipher_drv.h
+++ b/include/drv/wd_cipher_drv.h
@@ -56,8 +56,8 @@ struct wd_cipher_driver {
 	__u32	drv_ctx_size;
 	int	(*init)(struct wd_ctx_config_internal *config, void *priv);
 	void	(*exit)(void *priv);
-	int	(*cipher_send)(handle_t ctx, struct wd_cipher_msg *msg);
-	int	(*cipher_recv)(handle_t ctx, struct wd_cipher_msg *msg);
+	int	(*cipher_send)(handle_t ctx, void *cipher_msg);
+	int	(*cipher_recv)(handle_t ctx, void *cipher_msg);
 };
 
 void wd_cipher_set_driver(struct wd_cipher_driver *drv);

--- a/include/drv/wd_comp_drv.h
+++ b/include/drv/wd_comp_drv.h
@@ -61,8 +61,8 @@ struct wd_comp_driver {
 	__u32 drv_ctx_size;
 	int (*init)(struct wd_ctx_config_internal *config, void *priv);
 	void (*exit)(void *priv);
-	int (*comp_send)(handle_t ctx, struct wd_comp_msg *msg);
-	int (*comp_recv)(handle_t ctx, struct wd_comp_msg *msg);
+	int (*comp_send)(handle_t ctx, void *comp_msg);
+	int (*comp_recv)(handle_t ctx, void *comp_msg);
 };
 
 void wd_comp_set_driver(struct wd_comp_driver *drv);

--- a/include/drv/wd_comp_drv.h
+++ b/include/drv/wd_comp_drv.h
@@ -61,8 +61,8 @@ struct wd_comp_driver {
 	__u32 drv_ctx_size;
 	int (*init)(struct wd_ctx_config_internal *config, void *priv);
 	void (*exit)(void *priv);
-	int (*comp_send)(handle_t ctx, struct wd_comp_msg *msg, void *priv);
-	int (*comp_recv)(handle_t ctx, struct wd_comp_msg *msg, void *priv);
+	int (*comp_send)(handle_t ctx, struct wd_comp_msg *msg);
+	int (*comp_recv)(handle_t ctx, struct wd_comp_msg *msg);
 };
 
 void wd_comp_set_driver(struct wd_comp_driver *drv);

--- a/include/drv/wd_dh_drv.h
+++ b/include/drv/wd_dh_drv.h
@@ -30,8 +30,8 @@ struct wd_dh_driver {
 	int (*init)(struct wd_ctx_config_internal *config, void *priv,
 		    const char *alg_name);
 	void (*exit)(void *priv);
-	int (*send)(handle_t sess, struct wd_dh_msg *msg);
-	int (*recv)(handle_t sess, struct wd_dh_msg *msg);
+	int (*send)(handle_t sess, void *dh_msg);
+	int (*recv)(handle_t sess, void *dh_msg);
 };
 
 void wd_dh_set_driver(struct wd_dh_driver *drv);

--- a/include/drv/wd_digest_drv.h
+++ b/include/drv/wd_digest_drv.h
@@ -58,8 +58,8 @@ struct wd_digest_driver {
 	__u32	drv_ctx_size;
 	int	(*init)(struct wd_ctx_config_internal *config, void *priv);
 	void	(*exit)(void *priv);
-	int	(*digest_send)(handle_t ctx, struct wd_digest_msg *msg);
-	int	(*digest_recv)(handle_t ctx, struct wd_digest_msg *msg);
+	int	(*digest_send)(handle_t ctx, void *digest_msg);
+	int	(*digest_recv)(handle_t ctx, void *digest_msg);
 };
 
 void wd_digest_set_driver(struct wd_digest_driver *drv);

--- a/include/drv/wd_ecc_drv.h
+++ b/include/drv/wd_ecc_drv.h
@@ -184,8 +184,8 @@ struct wd_ecc_driver {
 	int (*init)(struct wd_ctx_config_internal *config, void *priv,
 		    const char *alg_name);
 	void (*exit)(void *priv);
-	int (*send)(handle_t sess, struct wd_ecc_msg *msg);
-	int (*recv)(handle_t sess, struct wd_ecc_msg *msg);
+	int (*send)(handle_t sess, void *ecc_msg);
+	int (*recv)(handle_t sess, void *ecc_msg);
 };
 
 void wd_ecc_set_driver(struct wd_ecc_driver *drv);

--- a/include/drv/wd_rsa_drv.h
+++ b/include/drv/wd_rsa_drv.h
@@ -53,8 +53,8 @@ struct wd_rsa_driver {
 	int (*init)(struct wd_ctx_config_internal *config, void *priv,
 		    const char *alg_name);
 	void (*exit)(void *priv);
-	int (*send)(handle_t sess, struct wd_rsa_msg *msg);
-	int (*recv)(handle_t sess, struct wd_rsa_msg *msg);
+	int (*send)(handle_t sess, void *rsa_msg);
+	int (*recv)(handle_t sess, void *rsa_msg);
 };
 
 void wd_rsa_set_driver(struct wd_rsa_driver *drv);

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -99,6 +99,11 @@ struct wd_ctx_attr {
 	__u8 mode;
 };
 
+struct wd_msg_handle {
+	int (*send)(handle_t sess, void *msg);
+	int (*recv)(handle_t sess, void *msg);
+};
+
 /*
  * wd_init_ctx_config() - Init internal ctx configuration.
  * @in:	ctx configuration in global setting.
@@ -326,6 +331,19 @@ int wd_check_ctx(struct wd_ctx_config_internal *config, __u8 mode, __u32 idx);
  * Return 0 if the value is 0 or 1, otherwise return -WD_EINVAL.
  */
 int wd_set_epoll_en(const char *var_name, bool *epoll_en);
+
+/**
+ * wd_handle_msg_sync() - recv msg from hardware
+ * @msg_handle: callback of msg handle ops.
+ * @ctx: the handle of context.
+ * @msg: the msg of task.
+ * @balance: estimated number of receiving msg.
+ * @epoll_en: whether to enable epoll.
+ *
+ * Return 0 if successful or less than 0 otherwise.
+ */
+int wd_handle_msg_sync(struct wd_msg_handle *msg_handle, handle_t ctx,
+		void *msg, __u64 *balance, bool epoll_en);
 
 /**
  * wd_init_check() - Check input parameters for wd_<alg>_init.

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -327,6 +327,15 @@ int wd_check_ctx(struct wd_ctx_config_internal *config, __u8 mode, __u32 idx);
  */
 int wd_set_epoll_en(const char *var_name, bool *epoll_en);
 
+/**
+ * wd_init_check() - Check input parameters for wd_<alg>_init.
+ * @config: Ctx configuration input by user.
+ * @sched: Scheduler configuration input by user.
+ *
+ * Return 0 if successful or less than 0 otherwise.
+ */
+int wd_init_param_check(struct wd_ctx_config *config, struct wd_sched *sched);
+
 #ifdef __cplusplus
 }
 #endif

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -388,27 +388,12 @@ static int aead_param_check(struct wd_aead_sess *sess,
 	return 0;
 }
 
-static int aead_init_check(struct wd_ctx_config *config, struct wd_sched *sched)
-{
-	if (!config || !config->ctxs || !config->ctxs[0].ctx || !sched) {
-		WD_ERR("invalid: wd aead config or sched is NULL!\n");
-		return -WD_EINVAL;
-	}
-
-	if (!wd_is_sva(config->ctxs[0].ctx)) {
-		WD_ERR("err, non sva, please check system!\n");
-		return -WD_EINVAL;
-	}
-
-	return 0;
-}
-
 int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
 	int ret;
 
-	ret = aead_init_check(config, sched);
+	ret = wd_init_param_check(config, sched);
 	if (ret)
 		return ret;
 

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -151,22 +151,6 @@ static int cipher_key_len_check(struct wd_cipher_sess *sess, __u32 length)
 	return ret;
 }
 
-static int cipher_init_check(struct wd_ctx_config *config,
-			     struct wd_sched *sched)
-{
-	if (!config || !config->ctxs || !config->ctxs[0].ctx || !sched) {
-		WD_ERR("invalid: wd cipher config or sched is NULL!\n");
-		return -WD_EINVAL;
-	}
-
-	if (!wd_is_sva(config->ctxs[0].ctx)) {
-		WD_ERR("err, non sva, please check system!\n");
-		return -WD_EINVAL;
-	}
-
-	return 0;
-}
-
 int wd_cipher_set_key(handle_t h_sess, const __u8 *key, __u32 key_len)
 {
 	struct wd_cipher_sess *sess = (struct wd_cipher_sess *)h_sess;
@@ -248,7 +232,7 @@ int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	void *priv;
 	int ret;
 
-	ret = cipher_init_check(config, sched);
+	ret = wd_init_param_check(config, sched);
 	if (ret)
 		return ret;
 

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -85,15 +85,9 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	void *priv;
 	int ret;
 
-	if (!config || !config->ctxs || !config->ctxs[0].ctx || !sched) {
-		WD_ERR("invalid: config or sched is NULL!\n");
-		return -WD_EINVAL;
-	}
-
-	if (!wd_is_sva(config->ctxs[0].ctx)) {
-		WD_ERR("failed to find sva device, please check system!\n");
-		return -WD_EINVAL;
-	}
+	ret = wd_init_param_check(config, sched);
+	if (ret)
+		return ret;
 
 	ret = wd_set_epoll_en("WD_COMP_EPOLL_EN",
 			      &wd_comp_setting.config.epoll_en);

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -692,16 +692,11 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 	msg->tag = tag;
 	msg->stream_mode = WD_COMP_STATELESS;
 
-	pthread_spin_lock(&ctx->lock);
-
 	ret = wd_comp_setting.driver->comp_send(ctx->ctx, msg);
 	if (unlikely(ret < 0)) {
-		pthread_spin_unlock(&ctx->lock);
 		WD_ERR("wd comp send error, ret = %d!\n", ret);
 		goto fail_with_msg;
 	}
-
-	pthread_spin_unlock(&ctx->lock);
 
 	ret = wd_add_task_to_async_queue(&wd_comp_env_config, idx);
 	if (unlikely(ret))

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -175,7 +175,6 @@ struct wd_comp_msg *wd_comp_get_msg(__u32 idx, __u32 tag)
 int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 {
 	struct wd_ctx_config_internal *config = &wd_comp_setting.config;
-	void *priv = wd_comp_setting.priv;
 	struct wd_ctx_internal *ctx;
 	struct wd_comp_msg resp_msg;
 	struct wd_comp_msg *msg;
@@ -198,8 +197,7 @@ int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	ctx = config->ctxs + idx;
 
 	do {
-		ret = wd_comp_setting.driver->comp_recv(ctx->ctx, &resp_msg,
-							priv);
+		ret = wd_comp_setting.driver->comp_recv(ctx->ctx, &resp_msg);
 		if (unlikely(ret < 0)) {
 			if (ret == -WD_HW_EACCESS)
 				WD_ERR("wd comp recv hw error!\n");
@@ -398,7 +396,6 @@ static int wd_comp_sync_job(struct wd_comp_sess *sess,
 {
 	struct wd_ctx_config_internal *config = &wd_comp_setting.config;
 	handle_t h_sched_ctx = wd_comp_setting.sched.h_sched_ctx;
-	void *priv = wd_comp_setting.priv;
 	struct wd_ctx_internal *ctx;
 	__u64 recv_count = 0;
 	__u32 idx;
@@ -415,7 +412,7 @@ static int wd_comp_sync_job(struct wd_comp_sess *sess,
 
 	pthread_spin_lock(&ctx->lock);
 
-	ret = wd_comp_setting.driver->comp_send(ctx->ctx, msg, priv);
+	ret = wd_comp_setting.driver->comp_send(ctx->ctx, msg);
 	if (unlikely(ret < 0)) {
 		pthread_spin_unlock(&ctx->lock);
 		WD_ERR("wd comp send error, ret = %d!\n", ret);
@@ -428,7 +425,7 @@ static int wd_comp_sync_job(struct wd_comp_sess *sess,
 			if (unlikely(ret < 0))
 				WD_ERR("wd ctx wait timeout, ret = %d!\n", ret);
 		}
-		ret = wd_comp_setting.driver->comp_recv(ctx->ctx, msg, priv);
+		ret = wd_comp_setting.driver->comp_recv(ctx->ctx, msg);
 		if (unlikely(ret == -WD_HW_EACCESS)) {
 			pthread_spin_unlock(&ctx->lock);
 			WD_ERR("wd comp recv hw error!\n");
@@ -663,7 +660,6 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 	struct wd_ctx_config_internal *config = &wd_comp_setting.config;
 	struct wd_comp_sess *sess = (struct wd_comp_sess *)h_sess;
 	handle_t h_sched_ctx = wd_comp_setting.sched.h_sched_ctx;
-	void *priv = wd_comp_setting.priv;
 	struct wd_ctx_internal *ctx;
 	struct wd_comp_msg *msg;
 	int tag, ret;
@@ -698,7 +694,7 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 
 	pthread_spin_lock(&ctx->lock);
 
-	ret = wd_comp_setting.driver->comp_send(ctx->ctx, msg, priv);
+	ret = wd_comp_setting.driver->comp_send(ctx->ctx, msg);
 	if (unlikely(ret < 0)) {
 		pthread_spin_unlock(&ctx->lock);
 		WD_ERR("wd comp send error, ret = %d!\n", ret);

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -323,13 +323,9 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 		goto fail_with_msg;
 	msg->tag = mid;
 
-	pthread_spin_lock(&ctx->lock);
 	ret = dh_send(ctx->ctx, msg);
-	if (ret) {
-		pthread_spin_unlock(&ctx->lock);
+	if (ret)
 		goto fail_with_msg;
-	}
-	pthread_spin_unlock(&ctx->lock);
 
 	ret = wd_add_task_to_async_queue(&wd_dh_env_config, idx);
 	if (ret)

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -78,28 +78,14 @@ void wd_dh_set_driver(struct wd_dh_driver *drv)
 	wd_dh_setting.driver = drv;
 }
 
-static int param_check(struct wd_ctx_config *config, struct wd_sched *sched)
-{
-	if (!config || !config->ctxs || !config->ctxs[0].ctx || !sched) {
-		WD_ERR("invalid: config or sched is NULL!\n");
-		return -WD_EINVAL;
-	}
-
-	if (!wd_is_sva(config->ctxs[0].ctx)) {
-		WD_ERR("invalid: the mode is non sva, please check system!\n");
-		return -WD_EINVAL;
-	}
-
-	return 0;
-}
-
 int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
 	int ret;
 
-	if (param_check(config, sched))
-		return -WD_EINVAL;
+	ret = wd_init_param_check(config, sched);
+	if (ret)
+		return ret;
 
 	ret = wd_set_epoll_en("WD_DH_EPOLL_EN",
 			      &wd_dh_setting.config.epoll_en);

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -150,27 +150,12 @@ void wd_digest_free_sess(handle_t h_sess)
 	free(sess);
 }
 
-static int digest_init_check(struct wd_ctx_config *config, struct wd_sched *sched)
-{
-	if (!config || !config->ctxs || !config->ctxs[0].ctx || !sched) {
-		WD_ERR("failed to check input param!\n");
-		return -WD_EINVAL;
-	}
-
-	if (!wd_is_sva(config->ctxs[0].ctx)) {
-		WD_ERR("err, non sva, please check system!\n");
-		return -WD_EINVAL;
-	}
-
-	return 0;
-}
-
 int wd_digest_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
 	int ret;
 
-	ret = digest_init_check(config, sched);
+	ret = wd_init_param_check(config, sched);
 	if (ret)
 		return ret;
 

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -2151,13 +2151,9 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
 		goto fail_with_msg;
 	msg->tag = mid;
 
-	pthread_spin_lock(&ctx->lock);
 	ret = ecc_send(ctx->ctx, msg);
-	if (ret) {
-		pthread_spin_unlock(&ctx->lock);
+	if (ret)
 		goto fail_with_msg;
-	}
-	pthread_spin_unlock(&ctx->lock);
 
 	ret = wd_add_task_to_async_queue(&wd_ecc_env_config, idx);
 	if (ret)

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -132,28 +132,14 @@ void wd_ecc_set_driver(struct wd_ecc_driver *drv)
 	wd_ecc_setting.driver = drv;
 }
 
-static int init_param_check(struct wd_ctx_config *config, struct wd_sched *sched)
-{
-	if (!config || !config->ctxs || !config->ctxs[0].ctx || !sched) {
-		WD_ERR("invalid: config or sched is NULL!\n");
-		return -WD_EINVAL;
-	}
-
-	if (!wd_is_sva(config->ctxs[0].ctx)) {
-		WD_ERR("invalid: the mode is non sva, please check system!\n");
-		return -WD_EINVAL;
-	}
-
-	return 0;
-}
-
 int wd_ecc_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
 	int ret;
 
-	if (init_param_check(config, sched))
-		return -WD_EINVAL;
+	ret = wd_init_param_check(config, sched);
+	if (ret)
+		return ret;
 
 	ret = wd_set_epoll_en("WD_ECC_EPOLL_EN",
 			      &wd_ecc_setting.config.epoll_en);

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -19,11 +19,9 @@
 #define WD_POOL_MAX_ENTRIES		1024
 #define WD_HW_EACCESS			62
 
-#define RSA_BALANCE_THRHD		1280
 #define RSA_MAX_KEY_SIZE		512
-#define RSA_RECV_MAX_CNT		60000000 // 1 min
 
-static __thread int balance;
+static __thread __u64 balance;
 
 struct wd_rsa_pubkey {
 	struct wd_dtb n;
@@ -251,46 +249,12 @@ static int fill_rsa_msg(struct wd_rsa_msg *msg, struct wd_rsa_req *req,
 	return 0;
 }
 
-static int rsa_recv_sync(handle_t ctx, struct wd_rsa_msg *msg)
-{
-	struct wd_rsa_req *req = &msg->req;
-	__u32 rx_cnt = 0;
-	int ret;
-
-	do {
-		if (wd_rsa_setting.config.epoll_en) {
-			ret = wd_ctx_wait(ctx, POLL_TIME);
-			if (ret < 0)
-				WD_ERR("wd ctx wait timeout(%d)!\n", ret);
-		}
-
-		ret = wd_rsa_setting.driver->recv(ctx, msg);
-		if (ret == -WD_EAGAIN) {
-			if (rx_cnt++ >= RSA_RECV_MAX_CNT) {
-				WD_ERR("failed to recv: timeout!\n");
-				return -WD_ETIMEDOUT;
-			}
-
-			if (balance > RSA_BALANCE_THRHD)
-				usleep(1);
-		} else if (ret < 0) {
-			WD_ERR("failed to recv: error = %d!\n", ret);
-			return ret;
-		}
-	} while (ret < 0);
-
-	balance = rx_cnt;
-	req->status = msg->result;
-	req->dst_bytes = msg->req.dst_bytes;
-
-	return GET_NEGATIVE(req->status);
-}
-
 int wd_do_rsa_sync(handle_t h_sess, struct wd_rsa_req *req)
 {
 	struct wd_ctx_config_internal *config = &wd_rsa_setting.config;
 	handle_t h_sched_ctx = wd_rsa_setting.sched.h_sched_ctx;
 	struct wd_rsa_sess *sess = (struct wd_rsa_sess *)h_sess;
+	struct wd_msg_handle msg_handle;
 	struct wd_ctx_internal *ctx;
 	struct wd_rsa_msg msg;
 	__u32 idx;
@@ -315,18 +279,20 @@ int wd_do_rsa_sync(handle_t h_sess, struct wd_rsa_req *req)
 	if (unlikely(ret))
 		return ret;
 
+	msg_handle.send = wd_rsa_setting.driver->send;
+	msg_handle.recv = wd_rsa_setting.driver->recv;
+
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_rsa_setting.driver->send(ctx->ctx, &msg);
-	if (unlikely(ret < 0)) {
-		WD_ERR("failed to send rsa BD, ret = %d!\n", ret);
-		goto fail;
-	}
-
-	ret = rsa_recv_sync(ctx->ctx, &msg);
-fail:
+	ret = wd_handle_msg_sync(&msg_handle, ctx->ctx, &msg, &balance,
+				 wd_rsa_setting.config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
+	if (unlikely(ret))
+		return ret;
 
-	return ret;
+	req->dst_bytes = msg.req.dst_bytes;
+	req->status = msg.result;
+
+	return GET_NEGATIVE(msg.result);
 }
 
 int wd_do_rsa_async(handle_t sess, struct wd_rsa_req *req)

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -118,28 +118,14 @@ void wd_rsa_set_driver(struct wd_rsa_driver *drv)
 	wd_rsa_setting.driver = drv;
 }
 
-static int param_check(struct wd_ctx_config *config, struct wd_sched *sched)
-{
-	if (!config || !config->ctxs[0].ctx || !sched) {
-		WD_ERR("invalid: config or sched NULL!\n");
-		return -WD_EINVAL;
-	}
-
-	if (!wd_is_sva(config->ctxs[0].ctx)) {
-		WD_ERR("invalid: the mode is non sva, please check system!\n");
-		return -WD_EINVAL;
-	}
-
-	return 0;
-}
-
 int wd_rsa_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
 	int ret;
 
-	if (param_check(config, sched))
-		return -WD_EINVAL;
+	ret = wd_init_param_check(config, sched);
+	if (ret)
+		return ret;
 
 	ret = wd_set_epoll_en("WD_RSA_EPOLL_EN",
 			      &wd_rsa_setting.config.epoll_en);

--- a/wd_util.c
+++ b/wd_util.c
@@ -1628,3 +1628,23 @@ int wd_set_epoll_en(const char *var_name, bool *epoll_en)
 
 	return 0;
 }
+
+int wd_init_param_check(struct wd_ctx_config *config, struct wd_sched *sched)
+{
+	if (!config || !config->ctxs || !config->ctxs[0].ctx) {
+		WD_ERR("invalid: config or config->ctxs is NULL!\n");
+		return -WD_EINVAL;
+	}
+
+	if (!sched) {
+		WD_ERR("invalid: sched is NULL!\n");
+		return -WD_EINVAL;
+	}
+
+	if (!wd_is_sva(config->ctxs[0].ctx)) {
+		WD_ERR("invalid: the mode is non sva, please check system!\n");
+		return -WD_EINVAL;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
These patches move some redundant codes to wd_utils from wd_<alg>.c, and remove the unnecessary locks in wd_<alg>.c.