### PR TITLE
uadk: missing header file after install uadk

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,13 +25,13 @@ UADK_VERSION = -version-number ${MAJOR}:${MINOR}:${REVISION}
 
 AM_CFLAGS+= -DUADK_VERSION_NUMBER="\"libwd version: ${MAJOR}.${MINOR}.${REVISION}\""
 
-include_HEADERS = include/wd.h include/wd_cipher.h include/wd_comp.h \
-		  include/wd_dh.h include/wd_digest.h include/wd_rsa.h \
-		  include/uacce.h include/wd_alg_common.h \
+include_HEADERS = include/wd.h include/wd_cipher.h include/wd_aead.h \
+		  include/wd_comp.h include/wd_dh.h include/wd_digest.h \
+		  include/wd_rsa.h  include/uacce.h include/wd_alg_common.h \
 		  include/wd_common.h include/wd_ecc.h include/wd_sched.h
 
-nobase_include_HEADERS = v1/wd.h v1/wd_cipher.h v1/uacce.h v1/wd_dh.h v1/wd_digest.h \
-			 v1/wd_rsa.h v1/wd_bmm.h
+nobase_include_HEADERS = v1/wd.h v1/wd_cipher.h v1/wd_aead.h v1/uacce.h v1/wd_dh.h \
+			 v1/wd_digest.h v1/wd_rsa.h v1/wd_bmm.h
 
 lib_LTLIBRARIES=libwd.la libwd_comp.la libwd_crypto.la libhisi_zip.la \
 		libhisi_hpre.la libhisi_sec.la


### PR DESCRIPTION
Add header file in build file.

Signed-off-by: Kai Ye <yekai13@huawei.com>