### PR TITLE
wd/sched: remove support unset sched_param

### DIFF
--- a/include/drv/wd_ecc_drv.h
+++ b/include/drv/wd_ecc_drv.h
@@ -45,8 +45,6 @@ extern "C" {
 #define WD_X448				0x2
 #define WD_SM2P256			0x3
 
-#define offsetof(t, m) ((size_t)(uintptr_t)&((t *)0)->m)
-
 /* ECC message format */
 struct wd_ecc_msg {
 	struct wd_ecc_req req;

--- a/include/hisi_qm_udrv.h
+++ b/include/hisi_qm_udrv.h
@@ -5,6 +5,7 @@
 #define __HZIP_DRV_H__
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <pthread.h>
 #include <linux/types.h>
 
@@ -29,10 +30,9 @@ extern "C" {
 #define BYTE_BITS			8
 #define BYTE_BITS_SHIFT		3
 
-#define __offsetof(t, m) ((size_t)(uintptr_t)&((t *)0)->m)
 #define container_of(ptr, type, member) ({ \
 		typeof(((type *)0)->member)(*__mptr) = (ptr); \
-		(type *)((char *)__mptr - __offsetof(type, member)); })
+		(type *)((char *)__mptr - offsetof(type, member)); })
 
 enum hisi_qm_sgl_copy_dir {
 	COPY_SGL_TO_PBUFF,

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <stddef.h>
 #include <string.h>
 #include <time.h>
 #include <dlfcn.h>


### PR DESCRIPTION
Due to the parameters used to select a ctx come from wd_<alg>_sess
rather than request, UADK has no way to init the sched_params
instead of the user during create wd_<alg>_sess.

UADK only supports to assign configuration which can get from
interface. But it absolutely does not include the algorithms
and operations that the user will use in the future.

So the users really need UADK support default configuration,
providing more encapsulated interfaces is a feasible solution.

Signed-off-by: Yang Shen <youngershen@foxmail.com>