### PR TITLE
uadk - mv some function to header file

### DIFF
--- a/include/wd.h
+++ b/include/wd.h
@@ -488,6 +488,21 @@ void wd_mempool_stats(handle_t mempool, struct wd_mempool_stats *stats);
  */
 void wd_blockpool_stats(handle_t blkpool, struct wd_blockpool_stats *stats);
 
+/**
+ * wd_clone_dev() - clone a new uacce device.
+ * @dev: The source device.
+ *
+ * Return a pointer value for successed, and NULL for error.
+ */
+struct uacce_dev *wd_clone_dev(struct uacce_dev *dev);
+
+/**
+ * wd_add_to_list() - add a node to end of list.
+ * @head: The list head.
+ * @node: The node need to be add.
+ */
+void wd_add_to_list(struct uacce_dev_list *head, struct uacce_dev_list *node);
+
 #ifdef __cplusplus
 }
 #endif

--- a/wd.c
+++ b/wd.c
@@ -289,7 +289,13 @@ out:
 	return strndup(name, len);
 }
 
-static struct uacce_dev *clone_uacce_dev(struct uacce_dev *dev)
+static void wd_ctx_init_qfrs_offs(struct wd_ctx_h *ctx)
+{
+	memcpy(&ctx->qfrs_offs, &ctx->dev->qfrs_offs,
+	       sizeof(ctx->qfrs_offs));
+}
+
+struct uacce_dev *wd_clone_dev(struct uacce_dev *dev)
 {
 	struct uacce_dev *new;
 
@@ -302,10 +308,14 @@ static struct uacce_dev *clone_uacce_dev(struct uacce_dev *dev)
 	return new;
 }
 
-static void wd_ctx_init_qfrs_offs(struct wd_ctx_h *ctx)
+void wd_add_to_list(struct uacce_dev_list *head, struct uacce_dev_list *node)
 {
-	memcpy(&ctx->qfrs_offs, &ctx->dev->qfrs_offs,
-	       sizeof(ctx->qfrs_offs));
+	struct uacce_dev_list *tmp = head;
+
+	while (tmp->next)
+		tmp = tmp->next;
+
+	tmp->next = node;
 }
 
 handle_t wd_request_ctx(struct uacce_dev *dev)
@@ -340,7 +350,7 @@ handle_t wd_request_ctx(struct uacce_dev *dev)
 	if (!ctx->drv_name)
 		goto free_dev_name;
 
-	ctx->dev = clone_uacce_dev(dev);
+	ctx->dev = wd_clone_dev(dev);
 	if (!ctx->dev)
 		goto free_drv_name;
 
@@ -580,17 +590,6 @@ static bool dev_has_alg(const char *dev_alg_name, const char *alg_name)
 	return false;
 }
 
-static void add_uacce_dev_to_list(struct uacce_dev_list *head,
-				  struct uacce_dev_list *node)
-{
-	struct uacce_dev_list *tmp = head;
-
-	while (tmp->next)
-		tmp = tmp->next;
-
-	tmp->next = node;
-}
-
 static int check_alg_name(const char *alg_name)
 {
 	int i = 0;
@@ -653,7 +652,7 @@ struct uacce_dev_list *wd_get_accel_list(const char *alg_name)
 		if (!head)
 			head = node;
 		else
-			add_uacce_dev_to_list(head, node);
+			wd_add_to_list(head, node);
 	}
 
 	closedir(wd_class);
@@ -712,7 +711,7 @@ struct uacce_dev *wd_get_accel_dev(const char *alg_name)
 	}
 
 	if (dev)
-		target = clone_uacce_dev(dev);
+		target = wd_clone_dev(dev);
 
 	wd_free_list_accels(head);
 


### PR DESCRIPTION
Since two function will be used for mutil files, move them to header file.

Signed-off-by: Yang Shen <shenyang39@huawei.com>