### PR TITLE
uadk - add wd_comp_init2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,7 +87,7 @@ AM_CFLAGS += -DWD_NO_LOG
 
 libwd_la_LIBADD = $(libwd_la_OBJECTS) -lnuma
 
-libwd_comp_la_LIBADD = $(libwd_la_OBJECTS) -ldl
+libwd_comp_la_LIBADD = $(libwd_la_OBJECTS) -ldl -lnuma
 libwd_comp_la_DEPENDENCIES = libwd.la
 
 libhisi_zip_la_LIBADD = -ldl
@@ -104,7 +104,7 @@ else
 libwd_la_LDFLAGS=$(UADK_VERSION)
 libwd_la_LIBADD= -lnuma
 
-libwd_comp_la_LIBADD= -lwd -ldl
+libwd_comp_la_LIBADD= -lwd -ldl -lnuma
 libwd_comp_la_LDFLAGS=$(UADK_VERSION)
 libwd_comp_la_DEPENDENCIES= libwd.la
 

--- a/docs/wd_alg_init2.md
+++ b/docs/wd_alg_init2.md
@@ -1,0 +1,159 @@
+# wd_alg_init2
+
+## Preface
+
+The current uadk initialization process is:
+1.Call wd_request_ctx() to request ctxs from devices.
+2.Call wd_sched_rr_alloc() to create a sched(or some other scheduler alloc function if exits).
+3.Initialize the sched.
+4.Call wd_alg_init() with ctx_config and sched.
+
+```flow
+st=>start: Start
+o1=>operation: request ctxs
+o2=>operation: create uadk_sched and instance ctxs to sched region
+o3=>operation: call wd_alg_init
+e=>end
+st->o1->o2->o3->e
+```
+
+Logic is reasonable. But in practice, the step of wd_request_ctx()
+and wd_sched_rr_alloc() are very tedious. This makes it difficult
+for users to use the interface. One of the main reasons for this is
+that uadk has made a lot of configurations in the scheduler in order
+to provide users with better performance. Based on this consideration,
+the current uadk requires the user to arrange the division of hardware
+resources according to the device topology during initialization.
+Therefore, as a high-level interface, this scheme can provide customized
+scheme configuration for users with deep needs.
+
+## wd_alg_init2
+
+### Design
+
+Is there any way to simplify these steps? Not currently. Because the
+architecture model designed by uadk is to manage hardware resources
+through a scheduler, users can no longer perceive after specifying
+hardware resources, and all subsequent tasks are handled by the scheduler.
+The original intention of this design is to make the scenarios supported
+by uadk more flexible. Because the resource requirements of different
+business scenarios are different from the task model of the business
+itself, the best performance experience can be obtained through the
+scheduler to match.
+
+But we can try to provide a layer of encapsulation. The original design
+intention of this layer of encapsulation is that users only need to
+specify available resources and requirements, and the configuration of
+resources is completed internally by the interface. Because the previous
+interface complexity mainly lies in the parameter configuration of CTX
+and scheduler, it is easy for users to make configuration errors and
+generate bugs because of their misunderstanding of parameters.
+
+All algorithms have the same input parameters and initialization logic.
+
+```c
+struct wd_ctx_config {
+	__u32 ctx_num;
+	struct wd_ctx *ctxs;
+	void *priv;
+};
+
+struct wd_sched {
+	const char *name;
+	int sched_policy;
+	handle_t (*sched_init)(handle_t h_sched_ctx, void *sched_param);
+	__u32 (*pick_next_ctx)(handle_t h_sched_ctx, void *sched_key,
+			       const int sched_mode);
+	int (*poll_policy)(handle_t h_sched_ctx, __u32 expect, __u32 *count);
+	handle_t h_sched_ctx;
+};
+
+int wd_alg_init(struct wd_ctx_config *config, struct wd_sched *sched);
+```
+
+`wd_ctx_config` is the requested ctxs descriptor, and the attributes
+of ctxs are contained in their own structure. The attributes will be
+used in scheduler for picking ctx according to request type. The main
+difficulty in this step is that users need to apply for CTXs from the
+appropriate device nodes according to their own business distribution.
+If the user does not consider the appropriate device distribution,
+it may lead to cross chip or cross numa node which will affect
+performance.
+
+`wd_sched` is the scheduler descriptor of the request. It will create
+the scheduling domain based parameters passed by the users. User needs
+to allocate the ctxs applied to the scheduling domain that meets the
+attribute, so that uadk can select the appropriate ctxs according to
+the issued business. The main difficulty in this step is that the user
+needs to initialize the correct scheduling domain according to the ctxs
+attributes previously applied. However, there are many attributes of
+ctxs here, which should be divided by multiple dimensions. If the
+parameters are not understood enough, it is easy to make queue
+allocation errors, resulting in the scheduling of the wrong ctxs when
+the task is finally issued, and cause unexpected errors.
+
+Therefore, the next thing to be done is to use limited and easy-to-use
+input parameters to describe users' requirements on the two input
+parameters, ensuring that the functions of the new interface init2
+are the same as those of init. For ease of description, v1 is used
+to refer to the existing interface, and v2 is used to refer to the
+layer of encapsulation.
+
+Let's clarify the following logic first: all uacce devices under a
+numa node can be regarded as the same. So although we request for
+ctxs from the device, we manage ctxs according to numa nodes.
+That means if users want to get the same performance for all cpu,
+the uadk configure should be same for all numa node.
+
+At present, at least 4 parameters are required to meet the user
+configuration requirements with the V1 interface function remains
+unchanged.
+
+@alg: The algorithm users wanted.
+
+@sched_type: Scheduling type the user wants to use.
+
+@task_tp: Reserved.
+
+@wd_ctx_params: op_type_num and ctx_set_num means the requested ctx
+number for each numa node. Due to users may have different requirements
+for different types of ctx numbers, needs a two-dimensional array as
+input. The bitmask provided by libnuma. Users can use this parameter
+to control requesting ctxs devices in the bind NUMA scenario.
+This parameter is mainly convenient for users to use in the binding
+cpu scenario. It can avoid resource waste or initialization failure
+caused by insufficient resources. Libnuma provides a complete operation
+interface which can be found in numa.h.
+
+To sum up, the wd_alg_init2_() is as follows
+
+```c
+struct wd_ctx_nums {
+	__u32 sync_ctx_num;
+	__u32 async_ctx_num;
+};
+
+struct wd_ctx_params {
+	__u32 op_type_num;
+	struct wd_ctx_nums *ctx_set_num;
+	struct bitmask *bmp;
+};
+
+init wd_alg_init2_(char *alg, __u32 sched_type, int task_tp,
+                   struct wd_ctx_params *ctx_params);
+```
+
+Somebody may say that the wd_alg_init2_() is still complex for three
+input parameters are structure. So the interface support default value
+for some parameters. The @bmp can be set as NULL, and then it will be
+initialized according to device list. The @cparams can be set as NULL,
+and it has a default value in wd_alg.c. So there is a simpler interface
+wd_alg_init2().
+
+```c
+#define wd_alg_init2(alg, sched_type, task_tp) \
+	wd_alg_init2_(alg, sched_type, task_tp, NULL)
+```
+
+Please do not use this interface with wd_comp_init() together,
+or some resources may be leak.

--- a/docs/wd_design.md
+++ b/docs/wd_design.md
@@ -81,6 +81,7 @@
 |         |                |2) Change *user* layer to *sched* layer since |
 |         |                |   sample_sched is moved from user space into UADK |
 |         |                |   framework. |
+|  1.4    |                |1) Update *wd_alg_init* reentrancy. |
 
 
 ## Terminology
@@ -493,7 +494,9 @@ device.
 Return 0 if it succeeds. And return error number if it fails.
 
 In *wd_comp_init()*, context resources, user scheduler and vendor driver are
-initialized.
+initialized. This function supports multi-threaded concurrent calls and
+reentrant. When one thread is initializing, other threads will wait for
+completion.
 
 
 ***void wd_comp_uninit(void)***

--- a/include/wd.h
+++ b/include/wd.h
@@ -91,11 +91,6 @@ typedef void (*wd_log)(const char *format, ...);
 #define WD_IS_ERR(h)			((uintptr_t)(h) > \
 					(uintptr_t)(-1000))
 
-static inline void *WD_ERR_PTR(uintptr_t error)
-{
-	return (void *)error;
-}
-
 enum wcrypto_type {
 	WD_CIPHER,
 	WD_DIGEST,
@@ -183,6 +178,16 @@ static inline void wd_iowrite64(void *addr, uint64_t value)
 {
 	wmb();
 	*((volatile uint64_t *)addr) = value;
+}
+
+static inline void *WD_ERR_PTR(uintptr_t error)
+{
+	return (void *)error;
+}
+
+static inline long WD_PTR_ERR(const void *ptr)
+{
+	return (long)ptr;
 }
 
 /**

--- a/include/wd.h
+++ b/include/wd.h
@@ -349,6 +349,16 @@ int wd_get_avail_ctx(struct uacce_dev *dev);
 struct uacce_dev_list *wd_get_accel_list(const char *alg_name);
 
 /**
+ * wd_find_dev_by_numa() - get device with max available ctx number from an
+ *			   device list according to numa id.
+ * @list: The device list.
+ * @numa_id: The numa_id.
+ *
+ * Return device if succeed and other error number if fail.
+ */
+struct uacce_dev *wd_find_dev_by_numa(struct uacce_dev_list *list, int numa_id);
+
+/**
  * wd_get_accel_dev() - Get device supporting the algorithm with
 			smallest numa distance to current numa node.
  * @alg_name: Algorithm name, which could be got from
@@ -522,6 +532,20 @@ struct uacce_dev *wd_clone_dev(struct uacce_dev *dev);
  * @node: The node need to be add.
  */
 void wd_add_dev_to_list(struct uacce_dev_list *head, struct uacce_dev_list *node);
+
+/**
+ * wd_create_device_nodemask() - create a numa node mask of device list.
+ * @list: The devices list.
+ *
+ * Return a pointer value if succeed, and error number if fail.
+ */
+struct bitmask *wd_create_device_nodemask(struct uacce_dev_list *list);
+
+/**
+ * wd_free_device_nodemask() - free a numa node mask.
+ * @bmp: A numa node mask.
+ */
+void wd_free_device_nodemask(struct bitmask *bmp);
 
 /**
  * wd_ctx_get_dev_name() - Get the device name about task.

--- a/include/wd.h
+++ b/include/wd.h
@@ -509,6 +509,21 @@ void wd_mempool_stats(handle_t mempool, struct wd_mempool_stats *stats);
 void wd_blockpool_stats(handle_t blkpool, struct wd_blockpool_stats *stats);
 
 /**
+ * wd_clone_dev() - clone a new uacce device.
+ * @dev: The source device.
+ *
+ * Return a pointer value if succeed, and NULL if fail.
+ */
+struct uacce_dev *wd_clone_dev(struct uacce_dev *dev);
+
+/**
+ * wd_add_dev_to_list() - add a node to end of list.
+ * @head: The list head.
+ * @node: The node need to be add.
+ */
+void wd_add_dev_to_list(struct uacce_dev_list *head, struct uacce_dev_list *node);
+
+/**
  * wd_ctx_get_dev_name() - Get the device name about task.
  * @h_ctx: The handle of context.
  * Return device name.

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -63,6 +63,33 @@ struct wd_ctx_config {
 	void *priv;
 };
 
+/**
+ * struct wd_ctx_nums - Define the ctx sets numbers.
+ * @sync_ctx_num: The ctx numbers which are used for sync mode for each
+ * ctx sets.
+ * @async_ctx_num: The ctx numbers which are used for async mode for each
+ * ctx sets.
+ */
+struct wd_ctx_nums {
+	__u32 sync_ctx_num;
+	__u32 async_ctx_num;
+};
+
+/**
+ * struct wd_ctx_params - Define the ctx sets params which are used for init
+ * algorithms.
+ * @op_type_num: Used for index of ctx_set_num, the order is the same as
+ * wd_<alg>_op_type.
+ * @ctx_set_num: Each operation type ctx sets numbers.
+ * @bmp: Ctxs distribution. Means users want to run business process on these
+ * numa or request ctx from devices located in these numa.
+ */
+struct wd_ctx_params {
+	__u32 op_type_num;
+	struct wd_ctx_nums *ctx_set_num;
+	struct bitmask *bmp;
+};
+
 struct wd_ctx_internal {
 	handle_t ctx;
 	__u8 op_type;

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -7,6 +7,7 @@
 #ifndef __WD_COMP_H
 #define __WD_COMP_H
 
+#include <numa.h>
 #include "wd.h"
 #include "wd_alg_common.h"
 
@@ -112,6 +113,35 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched);
  * wd_comp_uninit() - Un-initialise ctx configuration and scheduler.
  */
 void wd_comp_uninit(void);
+
+/**
+ * wd_comp_init2_() - A simplify interface to initializate uadk
+ * compression/decompression. This interface keeps most functions of
+ * wd_comp_init(). Users just need to descripe the deployment of
+ * business scenarios. Then the initialization will request appropriate
+ * resources to support the business scenarios.
+ * To make the initializate simpler, ctx_params support set NULL.
+ * And then the function will set them as default.
+ * Please do not use this interface with wd_comp_init() together, or
+ * some resources may be leak.
+ *
+ * @alg: The algorithm users want to use.
+ * @sched_type: The scheduling type users want to use.
+ * @task_tp: Reserved.
+ * @ctx_params: The ctxs resources users want to use. Include per operation
+ * type ctx numbers and business process run numa.
+ *
+ * Return 0 if succeed and others if fail.
+ */
+int wd_comp_init2_(char *alg, __u32 sched_type, int task_tp, struct wd_ctx_params *ctx_params);
+
+#define wd_comp_init2(alg, sched_type, task_tp) \
+	wd_comp_init2_(alg, sched_type, task_tp, NULL)
+
+/**
+ * wd_comp_uninit2() - Uninitialise ctx configuration and scheduler.
+ */
+void wd_comp_uninit2(void);
 
 struct wd_comp_sess_setup {
 	enum wd_comp_alg_type alg_type; /* Denoted by enum wd_comp_alg_type */

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -21,6 +21,12 @@ extern "C" {
 	for ((i) = 0, (config_numa) = (config)->config_per_numa; \
 	     (i) < (config)->numa_num; (config_numa)++, (i)++)
 
+enum wd_status {
+	WD_UNINIT,
+	WD_INITING,
+	WD_INIT,
+};
+
 struct wd_async_msg_pool {
 	struct msg_pool *pools;
 	__u32 pool_num;
@@ -355,6 +361,48 @@ int wd_handle_msg_sync(struct wd_msg_handle *msg_handle, handle_t ctx,
  * Return 0 if successful or less than 0 otherwise.
  */
 int wd_init_param_check(struct wd_ctx_config *config, struct wd_sched *sched);
+
+/**
+ * wd_alg_try_init() - Check the algorithm status and set it as WD_INITING
+ * if need initialization.
+ * @status: algorithm initialization status.
+ *
+ * Return true if need initialization and false if initialized, otherwise will wait
+ * last initialization result.
+ */
+bool wd_alg_try_init(enum wd_status *status);
+
+/**
+ * wd_alg_set_init() - Set the algorithm status as WD_INIT.
+ * @status: algorithm initialization status.
+ */
+static inline void wd_alg_set_init(enum wd_status *status)
+{
+	enum wd_status setting = WD_INIT;
+
+	__atomic_store(status, &setting, __ATOMIC_RELAXED);
+}
+
+/**
+ * wd_alg_get_init() - Get the algorithm status.
+ * @status: algorithm initialization status.
+ * @value: value of algorithm initialization status.
+ */
+static inline void wd_alg_get_init(enum wd_status *status, enum wd_status *value)
+{
+	__atomic_load(status, value, __ATOMIC_RELAXED);
+}
+
+/**
+ * wd_alg_clear_init() - Set the algorithm status as WD_UNINIT.
+ * @status: algorithm initialization status.
+ */
+static inline void wd_alg_clear_init(enum wd_status *status)
+{
+	enum wd_status setting = WD_UNINIT;
+
+	__atomic_store(status, &setting, __ATOMIC_RELAXED);
+}
 
 /**
  * wd_dfx_msg_cnt() - Message counter interface for ctx

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -7,6 +7,7 @@
 #ifndef __WD_UTIL_H
 #define __WD_UTIL_H
 
+#include <numa.h>
 #include <stdbool.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
@@ -110,6 +111,14 @@ struct wd_ctx_attr {
 struct wd_msg_handle {
 	int (*send)(handle_t sess, void *msg);
 	int (*recv)(handle_t sess, void *msg);
+};
+
+struct wd_init_attrs {
+	__u32 sched_type;
+	char *alg;
+	struct wd_sched *sched;
+	struct wd_ctx_params *ctx_params;
+	struct wd_ctx_config *ctx_config;
 };
 
 /*
@@ -403,6 +412,15 @@ static inline void wd_alg_clear_init(enum wd_status *status)
 
 	__atomic_store(status, &setting, __ATOMIC_RELAXED);
 }
+
+/**
+ * wd_alg_pre_init() - Request the ctxs and initialize the sched_domain
+ *                     with the given devices list, ctxs number and numa mask.
+ * @attrs: the algorithm initialization parameters.
+ *
+ * Return device if succeed and other error number if fail.
+ */
+int wd_alg_pre_init(struct wd_init_attrs *attrs);
 
 /**
  * wd_dfx_msg_cnt() - Message counter interface for ctx

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -31,6 +31,7 @@ static int g_aead_mac_len[WD_DIGEST_TYPE_MAX] = {
 };
 
 struct wd_aead_setting {
+	enum wd_status status;
 	struct wd_ctx_config_internal config;
 	struct wd_sched sched;
 	struct wd_aead_driver *driver;
@@ -392,24 +393,29 @@ static int wd_aead_param_check(struct wd_aead_sess *sess,
 int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
+	bool flag;
 	int ret;
+
+	flag = wd_alg_try_init(&wd_aead_setting.status);
+	if (!flag)
+		return 0;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_set_epoll_en("WD_AEAD_EPOLL_EN",
 			      &wd_aead_setting.config.epoll_en);
 	if (ret < 0)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_ctx_config(&wd_aead_setting.config, config);
 	if (ret)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_sched(&wd_aead_setting.sched, sched);
 	if (ret < 0)
-		goto out;
+		goto out_clear_ctx_config;
 
 	/* set driver */
 #ifdef WD_STATIC_DRV
@@ -421,33 +427,37 @@ int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 				config->ctx_num, WD_POOL_MAX_ENTRIES,
 				sizeof(struct wd_aead_msg));
 	if (ret < 0)
-		goto out_sched;
+		goto out_clear_sched;
 
 	/* init ctx related resources in specific driver */
 	priv = calloc(1, wd_aead_setting.driver->drv_ctx_size);
 	if (!priv) {
 		ret = -WD_ENOMEM;
-		goto out_priv;
+		goto out_clear_pool;
 	}
 	wd_aead_setting.priv = priv;
 
 	ret = wd_aead_setting.driver->init(&wd_aead_setting.config, priv);
 	if (ret < 0) {
 		WD_ERR("failed to init aead dirver!\n");
-		goto out_init;
+		goto out_free_priv;
 	}
+
+	wd_alg_set_init(&wd_aead_setting.status);
 
 	return 0;
 
-out_init:
+out_free_priv:
 	free(priv);
 	wd_aead_setting.priv = NULL;
-out_priv:
+out_clear_pool:
 	wd_uninit_async_request_pool(&wd_aead_setting.pool);
-out_sched:
+out_clear_sched:
 	wd_clear_sched(&wd_aead_setting.sched);
-out:
+out_clear_ctx_config:
 	wd_clear_ctx_config(&wd_aead_setting.config);
+out_clear_init:
+	wd_alg_clear_init(&wd_aead_setting.status);
 	return ret;
 }
 
@@ -465,6 +475,7 @@ void wd_aead_uninit(void)
 	wd_uninit_async_request_pool(&wd_aead_setting.pool);
 	wd_clear_sched(&wd_aead_setting.sched);
 	wd_clear_ctx_config(&wd_aead_setting.config);
+	wd_alg_clear_init(&wd_aead_setting.status);
 }
 
 static void fill_request_msg(struct wd_aead_msg *msg, struct wd_aead_req *req,

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -45,6 +45,7 @@ static const unsigned char des_weak_keys[DES_WEAK_KEY_NUM][DES_KEY_SIZE] = {
 };
 
 struct wd_cipher_setting {
+	enum wd_status status;
 	struct wd_ctx_config_internal config;
 	struct wd_sched      sched;
 	void *sched_ctx;
@@ -231,24 +232,29 @@ void wd_cipher_free_sess(handle_t h_sess)
 int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
+	bool flag;
 	int ret;
+
+	flag = wd_alg_try_init(&wd_cipher_setting.status);
+	if (!flag)
+		return 0;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_set_epoll_en("WD_CIPHER_EPOLL_EN",
 			      &wd_cipher_setting.config.epoll_en);
 	if (ret < 0)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_ctx_config(&wd_cipher_setting.config, config);
 	if (ret < 0)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_sched(&wd_cipher_setting.sched, sched);
 	if (ret < 0)
-		goto out;
+		goto out_clear_ctx_config;
 
 #ifdef WD_STATIC_DRV
 	/* set driver */
@@ -260,33 +266,37 @@ int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 					 config->ctx_num, WD_POOL_MAX_ENTRIES,
 					 sizeof(struct wd_cipher_msg));
 	if (ret < 0)
-		goto out_sched;
+		goto out_clear_sched;
 
 	/* init ctx related resources in specific driver */
 	priv = calloc(1, wd_cipher_setting.driver->drv_ctx_size);
 	if (!priv) {
 		ret = -WD_ENOMEM;
-		goto out_priv;
+		goto out_clear_pool;
 	}
 	wd_cipher_setting.priv = priv;
 
 	ret = wd_cipher_setting.driver->init(&wd_cipher_setting.config, priv);
 	if (ret < 0) {
-		WD_ERR("hisi sec init failed.\n");
-		goto out_init;
+		WD_ERR("failed to do dirver init, ret = %d.\n", ret);
+		goto out_free_priv;
 	}
+
+	wd_alg_set_init(&wd_cipher_setting.status);
 
 	return 0;
 
-out_init:
+out_free_priv:
 	free(priv);
 	wd_cipher_setting.priv = NULL;
-out_priv:
+out_clear_pool:
 	wd_uninit_async_request_pool(&wd_cipher_setting.pool);
-out_sched:
+out_clear_sched:
 	wd_clear_sched(&wd_cipher_setting.sched);
-out:
+out_clear_ctx_config:
 	wd_clear_ctx_config(&wd_cipher_setting.config);
+out_clear_init:
+	wd_alg_clear_init(&wd_cipher_setting.status);
 	return ret;
 }
 
@@ -304,6 +314,7 @@ void wd_cipher_uninit(void)
 	wd_uninit_async_request_pool(&wd_cipher_setting.pool);
 	wd_clear_sched(&wd_cipher_setting.sched);
 	wd_clear_ctx_config(&wd_cipher_setting.config);
+	wd_alg_clear_init(&wd_cipher_setting.status);
 }
 
 static void fill_request_msg(struct wd_cipher_msg *msg,

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -32,6 +32,7 @@ struct wd_dh_sess {
 };
 
 static struct wd_dh_setting {
+	enum wd_status status;
 	struct wd_ctx_config_internal config;
 	struct wd_sched sched;
 	void *sched_ctx;
@@ -78,24 +79,29 @@ void wd_dh_set_driver(struct wd_dh_driver *drv)
 int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
+	bool flag;
 	int ret;
+
+	flag = wd_alg_try_init(&wd_dh_setting.status);
+	if (!flag)
+		return 0;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_set_epoll_en("WD_DH_EPOLL_EN",
 			      &wd_dh_setting.config.epoll_en);
 	if (ret < 0)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_ctx_config(&wd_dh_setting.config, config);
 	if (ret)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_sched(&wd_dh_setting.sched, sched);
 	if (ret)
-		goto out;
+		goto out_clear_ctx_config;
 
 #ifdef WD_STATIC_DRV
 	wd_dh_set_static_drv();
@@ -106,13 +112,13 @@ int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 					 config->ctx_num, WD_POOL_MAX_ENTRIES,
 					 sizeof(struct wd_dh_msg));
 	if (ret)
-		goto out_sched;
+		goto out_clear_sched;
 
 	/* initialize ctx related resources in specific driver */
 	priv = calloc(1, wd_dh_setting.driver->drv_ctx_size);
 	if (!priv) {
 		ret = -WD_ENOMEM;
-		goto out_priv;
+		goto out_clear_pool;
 	}
 
 	wd_dh_setting.priv = priv;
@@ -120,21 +126,24 @@ int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 					 wd_dh_setting.driver->alg_name);
 	if (ret < 0) {
 		WD_ERR("failed to init dh driver, ret= %d!\n", ret);
-		goto out_init;
+		goto out_free_priv;
 	}
+
+	wd_alg_set_init(&wd_dh_setting.status);
 
 	return 0;
 
-out_init:
+out_free_priv:
 	free(priv);
 	wd_dh_setting.priv = NULL;
-out_priv:
+out_clear_pool:
 	wd_uninit_async_request_pool(&wd_dh_setting.pool);
-out_sched:
+out_clear_sched:
 	wd_clear_sched(&wd_dh_setting.sched);
-out:
+out_clear_ctx_config:
 	wd_clear_ctx_config(&wd_dh_setting.config);
-
+out_clear_init:
+	wd_alg_clear_init(&wd_dh_setting.status);
 	return ret;
 }
 
@@ -156,6 +165,7 @@ void wd_dh_uninit(void)
 	/* unset config, sched, driver */
 	wd_clear_sched(&wd_dh_setting.sched);
 	wd_clear_ctx_config(&wd_dh_setting.config);
+	wd_alg_clear_init(&wd_dh_setting.status);
 }
 
 static int fill_dh_msg(struct wd_dh_msg *msg, struct wd_dh_req *req,

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -72,6 +72,7 @@ struct wd_rsa_sess {
 };
 
 static struct wd_rsa_setting {
+	enum wd_status status;
 	struct wd_ctx_config_internal config;
 	struct wd_sched sched;
 	void *sched_ctx;
@@ -118,24 +119,29 @@ void wd_rsa_set_driver(struct wd_rsa_driver *drv)
 int wd_rsa_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	void *priv;
+	bool flag;
 	int ret;
+
+	flag = wd_alg_try_init(&wd_rsa_setting.status);
+	if (!flag)
+		return 0;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_set_epoll_en("WD_RSA_EPOLL_EN",
 			      &wd_rsa_setting.config.epoll_en);
 	if (ret < 0)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_ctx_config(&wd_rsa_setting.config, config);
 	if (ret < 0)
-		return ret;
+		goto out_clear_init;
 
 	ret = wd_init_sched(&wd_rsa_setting.sched, sched);
 	if (ret < 0)
-		goto out;
+		goto out_clear_ctx_config;
 
 #ifdef WD_STATIC_DRV
 	wd_rsa_set_static_drv();
@@ -146,13 +152,13 @@ int wd_rsa_init(struct wd_ctx_config *config, struct wd_sched *sched)
 					 config->ctx_num, WD_POOL_MAX_ENTRIES,
 					 sizeof(struct wd_rsa_msg));
 	if (ret < 0)
-		goto out_sched;
+		goto out_clear_sched;
 
 	/* initialize ctx related resources in specific driver */
 	priv = calloc(1, wd_rsa_setting.driver->drv_ctx_size);
 	if (!priv) {
 		ret = -WD_ENOMEM;
-		goto out_priv;
+		goto out_clear_pool;
 	}
 
 	wd_rsa_setting.priv = priv;
@@ -160,20 +166,24 @@ int wd_rsa_init(struct wd_ctx_config *config, struct wd_sched *sched)
 					  wd_rsa_setting.driver->alg_name);
 	if (ret < 0) {
 		WD_ERR("failed to init rsa driver, ret = %d!\n", ret);
-		goto out_init;
+		goto out_free_priv;
 	}
+
+	wd_alg_set_init(&wd_rsa_setting.status);
 
 	return 0;
 
-out_init:
+out_free_priv:
 	free(priv);
 	wd_rsa_setting.priv = NULL;
-out_priv:
+out_clear_pool:
 	wd_uninit_async_request_pool(&wd_rsa_setting.pool);
-out_sched:
+out_clear_sched:
 	wd_clear_sched(&wd_rsa_setting.sched);
-out:
+out_clear_ctx_config:
 	wd_clear_ctx_config(&wd_rsa_setting.config);
+out_clear_init:
+	wd_alg_clear_init(&wd_rsa_setting.status);
 	return ret;
 }
 
@@ -195,6 +205,7 @@ void wd_rsa_uninit(void)
 	/* unset config, sched, driver */
 	wd_clear_sched(&wd_rsa_setting.sched);
 	wd_clear_ctx_config(&wd_rsa_setting.config);
+	wd_alg_clear_init(&wd_rsa_setting.status);
 }
 
 static int fill_rsa_msg(struct wd_rsa_msg *msg, struct wd_rsa_req *req,


### PR DESCRIPTION
The current uadk initialization process is:
1.Call wd_request_ctx() to request ctxs from devices.
2.Call wd_sched_rr_alloc() to create a sched(or some other scheduler alloc
  function if exits).
3.Initialize the sched.
4.Call wd_<alg>_init() with ctx_config and sched.

Logic is reasonable. But in practice, the step of `wd_ request_ Ctx() `
and `wd_ sched_ rr_alloc() ` are very tedious. This makes it difficult
for users to use the interface. One of the main reasons for this is
that uadk has made a lot of configurations in the scheduler in order
to provide users with better performance. Based on this consideration,
the current uadk requires the user to arrange the division of hardware
resources according to the device topology during initialization.
Therefore, as a high-level interface, this scheme can provide customized
scheme configuration for users with deep needs.

All algorithm initialization interfaces have the same input parameters
and behavioral logic. The pre-processing of the wd_<alg>_init is actually
the configuration of `struct wd_ctx_config` and `struct wd_sched`.
Therefore, the next thing to be done is to use limited and easy-to-use
input parameters to describe users' requirements on the two input
parameters, ensuring that the functions of the new interface init2
are the same as those of init. For ease of description, v1 is used
to refer to the existing interface, and v2 is used to refer to the layer
of encapsulation.

At present, at least 4 parameters are required to meet the user
configuration requirements with the V1 interface function remains
unchanged.
@device_list: The available uacce device list. Users can get it by
wd_get_accel_list().
@numa_bitmask: The bitmask provided by libnuma. Users can use this
parameter to control requesting ctxs devices in the bind NUMA scenario.
@ctx_nums: The requested ctx number for each numa node. Due to users
may have different requirements for different types of ctx numbers,
needs a two-dimensional array as input.
@sched_type: Scheduling type the user wants to use.

What's more, some users want uadk to provide the default value about
input parameters for some performance insensitive scenes. C code has
no way to.