### PR TITLE
wd/sched: fix skey->type when param->numa_id < 0

### DIFF
--- a/wd_sched.c
+++ b/wd_sched.c
@@ -197,9 +197,11 @@ static handle_t session_sched_init(handle_t h_sched_ctx, void *sched_param)
 			return (handle_t)(-WD_ENOMEM);
 		}
 	} else {
-		skey->type = param->type;
 		skey->numa_id = param->numa_id;
 	}
+
+	if (param)
+		skey->type = param->type;
 
 	skey->sync_ctxid = session_sched_init_ctx(sched_ctx, skey, CTX_MODE_SYNC);
 	skey->async_ctxid = session_sched_init_ctx(sched_ctx, skey, CTX_MODE_ASYNC);


### PR DESCRIPTION
When param->numa_id < 0, skey->type is always 0.
Fixed by setting the type in both cases.

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>