### PR TITLE
doc: update release tag policy

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -92,10 +92,10 @@ any library with specified library version.
 The library version likes libNAME.so.{x}.{y}.{z}
 
 ```
-{x} stand for primary version, should change when APIs are changed which
+{x} stands for primary version that should change when APIs are changed which
     making things incompatible.
-{y} stand for sub version, accumulated for three monthes.
-{z} stand for mirror version, accumulated for each work week.
+{y} stands for sub version that is accumulated or reseted for each release.
+{z} stands for mirror version that is accumulated for each work week.
 ```
 
 
@@ -123,8 +123,37 @@ Clone kernel from [Github](https://github.com/Linaro/linux-kernel-warpdrive).
    uacce-devel-X.X. However, UADK should be alway compatible with
    former kernel versions.
 
+
+## Release Tag
+
+  The release tags is applied from October 2022. In tag description, release
+date must be mentioned. For example, the comment could be
+"Release 2.4.0 in 2022.10".
+
+
+### UADK
+
+  Release tags follow the format {primary}.{release version}.{minor}. The
+  example of release tags is in below.
+
+| Version just before Release  | Release version  | Comment  |
+|:----------|:----------|:----------|
+| 2.3.37    | 2.4.0    | Accumulate release number if API is kept stable.<br> Release name is always accumulated from the privous one. And minor version is started from 0. |
+| 2.3.37    | 3.0.0    | Reset release number if API is changed.<br> Release name is started from 0. And minor version is started from 0. |
+
+
+  If any bug fix is required after release, the new tag follows the format {primary}.{release}.{minor}-[a..z]. The example is in below.
+
+| Release version | Bugfix on Release | Comment |
+|:----------|:----------|:----------|
+| 2.4.0     | 2.4.0-a   | Apply the first patch set to fix bugs. |
+| 2.4.0-c   | 2.4.0-d   | Continue to fix bugs on release 2.4.0. |
+
+
+  At most, there're 26 fixing tags on one release.
+
 ## Main maintainers
 
-Haojian Zhuang <haojian.zhuang@linaro.org>
-Zhou Wang <wangzhou1@hisilicon.com>
+Haojian Zhuang <haojian.zhuang@linaro.org>\
+Zhou Wang <wangzhou1@hisilicon.com>\
 Longfang Liu <liulongfang@huawei.com>


### PR DESCRIPTION
Update the policy on release tag.

Each version followes the format of {x}.{y}.{z}. Make use of {y} to indiate the release. The release date must be mentioned in tag comments.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>