### PR TITLE
doc: remove build information in README

### DIFF
--- a/README
+++ b/README
@@ -31,25 +31,6 @@ include/*
 docs/*
 	Documentations.
 
-Build UADK in native environment
-
-    $ ./cleanup.sh
-
-    Make sure that all generated files could be removed.
-
-    $ ./autogen.sh
-    $ ./conf.sh
-
-    UADK could be configured as either static or dynamic library by conf.sh.
-    By default, it's configured as dynamic library.
-
-    $ make
-    $ sudo make install
-
-    Both dynamic and static libraries would be installed in /usr/local/lib
-    directory. And all head files would be installed in /usr/local/include/uadk
-    directory.
-
 ======================================
 
 The information of deploying UADK is in INSTALL file.


### PR DESCRIPTION
The detailed building instructions are listed in INTALL. And the simpler one is in README.

While user reads README, he may ignore the full version of building instructions in INSTALL. So remove the simpler one.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>