### PR TITLE
uadk: replace warpdrive with uadk

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,7 @@ UADK 2.3.11, Released Jul 9th, 2021
 
 	Offload Warpdrive WCRYPTO TRNG's DRBG/TRNG algorithms.
 
-	Support of poll in user space process as using warpdrive queues.
+	Support of poll in user space process as using queues.
 
 	Support container such as Docker with Warpdrive.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([warpdrive], [0.1], [liguozhu@hisilicon.com])
+AC_INIT([uadk], [2.3.37], [liguozhu@hisilicon.com])
 AC_CONFIG_SRCDIR([wd.c])
 AM_INIT_AUTOMAKE([1.10 no-define])
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -103,7 +103,7 @@ The library version likes libNAME.so.{x}.{y}.{z}
 
 ### Kernel Branch
 
-Clone kernel from [Github](https://github.com/Linaro/linux-kernel-warpdrive).
+Clone kernel from [Github](https://github.com/Linaro/uadk).
 
  Current working branch: uacce-devel
 

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -134,7 +134,7 @@ struct wd_cb_tag {
 	int ctx_id;	/* user id: context ID or other user identifier */
 };
 
-/* Digest tag format of warpdrive */
+/* Digest tag format */
 struct wd_digest_tag {
 	struct wd_cb_tag wd_tag;
 	__u64 long_data_len;

--- a/uadk_tool/benchmark/hpre_wd_benchmark.c
+++ b/uadk_tool/benchmark/hpre_wd_benchmark.c
@@ -549,8 +549,8 @@ void *hpre_wd_poll(void *data)
 	while (last_time) {
 		recv = wd_poll_ctx(queue, expt);
 		/*
-		 * warpdrive async mode poll easy to 100% with small package.
-		 * SEC_TST_PRT("warpdrive poll %d recv: %u!\n", i, recv);
+		 * async mode poll easy to 100% with small package.
+		 * SEC_TST_PRT("poll %d recv: %u!\n", i, recv);
 		 */
 
 		if (unlikely(recv < 0)) {

--- a/uadk_tool/benchmark/sec_wd_benchmark.c
+++ b/uadk_tool/benchmark/sec_wd_benchmark.c
@@ -527,8 +527,8 @@ void *sec_wd_poll(void *data)
 	while (last_time) {
 		recv = wd_poll_ctx(g_thread_queue.bd_res[id].queue, expt);
 		/*
-		 * warpdrive async mode poll easy to 100% with small package.
-		 * SEC_TST_PRT("warpdrive poll %d recv: %u!\n", i, recv);
+		 * async mode poll easy to 100% with small package.
+		 * SEC_TST_PRT("poll %d recv: %u!\n", i, recv);
 		 */
 		if (unlikely(recv < 0)) {
 			SEC_TST_PRT("poll ret: %u!\n", recv);

--- a/v1/wd_comp.c
+++ b/v1/wd_comp.c
@@ -113,8 +113,8 @@ static int init_comp_ctx(struct wcrypto_comp_ctx *ctx, int ctx_id,
 }
 
 /**
- * wcrypto_create_comp_ctx()- create a compress context on the warpdrive queue.
- * @q: warpdrive queue, need requested by user.
+ * wcrypto_create_comp_ctx()- create a compress context on the queue.
+ * @q: queue, need requested by user.
  * @setup: setup data of user
  */
 void *wcrypto_create_comp_ctx(struct wd_queue *q,

--- a/v1/wd_comp.h
+++ b/v1/wd_comp.h
@@ -198,7 +198,7 @@ struct wcrypto_comp_msg {
 };
 
 /**
- * The output format defined by warpdrive and drivers should fill the format
+ * The output format defined by uadk and drivers should fill the format
  * @literals_start:address of the literals data output by the hardware
  * @sequences_start:address of the sequences data output by the hardware
  * @lit_num:the size of literals


### PR DESCRIPTION
warpdrive is obsolete, replace it with uadk

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>