### PR TITLE
uadk: configure.ac openssl version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_CHECK_LIB(z, zlibVersion,
 	     [ have_zlib=false ])
 AM_CONDITIONAL([HAVE_ZLIB], [test "x$have_zlib" = "xtrue"])
 
-AC_CHECK_LIB(crypto, DH_new,
+PKG_CHECK_MODULES(libcrypto, libcrypto < 3.0 libcrypto >= 1.1,
 	     [ AC_DEFINE(HAVE_CRYPTO, 1, [Have crypto])
 	       have_crypto=true ],
 	     [ have_crypto=false ])


### PR DESCRIPTION
UADK only works with openssl 1.1.1x, so add check

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>