### PR TITLE
uadk: Replace -lcrypto with $(libcrypto_LIBS)

### DIFF
--- a/test/hisi_hpre_test/Makefile.am
+++ b/test/hisi_hpre_test/Makefile.am
@@ -12,4 +12,4 @@ test_hisi_hpre_LDADD=-L../../.libs -l:libwd.so.2 -l:libwd_crypto.so.2 \
 			-lnuma
 endif
 test_hisi_hpre_LDFLAGS=-Wl,-rpath,'/usr/local/lib'
-test_hisi_hpre_LDADD+= -lcrypto
+test_hisi_hpre_LDADD+= $(libcrypto_LIBS)

--- a/test/hisi_zip_test/Makefile.am
+++ b/test/hisi_zip_test/Makefile.am
@@ -7,10 +7,10 @@ zip_sva_perf_SOURCES=test_sva_perf.c test_lib.c	testsuit.c
 
 if WD_STATIC_DRV
 zip_sva_perf_LDADD=../../.libs/libwd.a ../../.libs/libwd_comp.a \
-		    ../../.libs/libhisi_zip.a -lpthread -lnuma -lcrypto
+		    ../../.libs/libhisi_zip.a -lpthread -lnuma $(libcrypto_LIBS)
 else
 zip_sva_perf_LDADD=-L../../.libs -l:libwd.so.2 -l:libwd_comp.so.2 \
-		   -lpthread -lnuma -lcrypto
+		   -lpthread -lnuma $(libcrypto_LIBS)
 endif
 zip_sva_perf_LDFLAGS=-Wl,-rpath,'/usr/local/lib'
 

--- a/uadk_tool/Makefile.am
+++ b/uadk_tool/Makefile.am
@@ -39,5 +39,5 @@ endif
 
 if HAVE_CRYPTO
 uadk_tool_SOURCES+=benchmark/sec_soft_benchmark.c benchmark/sec_soft_benchmark.h
-uadk_tool_LDADD+=-lcrypto
+uadk_tool_LDADD+=$(libcrypto_LIBS)
 endif


### PR DESCRIPTION
Only -lcrypto may fail since no -L

Instead, we can use
$(libcrypto_LIBS): -L/usr/local/lib -lcrypto
$(libcrypto_MOCKA_CFLAGS): -I/usr/local/include

configure.ac
PKG_CHECK_MODULES(libcrypto)

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>