### PR TITLE
v1: fix make distclean

### DIFF
--- a/v1/test/hisi_zip_test/Makefile.am
+++ b/v1/test/hisi_zip_test/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS=-Wall -O0 -fno-strict-aliasing -I$(top_srcdir)/v1 -I$(srcdir)/v1/test 
 AUTOMAKE_OPTIONS = subdir-objects
 bin_PROGRAMS=test_hisi_zip test_hisi_zlib wd_zip_test wd_zip_test_1630 test_hisi_zip_perf
 
-test_hisi_zip_SOURCES=test_hisi_zip.c ../wd_sched.c ../smm.c
+test_hisi_zip_SOURCES=test_hisi_zip.c ../wd_sched.c
 if WD_STATIC_DRV
 test_hisi_zip_LDADD=../../../.libs/libwd.a
 else

--- a/v1/test/hisi_zip_test/test_hisi_zip.c
+++ b/v1/test/hisi_zip_test/test_hisi_zip.c
@@ -30,6 +30,7 @@
 #include <pthread.h>
 #include <sched.h>
 #include "v1/wd_comp.h"
+#include "../smm.c"
 
 #define SYS_ERR_COND(cond, msg, ...) \
 do { \

--- a/v1/test/hisi_zip_test_sgl/Makefile.am
+++ b/v1/test/hisi_zip_test_sgl/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS=-Wall -O0 -fno-strict-aliasing -I$(top_srcdir)/v1 -I$(top_srcdir) -I$(
 AUTOMAKE_OPTIONS = subdir-objects
 bin_PROGRAMS=wd_zip_test_sgl sgl_test
 
-wd_zip_test_sgl_SOURCES=wd_zip_test_sgl.c zip_alg_sgl.c ../smm.c zip_alg_sgl.h wd_sched_sgl.c wd_sched_sgl.h
+wd_zip_test_sgl_SOURCES=wd_zip_test_sgl.c zip_alg_sgl.c zip_alg_sgl.h wd_sched_sgl.c wd_sched_sgl.h
 sgl_test_SOURCES=sgl_test.c sgl_test.h
 
 if WD_STATIC_DRV

--- a/v1/test/hisi_zip_test_sgl/wd_zip_test_sgl.c
+++ b/v1/test/hisi_zip_test_sgl/wd_zip_test_sgl.c
@@ -29,6 +29,7 @@
 #include "../../wd_comp.h"
 #include "../../wd_sgl.h"
 #include "../smm.h"
+#include "../smm.c"
 
 #ifdef DEBUG_LOG
 #define dbg(msg, ...) fprintf(stderr, msg, ##__VA_ARGS__)


### PR DESCRIPTION
Both hisi_zip_test and hisi_zip_test_sgl use ../smm.c, which blocks make distclean.
Fixed by #include "../smm.c" in each file.

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>