### PR TITLE
Add dynamic driver loading function

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ AM_CFLAGS+= -DUADK_RELEASED_TIME="\"Released ${MONTH} ${DAY}, ${YEAR}\""
 pkginclude_HEADERS = include/wd.h include/wd_cipher.h include/wd_aead.h \
 		  include/wd_comp.h include/wd_dh.h include/wd_digest.h \
 		  include/wd_rsa.h  include/uacce.h include/wd_alg_common.h \
-		  include/wd_ecc.h include/wd_sched.h
+		  include/wd_ecc.h include/wd_sched.h include/wd_alg.h
 
 nobase_pkginclude_HEADERS = v1/wd.h v1/wd_cipher.h v1/wd_aead.h v1/uacce.h v1/wd_dh.h \
 			 v1/wd_digest.h v1/wd_rsa.h v1/wd_bmm.h
@@ -41,7 +41,7 @@ nobase_pkginclude_HEADERS = v1/wd.h v1/wd_cipher.h v1/wd_aead.h v1/uacce.h v1/wd
 lib_LTLIBRARIES=libwd.la libwd_comp.la libwd_crypto.la libhisi_zip.la \
 		libhisi_hpre.la libhisi_sec.la
 
-libwd_la_SOURCES=wd.c wd_mempool.c wd.h		\
+libwd_la_SOURCES=wd.c wd_mempool.c wd.h	wd_alg.c wd_alg.h	\
 		 v1/wd.c v1/wd.h v1/wd_adapter.c v1/wd_adapter.h \
 		 v1/wd_rng.c v1/wd_rng.h	\
 		 v1/wd_rsa.c v1/wd_rsa.h	\

--- a/include/drv/wd_comp_drv.h
+++ b/include/drv/wd_comp_drv.h
@@ -55,34 +55,7 @@ struct wd_comp_msg {
 	__u32 tag;
 };
 
-struct wd_comp_driver {
-	const char *drv_name;
-	const char *alg_name;
-	__u32 drv_ctx_size;
-	int (*init)(struct wd_ctx_config_internal *config, void *priv);
-	void (*exit)(void *priv);
-	int (*comp_send)(handle_t ctx, void *comp_msg);
-	int (*comp_recv)(handle_t ctx, void *comp_msg);
-};
-
-void wd_comp_set_driver(struct wd_comp_driver *drv);
-struct wd_comp_driver *wd_comp_get_driver(void);
-
 struct wd_comp_msg *wd_comp_get_msg(__u32 idx, __u32 tag);
-
-#ifdef WD_STATIC_DRV
-#define WD_COMP_SET_DRIVER(drv)						      \
-struct wd_comp_driver *wd_comp_get_driver(void)				      \
-{									      \
-	return &drv;							      \
-}
-#else
-#define WD_COMP_SET_DRIVER(drv)						      \
-static void __attribute__((constructor)) set_comp_driver(void)		      \
-{									      \
-	wd_comp_set_driver(&(drv));					      \
-}
-#endif
 
 #ifdef __cplusplus
 }

--- a/include/wd.h
+++ b/include/wd.h
@@ -29,6 +29,7 @@ extern "C" {
 #define LINUX_PRTDIR_SIZE		2
 #define WD_CTX_CNT_NUM			1024
 #define WD_IPC_KEY			0x500011
+#define CRYPTO_MAX_ALG_NAME		128
 
 /* Required compiler attributes */
 #define likely(x)       __builtin_expect(!!(x), 1)
@@ -577,6 +578,17 @@ bool wd_need_debug(void);
  * wd_need_info() - Get the info flag from rsyslog.cnf
  */
 bool wd_need_info(void);
+
+struct wd_capability {
+	char	alg_name[CRYPTO_MAX_ALG_NAME];
+	char	drv_name[CRYPTO_MAX_ALG_NAME];
+	int	priority;
+
+	struct wd_capability *next;
+};
+
+struct wd_capability *wd_get_alg_cap(void);
+void wd_release_alg_cap(struct wd_capability *head);
 
 #ifdef __cplusplus
 }

--- a/include/wd_alg.h
+++ b/include/wd_alg.h
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright 2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ */
+
+#ifndef __WD_ALG_H
+#define __WD_ALG_H
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <asm/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define handle_t uintptr_t
+enum alg_priority {
+	UADK_ALG_SOFT = 0x0,
+	UADK_ALG_CE_INSTR     = 0x1,
+	UADK_ALG_SVE_INSTR     = 0x2,
+	UADK_ALG_HW    = 0x3
+};
+
+/*
+ * @drv_name: name of the current device driver
+ * @alg_name: name of the algorithm supported by the driver
+ * @priority: priority of the type of algorithm supported by the driver
+ * @queue_num: number of device queues required by the device to
+ *		 execute the algorithm business
+ * @op_type_num: number of modes in which the device executes the
+ *		 algorithm business and requires queues to be executed separately
+ * @priv_size: parameter memory size passed between the internal
+ *		 interfaces of the driver
+ * @fallback: soft calculation driver handle when performing soft
+ *		 calculation supplement
+ * @init: callback interface for initializing device drivers
+ * @exit: callback interface for destroying device drivers
+ * @send: callback interface used to send task packets to
+ *	    hardware devices.
+ * @recv: callback interface used to retrieve the calculation
+ *	    result of the task   packets from the hardware device.
+ * @get_usage: callback interface used to obtain the
+ *	    utilization rate of hardware devices.
+ */
+struct wd_alg_driver {
+	const char	*drv_name;
+	const char	*alg_name;
+	int	priority;
+	int	queue_num;
+	int	op_type_num;
+	int	priv_size;
+	handle_t fallback;
+
+	int (*init)(void *conf, void *priv);
+	void (*exit)(void *priv);
+	int (*send)(handle_t ctx, void *drv_msg);
+	int (*recv)(handle_t ctx, void *drv_msg);
+	int  (*get_usage)(void *param);
+};
+
+int wd_alg_driver_register(struct wd_alg_driver *drv);
+void wd_alg_driver_unregister(struct wd_alg_driver *drv);
+
+struct wd_alg_list {
+	const char	*alg_name;
+	const char	*drv_name;
+	int	priority;
+	bool	available;
+	int	refcnt;
+
+	struct wd_alg_driver *drv;
+	struct wd_alg_list *next;
+};
+
+struct wd_alg_driver *wd_request_drv(const char	*alg_name, bool hw_mask);
+void wd_release_drv(struct wd_alg_driver *drv);
+
+bool wd_drv_alg_support(const char *alg_name,
+	struct wd_alg_driver *drv);
+void wd_enable_drv(struct wd_alg_driver *drv);
+void wd_disable_drv(struct wd_alg_driver *drv);
+
+struct wd_alg_list *wd_get_alg_head(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -10,6 +10,7 @@
 #include <pthread.h>
 #include <stdbool.h>
 #include "wd.h"
+#include "wd_alg.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -28,6 +28,13 @@ extern "C" {
 #define CTX_TYPE_INVALID	9999
 #define POLL_TIME		1000
 
+enum alg_task_type {
+	TASK_MIX = 0x0,
+	TASK_HW,
+	TASK_INSTR,
+	TASK_MAX_TYPE,
+};
+
 enum wd_ctx_mode {
 	CTX_MODE_SYNC = 0,
 	CTX_MODE_ASYNC,
@@ -129,6 +136,9 @@ struct wd_sched {
 	int (*poll_policy)(handle_t h_sched_ctx, __u32 expect, __u32 *count);
 	handle_t h_sched_ctx;
 };
+
+typedef int (*wd_alg_init)(struct wd_ctx_config *config, struct wd_sched *sched);
+typedef int (*wd_alg_poll_ctx)(__u32 idx, __u32 expt, __u32 *count);
 
 struct wd_datalist {
 	void *data;

--- a/include/wd_sched.h
+++ b/include/wd_sched.h
@@ -18,7 +18,11 @@ extern "C" {
 enum sched_policy_type {
 	/* requests will be sent to ctxs one by one */
 	SCHED_POLICY_RR = 0,
-	SCHED_POLICY_BUTT
+	/* requests will no need ctxs */
+	SCHED_POLICY_NONE,
+	/* requests will   need a fixed ctx */
+	SCHED_POLICY_SINGLE,
+	SCHED_POLICY_BUTT,
 };
 
 struct sched_params {

--- a/libwd.map
+++ b/libwd.map
@@ -41,5 +41,13 @@ global:
 	wd_add_dev_to_list;
 	wd_find_dev_by_numa;
 
+	wd_alg_driver_register;
+	wd_alg_driver_unregister;
+	wd_request_drv;
+	wd_release_drv;
+	wd_drv_alg_support;
+	wd_enable_drv;
+	wd_disable_drv;
+	wd_get_alg_head;
 local: *;
 };

--- a/wd_alg.c
+++ b/wd_alg.c
@@ -1,0 +1,265 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright 2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ */
+
+#define _GNU_SOURCE
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include "wd.h"
+#include "wd_alg.h"
+
+#define SYS_CLASS_DIR			"/sys/class/uacce"
+static struct wd_alg_list alg_list_head;
+static struct wd_alg_list *alg_list_tail = &alg_list_head;
+
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static bool wd_check_accel_dev(const char *drv_name)
+{
+	struct dirent *dev_dir;
+	DIR *wd_class;
+
+	wd_class = opendir(SYS_CLASS_DIR);
+	if (!wd_class) {
+		WD_ERR("UADK framework isn't enabled in system!\n");
+		return NULL;
+	}
+
+	while ((dev_dir = readdir(wd_class)) != NULL) {
+		if (!strncmp(dev_dir->d_name, ".", LINUX_CRTDIR_SIZE) ||
+		     !strncmp(dev_dir->d_name, "..", LINUX_PRTDIR_SIZE))
+			continue;
+
+		if (!strncmp(dev_dir->d_name, drv_name, strlen(drv_name))) {
+			closedir(wd_class);
+			return true;
+		}
+	}
+	closedir(wd_class);
+
+	return false;
+}
+
+int wd_alg_driver_register(struct wd_alg_driver *drv)
+{
+	struct wd_alg_list *new_alg;
+
+	if (!drv) {
+		WD_ERR("invalid: register drv is NULL!\n");
+		return -WD_EINVAL;
+	}
+
+	new_alg = calloc(1, sizeof(struct wd_alg_list));
+	if (!new_alg) {
+		WD_ERR("failed to alloc alg driver memory!\n");
+		return -WD_ENOMEM;
+	}
+
+	new_alg->alg_name = drv->alg_name;
+	new_alg->drv_name = drv->drv_name;
+	new_alg->priority = drv->priority;
+	new_alg->drv = drv;
+	new_alg->refcnt = 0;
+	new_alg->next = NULL;
+
+	if (drv->priority == UADK_ALG_HW) {
+		/* If not find dev, remove this driver node */
+		new_alg->available = wd_check_accel_dev(drv->drv_name);
+		if (!new_alg->available) {
+			free(new_alg);
+			WD_ERR("failed to find alg driver's device!\n");
+			return -WD_ENODEV;
+		}
+	} else {
+		/* Should find the CPU if not support SVE or CE */
+		new_alg->available = true;
+	}
+
+	pthread_mutex_lock(&mutex);
+	alg_list_tail->next = new_alg;
+	alg_list_tail = new_alg;
+	pthread_mutex_unlock(&mutex);
+
+	return 0;
+}
+
+void wd_alg_driver_unregister(struct wd_alg_driver *drv)
+{
+	struct wd_alg_list *npre = &alg_list_head;
+	struct wd_alg_list *pnext = npre->next;
+
+	/* Alg driver list has no drivers */
+	if (!pnext || !drv)
+		return;
+
+	pthread_mutex_lock(&mutex);
+	while (pnext) {
+		if (!strcmp(drv->alg_name, pnext->alg_name) &&
+		     !strcmp(drv->drv_name, pnext->drv_name) &&
+		     drv->priority == pnext->priority) {
+			break;
+		}
+		npre = pnext;
+		pnext = pnext->next;
+	}
+
+	/* The current algorithm is not registered */
+	if (!pnext) {
+		pthread_mutex_unlock(&mutex);
+		return;
+	}
+
+	/* Used to locate the problem and ensure symmetrical use driver */
+	if (pnext->refcnt > 0)
+		WD_ERR("driver<%s> still in used: %d\n", pnext->drv_name, pnext->refcnt);
+
+	if (pnext == alg_list_tail)
+		alg_list_tail = npre;
+
+	npre->next = pnext->next;
+	free(pnext);
+	pthread_mutex_unlock(&mutex);
+}
+
+struct wd_alg_list *wd_get_alg_head(void)
+{
+	return &alg_list_head;
+}
+
+bool wd_drv_alg_support(const char *alg_name,
+	struct wd_alg_driver *drv)
+{
+	struct wd_alg_list *head = &alg_list_head;
+	struct wd_alg_list *pnext = head->next;
+
+	while (pnext) {
+		if (!strcmp(alg_name, pnext->alg_name) &&
+		     !strcmp(drv->drv_name, pnext->drv_name)) {
+			return true;
+		}
+		pnext = pnext->next;
+	}
+
+	return false;
+}
+
+void wd_enable_drv(struct wd_alg_driver *drv)
+{
+	struct wd_alg_list *head = &alg_list_head;
+	struct wd_alg_list *pnext = head->next;
+
+	if (!pnext || !drv)
+		return;
+
+	pthread_mutex_lock(&mutex);
+	while (pnext) {
+		if (!strcmp(drv->alg_name, pnext->alg_name) &&
+		     !strcmp(drv->drv_name, pnext->drv_name) &&
+		     drv->priority == pnext->priority) {
+			break;
+		}
+		pnext = pnext->next;
+	}
+
+	if (drv->priority == UADK_ALG_HW) {
+		/* If not find dev, remove this driver node */
+		pnext->available = wd_check_accel_dev(drv->drv_name);
+	} else {
+		/* Should find the CPU if not support SVE or CE */
+		pnext->available = true;
+	}
+	pthread_mutex_unlock(&mutex);
+}
+
+void wd_disable_drv(struct wd_alg_driver *drv)
+{
+	struct wd_alg_list *head = &alg_list_head;
+	struct wd_alg_list *pnext = head->next;
+
+	if (!pnext || !drv)
+		return;
+
+	pthread_mutex_lock(&mutex);
+	while (pnext) {
+		if (!strcmp(drv->alg_name, pnext->alg_name) &&
+		     !strcmp(drv->drv_name, pnext->drv_name) &&
+		     drv->priority == pnext->priority) {
+			break;
+		}
+		pnext = pnext->next;
+	}
+
+	pnext->available = false;
+	pthread_mutex_unlock(&mutex);
+}
+
+struct wd_alg_driver *wd_request_drv(const char *alg_name, bool hw_mask)
+{
+	struct wd_alg_list *head = &alg_list_head;
+	struct wd_alg_list *pnext = head->next;
+	struct wd_alg_list *select_node = NULL;
+	struct wd_alg_driver *drv = NULL;
+	int tmp_priority = -1;
+
+	if (!pnext || !alg_name) {
+		WD_ERR("invalid: request alg param is error!\n");
+		return NULL;
+	}
+
+	/* Check the list to get an best driver */
+	pthread_mutex_lock(&mutex);
+	while (pnext) {
+		/* hw_mask true mean not to used hardware dev */
+		if (hw_mask && pnext->drv->priority == UADK_ALG_HW) {
+			pnext = pnext->next;
+			continue;
+		}
+
+		if (!strcmp(alg_name, pnext->alg_name) && pnext->available &&
+		      pnext->drv->priority > tmp_priority) {
+			tmp_priority = pnext->drv->priority;
+			select_node = pnext;
+			drv = pnext->drv;
+		}
+		pnext = pnext->next;
+	}
+
+	if (select_node)
+		select_node->refcnt++;
+	pthread_mutex_unlock(&mutex);
+
+	return drv;
+}
+
+void wd_release_drv(struct wd_alg_driver *drv)
+{
+	struct wd_alg_list *head = &alg_list_head;
+	struct wd_alg_list *pnext = head->next;
+	struct wd_alg_list *select_node = NULL;
+
+	if (!pnext || !drv)
+		return;
+
+	pthread_mutex_lock(&mutex);
+	while (pnext) {
+		if (!strcmp(drv->alg_name, pnext->alg_name) &&
+			!strcmp(drv->drv_name, pnext->drv_name) &&
+			drv->priority == pnext->priority) {
+			select_node = pnext;
+			break;
+		}
+		pnext = pnext->next;
+	}
+
+	if (select_node && select_node->refcnt > 0)
+		select_node->refcnt--;
+	pthread_mutex_unlock(&mutex);
+}
+

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -230,7 +230,7 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 	wd_comp_sched->name = SCHED_RR_NAME;
 	wd_comp_init_attrs.sched = wd_comp_sched;
 
-	ret = wd_alg_pre_init(&wd_comp_init_attrs);
+	ret = wd_alg_attrs_init(&wd_comp_init_attrs);
 	if (ret)
 		goto out_freesched;
 


### PR DESCRIPTION
Update the current driver adaptation and usage method, from fixed
use of Hisilicon device driver to automatic registration of the
driver according to the algorithm.

When the algorithm API layer uses the driver, it is no longer
bound to the fixed device driver, but dynamically obtained
and stored according to the algorithm query to use.

Update the driver and API layer of the zip module, keep the
function of the init interface unchanged, update the implementation
of the init2 interface and match the dynamic loading function.