### PR TITLE
wd: Fix GCC 12 build issue

### DIFF
--- a/wd.c
+++ b/wd.c
@@ -190,7 +190,7 @@ int wd_is_isolate(struct uacce_dev *dev)
 	int value = 0;
 	int ret;
 
-	if (!dev || !dev->dev_root)
+	if (!dev || !strlen(dev->dev_root))
 		return -WD_EINVAL;
 
 	ret = access_attr(dev->dev_root, "isolate", F_OK);


### PR DESCRIPTION
Build errors happen with GCC 12

wd.c: In function 'wd_is_isolate':
wd.c:193:21: error: the comparison will always evaluate as 'true' for the address of 'dev_root' will never be NULL [-Werror=address]
  193 |         if (!dev || !dev->dev_root)
        |                     ^
	In file included from wd.c:21:
	./include/wd.h:131:14: note: 'dev_root' declared here
	  131 |         char dev_root[PATH_STR_SIZE];
	        |              ^~~~~~~~
		cc1: all warnings being treated as errors
		make[1]: *** [Makefile:816: wd.lo] Error 1

Fix by using strlen(dev->dev_root).

Signed-off-by: Thomas Monjalon <thomas@monjalon.net>
Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>