### PR TITLE
uadk: wd_get_usable_list failed to get usable devices in guest

### DIFF
--- a/wd_util.c
+++ b/wd_util.c
@@ -2249,6 +2249,8 @@ struct uacce_dev_list *wd_get_usable_list(struct uacce_dev_list *list, struct bi
 	p = list;
 	while (p) {
 		dev = p->dev;
+		if (dev->numa_id < 0)
+			dev->numa_id = 0;
 		numa_id = dev->numa_id;
 		ret = numa_bitmask_isbitset(bmp, numa_id);
 		if (!ret) {


### PR DESCRIPTION
In guest, device numa id is -1, causing wd_get_usable_list failed to get usable devices

cat /sys/class/uacce/hisi_sec2-0/device/numa_node
-1

uadk_tool test --m sec --digest 0 --sync --optype 0 --pktlen 16 \
	--keylen 16 --times 1 --multi 1 --init 2
failed to get usable devices(-19)!

Fixed by change numa_id to 0 in such case