### PR TITLE
uadk: driver alloc and free resources by itself

### DIFF
--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -497,60 +497,90 @@ out:
 	return -WD_EINVAL;
 }
 
-static int hpre_rsa_dh_init(void *conf, void *priv)
+static int hpre_rsa_dh_init(struct wd_alg_driver *drv, void *conf)
 {
 	struct wd_ctx_config_internal *config = (struct wd_ctx_config_internal *)conf;
-	struct hisi_hpre_ctx *hpre_ctx = (struct hisi_hpre_ctx *)priv;
+	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
 	struct hisi_qm_priv qm_priv;
 	int ret;
+
+	if (priv) {
+		/* return if already inited */
+		return 0;
+	}
 
 	if (!config->ctx_num) {
 		WD_ERR("invalid: hpre rsa/dh init config ctx num is 0!\n");
 		return -WD_EINVAL;
 	}
 
+	drv->priv = malloc(sizeof(struct hisi_hpre_ctx));
+	if (!drv->priv)
+		return -WD_EINVAL;
+
 	qm_priv.op_type = HPRE_HW_V2_ALG_TYPE;
-	ret = hpre_init_qm_priv(config, hpre_ctx, &qm_priv);
-	if (ret)
+	ret = hpre_init_qm_priv(config, drv->priv, &qm_priv);
+	if (ret) {
+		free(drv->priv);
 		return ret;
+	}
 
 	return 0;
 }
 
-static int hpre_ecc_init(void *conf, void *priv)
+static int hpre_ecc_init(struct wd_alg_driver *drv, void *conf)
 {
 	struct wd_ctx_config_internal *config = (struct wd_ctx_config_internal *)conf;
-	struct hisi_hpre_ctx *hpre_ctx = (struct hisi_hpre_ctx *)priv;
+	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
 	struct hisi_qm_priv qm_priv;
 	int ret;
+
+	if (priv) {
+		/* return if already inited */
+		return 0;
+	}
 
 	if (!config->ctx_num) {
 		WD_ERR("invalid: hpre ecc init config ctx num is 0!\n");
 		return -WD_EINVAL;
 	}
 
+	drv->priv = malloc(sizeof(struct hisi_hpre_ctx));
+	if (!drv->priv)
+		return -WD_EINVAL;
+
 	qm_priv.op_type = HPRE_HW_V3_ECC_ALG_TYPE;
-	ret = hpre_init_qm_priv(config, hpre_ctx, &qm_priv);
-	if (ret)
+	ret = hpre_init_qm_priv(config, drv->priv, &qm_priv);
+	if (ret) {
+		free(drv->priv);
 		return ret;
+	}
 
 	return 0;
 }
 
-static void hpre_exit(void *priv)
+static void hpre_exit(struct wd_alg_driver *drv)
 {
-	struct hisi_hpre_ctx *hpre_ctx = (struct hisi_hpre_ctx *)priv;
-	struct wd_ctx_config_internal *config = &hpre_ctx->config;
+	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
+	struct wd_ctx_config_internal *config = &priv->config;
 	handle_t h_qp;
 	__u32 i;
+
+	if (!priv) {
+		/* return if already exit */
+		return;
+	}
 
 	for (i = 0; i < config->ctx_num; i++) {
 		h_qp = (handle_t)wd_ctx_get_priv(config->ctxs[i].ctx);
 		hisi_qm_free_qp(h_qp);
 	}
+
+	free(priv);
+	drv->priv = NULL;
 }
 
-static int rsa_send(handle_t ctx, void *rsa_msg)
+static int rsa_send(struct wd_alg_driver *drv, handle_t ctx, void *rsa_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_rsa_msg *msg = rsa_msg;
@@ -606,7 +636,7 @@ static void hpre_result_check(struct hisi_hpre_sqe *hw_msg,
 	}
 }
 
-static int rsa_recv(handle_t ctx, void *rsa_msg)
+static int rsa_recv(struct wd_alg_driver *drv, handle_t ctx, void *rsa_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
@@ -704,7 +734,7 @@ static int dh_out_transfer(struct wd_dh_msg *msg,
 	return WD_SUCCESS;
 }
 
-static int dh_send(handle_t ctx, void *dh_msg)
+static int dh_send(struct wd_alg_driver *drv, handle_t ctx, void *dh_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_dh_msg *msg = dh_msg;
@@ -749,7 +779,7 @@ static int dh_send(handle_t ctx, void *dh_msg)
 	return hisi_qm_send(h_qp, &hw_msg, 1, &send_cnt);
 }
 
-static int dh_recv(handle_t ctx, void *dh_msg)
+static int dh_recv(struct wd_alg_driver *drv, handle_t ctx, void *dh_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
@@ -1840,7 +1870,7 @@ free_dst:
 	return ret;
 }
 
-static int ecc_send(handle_t ctx, void *ecc_msg)
+static int ecc_send(struct wd_alg_driver *drv, handle_t ctx, void *ecc_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_ecc_msg *msg = ecc_msg;
@@ -2412,7 +2442,7 @@ fail:
 	return ret;
 }
 
-static int ecc_recv(handle_t ctx, void *ecc_msg)
+static int ecc_recv(struct wd_alg_driver *drv, handle_t ctx, void *ecc_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_ecc_msg *msg = ecc_msg;
@@ -2449,7 +2479,6 @@ static int hpre_get_usage(void *param)
 	.alg_name = (hpre_alg_name),\
 	.calc_type = UADK_ALG_HW,\
 	.priority = 100,\
-	.priv_size = sizeof(struct hisi_hpre_ctx),\
 	.queue_num = HPRE_CTX_Q_NUM_DEF,\
 	.op_type_num = 1,\
 	.fallback = 0,\
@@ -2473,7 +2502,6 @@ static struct wd_alg_driver hpre_rsa_driver = {
 	.alg_name = "rsa",
 	.calc_type = UADK_ALG_HW,
 	.priority = 100,
-	.priv_size = sizeof(struct hisi_hpre_ctx),
 	.queue_num = HPRE_CTX_Q_NUM_DEF,
 	.op_type_num = 1,
 	.fallback = 0,
@@ -2489,7 +2517,6 @@ static struct wd_alg_driver hpre_dh_driver = {
 	.alg_name = "dh",
 	.calc_type = UADK_ALG_HW,
 	.priority = 100,
-	.priv_size = sizeof(struct hisi_hpre_ctx),
 	.queue_num = HPRE_CTX_Q_NUM_DEF,
 	.op_type_num = 1,
 	.fallback = 0,

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -534,8 +534,8 @@ static __u32 g_sec_hmac_full_len[WD_DIGEST_TYPE_MAX] = {
 	SEC_HMAC_SHA512_MAC_LEN, SEC_HMAC_SHA512_224_MAC_LEN, SEC_HMAC_SHA512_256_MAC_LEN
 };
 
-static int hisi_sec_init(void *conf, void *priv);
-static void hisi_sec_exit(void *priv);
+static int hisi_sec_init(struct wd_alg_driver *drv, void *conf);
+static void hisi_sec_exit(struct wd_alg_driver *drv);
 
 static int hisi_sec_get_usage(void *param)
 {
@@ -548,7 +548,6 @@ static int hisi_sec_get_usage(void *param)
 	.alg_name = (sec_alg_name),\
 	.calc_type = UADK_ALG_HW,\
 	.priority = 100,\
-	.priv_size = sizeof(struct hisi_sec_ctx),\
 	.queue_num = SEC_CTX_Q_NUM_DEF,\
 	.op_type_num = 1,\
 	.fallback = 0,\
@@ -1091,7 +1090,7 @@ static int fill_cipher_bd2(struct wd_cipher_msg *msg, struct hisi_sec_sqe *sqe)
 	return 0;
 }
 
-int hisi_sec_cipher_send(handle_t ctx, void *cipher_msg)
+int hisi_sec_cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_cipher_msg *msg = cipher_msg;
@@ -1136,7 +1135,7 @@ int hisi_sec_cipher_send(handle_t ctx, void *cipher_msg)
 	return 0;
 }
 
-int hisi_sec_cipher_recv(handle_t ctx, void *cipher_msg)
+int hisi_sec_cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_cipher_msg *recv_msg = cipher_msg;
@@ -1290,7 +1289,7 @@ static int fill_cipher_bd3(struct wd_cipher_msg *msg, struct hisi_sec_sqe3 *sqe)
 	return 0;
 }
 
-int hisi_sec_cipher_send_v3(handle_t ctx, void *cipher_msg)
+int hisi_sec_cipher_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_cipher_msg *msg = cipher_msg;
@@ -1380,7 +1379,7 @@ static void parse_cipher_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		dump_sec_msg(temp_msg, "cipher");
 }
 
-int hisi_sec_cipher_recv_v3(handle_t ctx, void *cipher_msg)
+int hisi_sec_cipher_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_cipher_msg *recv_msg = cipher_msg;
@@ -1651,7 +1650,7 @@ static int digest_len_check(struct wd_digest_msg *msg,  enum sec_bd_type type)
 	return 0;
 }
 
-int hisi_sec_digest_send(handle_t ctx, void *digest_msg)
+int hisi_sec_digest_send(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_digest_msg *msg = digest_msg;
@@ -1718,7 +1717,7 @@ put_sgl:
 	return ret;
 }
 
-int hisi_sec_digest_recv(handle_t ctx, void *digest_msg)
+int hisi_sec_digest_recv(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_digest_msg *recv_msg = digest_msg;
@@ -1895,7 +1894,7 @@ static void fill_digest_v3_scene(struct hisi_sec_sqe3 *sqe,
 	sqe->bd_param |= (__u16)(de | scene);
 }
 
-int hisi_sec_digest_send_v3(handle_t ctx, void *digest_msg)
+int hisi_sec_digest_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_digest_msg *msg = digest_msg;
@@ -1994,7 +1993,7 @@ static void parse_digest_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		dump_sec_msg(temp_msg, "digest");
 }
 
-int hisi_sec_digest_recv_v3(handle_t ctx, void *digest_msg)
+int hisi_sec_digest_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_digest_msg *recv_msg = digest_msg;
@@ -2466,7 +2465,7 @@ int aead_msg_state_check(struct wd_aead_msg *msg)
 	return 0;
 }
 
-int hisi_sec_aead_send(handle_t ctx, void *aead_msg)
+int hisi_sec_aead_send(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_aead_msg *msg = aead_msg;
@@ -2588,7 +2587,7 @@ static bool soft_compute_check(struct hisi_qp *qp, struct wd_aead_msg *msg)
 		qp->q_info.qp_mode == CTX_MODE_SYNC;
 }
 
-int hisi_sec_aead_recv(handle_t ctx, void *aead_msg)
+int hisi_sec_aead_recv(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_aead_msg *recv_msg = aead_msg;
@@ -2850,7 +2849,7 @@ static int fill_aead_bd3(struct wd_aead_msg *msg, struct hisi_sec_sqe3 *sqe)
 	return 0;
 }
 
-int hisi_sec_aead_send_v3(handle_t ctx, void *aead_msg)
+int hisi_sec_aead_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_aead_msg *msg = aead_msg;
@@ -2950,7 +2949,7 @@ static void parse_aead_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		dump_sec_msg(temp_msg, "aead");
 }
 
-int hisi_sec_aead_recv_v3(handle_t ctx, void *aead_msg)
+int hisi_sec_aead_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct wd_aead_msg *recv_msg = aead_msg;
@@ -3022,19 +3021,28 @@ static void hisi_sec_driver_adapter(struct hisi_qp *qp)
 	}
 }
 
-static int hisi_sec_init(void *conf, void *priv)
+static int hisi_sec_init(struct wd_alg_driver *drv, void *conf)
 {
+	struct hisi_sec_ctx *priv = (struct hisi_sec_ctx *)drv->priv;
 	struct wd_ctx_config_internal *config = conf;
-	struct hisi_sec_ctx *sec_ctx = priv;
 	struct hisi_qm_priv qm_priv;
 	handle_t h_qp = 0;
 	handle_t h_ctx;
 	__u32 i, j;
 
+	if (priv) {
+		/* return if already inited */
+		return 0;
+	}
+
 	if (!config->ctx_num) {
 		WD_ERR("invalid: sec init config ctx num is 0!\n");
 		return -WD_EINVAL;
 	}
+
+	priv = malloc(sizeof(struct hisi_sec_ctx));
+	if (!priv)
+		return -WD_EINVAL;
 
 	qm_priv.sqe_size = sizeof(struct hisi_sec_sqe);
 	/* allocate qp for each context */
@@ -3052,8 +3060,9 @@ static int hisi_sec_init(void *conf, void *priv)
 			goto out;
 		config->ctxs[i].sqn = qm_priv.sqn;
 	}
-	memcpy(&sec_ctx->config, config, sizeof(struct wd_ctx_config_internal));
+	memcpy(&priv->config, config, sizeof(struct wd_ctx_config_internal));
 	hisi_sec_driver_adapter((struct hisi_qp *)h_qp);
+	drv->priv = priv;
 
 	return 0;
 
@@ -3062,26 +3071,29 @@ out:
 		h_qp = (handle_t)wd_ctx_get_priv(config->ctxs[j].ctx);
 		hisi_qm_free_qp(h_qp);
 	}
+	free(priv);
 	return -WD_EINVAL;
 }
 
-static void hisi_sec_exit(void *priv)
+static void hisi_sec_exit(struct wd_alg_driver *drv)
 {
-	struct hisi_sec_ctx *sec_ctx = priv;
+	struct hisi_sec_ctx *priv = (struct hisi_sec_ctx *)drv->priv;
 	struct wd_ctx_config_internal *config;
 	handle_t h_qp;
 	__u32 i;
 
 	if (!priv) {
-		WD_ERR("invalid: input parameter is NULL!\n");
+		/* return if already exit */
 		return;
 	}
 
-	config = &sec_ctx->config;
+	config = &priv->config;
 	for (i = 0; i < config->ctx_num; i++) {
 		h_qp = (handle_t)wd_ctx_get_priv(config->ctxs[i].ctx);
 		hisi_qm_free_qp(h_qp);
 	}
+	free(priv);
+	drv->priv = NULL;
 }
 
 static void __attribute__((constructor)) hisi_sec2_probe(void)

--- a/include/wd_alg.h
+++ b/include/wd_alg.h
@@ -41,8 +41,7 @@ enum alg_dev_type {
  *		 execute the algorithm task
  * @op_type_num: number of modes in which the device executes the
  *		 algorithm business and requires queues to be executed separately
- * @priv_size: parameter memory size passed between the internal
- *		 interfaces of the driver
+ * @priv: pointer of priv ctx
  * @fallback: soft calculation driver handle when performing soft
  *		 calculation supplement
  * @init: callback interface for initializing device drivers
@@ -61,15 +60,35 @@ struct wd_alg_driver {
 	int	calc_type;
 	int	queue_num;
 	int	op_type_num;
-	int	priv_size;
+	void	*priv;
 	handle_t fallback;
 
-	int (*init)(void *conf, void *priv);
-	void (*exit)(void *priv);
-	int (*send)(handle_t ctx, void *drv_msg);
-	int (*recv)(handle_t ctx, void *drv_msg);
+	int (*init)(struct wd_alg_driver *drv, void *conf);
+	void (*exit)(struct wd_alg_driver *drv);
+	int (*send)(struct wd_alg_driver *drv, handle_t ctx, void *drv_msg);
+	int (*recv)(struct wd_alg_driver *drv, handle_t ctx, void *drv_msg);
 	int (*get_usage)(void *param);
 };
+
+inline int wd_alg_driver_init(struct wd_alg_driver *drv, void *conf)
+{
+	return drv->init(drv, conf);
+}
+
+inline void wd_alg_driver_exit(struct wd_alg_driver *drv)
+{
+	drv->exit(drv);
+}
+
+inline int wd_alg_driver_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	return drv->send(drv, ctx, msg);
+}
+
+inline int wd_alg_driver_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	return drv->recv(drv, ctx, msg);
+}
 
 /**
  * wd_alg_driver_register() - Register a device driver.

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -113,8 +113,8 @@ struct wd_ctx_attr {
 };
 
 struct wd_msg_handle {
-	int (*send)(handle_t sess, void *msg);
-	int (*recv)(handle_t sess, void *msg);
+	int (*send)(struct wd_alg_driver *drv, handle_t ctx, void *drv_msg);
+	int (*recv)(struct wd_alg_driver *drv, handle_t ctx, void *drv_msg);
 };
 
 struct wd_init_attrs {
@@ -358,6 +358,7 @@ int wd_set_epoll_en(const char *var_name, bool *epoll_en);
 
 /**
  * wd_handle_msg_sync() - recv msg from hardware
+ * @drv: the driver to handle msg.
  * @msg_handle: callback of msg handle ops.
  * @ctx: the handle of context.
  * @msg: the msg of task.
@@ -366,8 +367,8 @@ int wd_set_epoll_en(const char *var_name, bool *epoll_en);
  *
  * Return 0 if successful or less than 0 otherwise.
  */
-int wd_handle_msg_sync(struct wd_msg_handle *msg_handle, handle_t ctx,
-		void *msg, __u64 *balance, bool epoll_en);
+int wd_handle_msg_sync(struct wd_alg_driver *drv, struct wd_msg_handle *msg_handle,
+		       handle_t ctx, void *msg, __u64 *balance, bool epoll_en);
 
 /**
  * wd_init_check() - Check input parameters for wd_<alg>_init.
@@ -464,14 +465,13 @@ void wd_alg_drv_unbind(struct wd_alg_driver *drv);
  *			to the obtained queue resource and the applied driver.
  * @config: device resources requested by the current algorithm.
  * @driver: device driver for the current algorithm application.
- * @drv_priv: the parameter pointer of the current device driver.
  *
  * Return 0 if succeed and other error number if fail.
  */
 int wd_alg_init_driver(struct wd_ctx_config_internal *config,
-	struct wd_alg_driver *driver, void **drv_priv);
+		       struct wd_alg_driver *driver);
 void wd_alg_uninit_driver(struct wd_ctx_config_internal *config,
-	struct wd_alg_driver *driver, void **drv_priv);
+			  struct wd_alg_driver *driver);
 
 /**
  * wd_dlopen_drv() - Open the dynamic library file of the device driver.

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -44,7 +44,6 @@ struct wd_aead_setting {
 	struct wd_sched sched;
 	struct wd_alg_driver *driver;
 	struct wd_async_msg_pool pool;
-	void *priv;
 	void *dlhandle;
 	void *dlh_list;
 } wd_aead_setting;
@@ -436,8 +435,7 @@ static int wd_aead_init_nolock(struct wd_ctx_config *config, struct wd_sched *sc
 		goto out_clear_sched;
 
 	ret = wd_alg_init_driver(&wd_aead_setting.config,
-					wd_aead_setting.driver,
-					&wd_aead_setting.priv);
+					wd_aead_setting.driver);
 	if (ret)
 		goto out_clear_pool;
 
@@ -492,13 +490,15 @@ static void wd_aead_uninit_nolock(void)
 	wd_uninit_async_request_pool(&wd_aead_setting.pool);
 	wd_clear_sched(&wd_aead_setting.sched);
 	wd_alg_uninit_driver(&wd_aead_setting.config,
-						 wd_aead_setting.driver,
-						 &wd_aead_setting.priv);
+			     wd_aead_setting.driver);
 }
 
 void wd_aead_uninit(void)
 {
-	if (!wd_aead_setting.priv)
+	enum wd_status status;
+
+	wd_alg_get_init(&wd_aead_setting.status, &status);
+	if (status == WD_UNINIT)
 		return;
 
 	wd_aead_uninit_nolock();
@@ -615,7 +615,10 @@ out_uninit:
 
 void wd_aead_uninit2(void)
 {
-	if (!wd_aead_setting.priv)
+	enum wd_status status;
+
+	wd_alg_get_init(&wd_aead_setting.status, &status);
+	if (status == WD_UNINIT)
 		return;
 
 	wd_aead_uninit_nolock();
@@ -701,8 +704,8 @@ static int send_recv_sync(struct wd_ctx_internal *ctx,
 	msg_handle.recv = wd_aead_setting.driver->recv;
 
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_handle_msg_sync(&msg_handle, ctx->ctx, msg, NULL,
-			  wd_aead_setting.config.epoll_en);
+	ret = wd_handle_msg_sync(wd_aead_setting.driver, &msg_handle, ctx->ctx,
+				 msg, NULL, wd_aead_setting.config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 
 	return ret;
@@ -777,7 +780,7 @@ int wd_do_aead_async(handle_t h_sess, struct wd_aead_req *req)
 	fill_request_msg(msg, req, sess);
 	msg->tag = msg_id;
 
-	ret = wd_aead_setting.driver->send(ctx->ctx, msg);
+	ret = wd_alg_driver_send(wd_aead_setting.driver, ctx->ctx, msg);
 	if (unlikely(ret < 0)) {
 		if (ret != -WD_EBUSY)
 			WD_ERR("failed to send BD, hw is err!\n");
@@ -826,7 +829,7 @@ int wd_aead_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	ctx = config->ctxs + idx;
 
 	do {
-		ret = wd_aead_setting.driver->recv(ctx->ctx, &resp_msg);
+		ret = wd_alg_driver_recv(wd_aead_setting.driver, ctx->ctx, &resp_msg);
 		if (ret == -WD_EAGAIN) {
 			return ret;
 		} else if (ret < 0) {

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -48,7 +48,6 @@ struct wd_comp_setting {
 	struct wd_sched sched;
 	struct wd_async_msg_pool pool;
 	struct wd_alg_driver *driver;
-	void *priv;
 	void *dlhandle;
 	void *dlh_list;
 } wd_comp_setting;
@@ -139,8 +138,7 @@ static int wd_comp_init_nolock(struct wd_ctx_config *config, struct wd_sched *sc
 		goto out_clear_sched;
 
 	ret = wd_alg_init_driver(&wd_comp_setting.config,
-					wd_comp_setting.driver,
-					&wd_comp_setting.priv);
+					wd_comp_setting.driver);
 	if (ret)
 		goto out_clear_pool;
 
@@ -157,9 +155,10 @@ out_clear_ctx_config:
 
 static int wd_comp_uninit_nolock(void)
 {
-	void *priv = wd_comp_setting.priv;
+	enum wd_status status;
 
-	if (!priv)
+	wd_alg_get_init(&wd_comp_setting.status, &status);
+	if (status == WD_UNINIT)
 		return -WD_EINVAL;
 
 	/* Uninit async request pool */
@@ -169,8 +168,7 @@ static int wd_comp_uninit_nolock(void)
 	wd_clear_sched(&wd_comp_setting.sched);
 
 	wd_alg_uninit_driver(&wd_comp_setting.config,
-		 wd_comp_setting.driver,
-		 &wd_comp_setting.priv);
+			     wd_comp_setting.driver);
 
 	return 0;
 }
@@ -359,7 +357,7 @@ int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	ctx = config->ctxs + idx;
 
 	do {
-		ret = wd_comp_setting.driver->recv(ctx->ctx, &resp_msg);
+		ret = wd_alg_driver_recv(wd_comp_setting.driver, ctx->ctx, &resp_msg);
 		if (unlikely(ret < 0)) {
 			if (ret == -WD_HW_EACCESS)
 				WD_ERR("wd comp recv hw error!\n");
@@ -594,8 +592,8 @@ static int wd_comp_sync_job(struct wd_comp_sess *sess,
 	msg_handle.recv = wd_comp_setting.driver->recv;
 
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_handle_msg_sync(&msg_handle, ctx->ctx, msg,
-				 NULL, config->epoll_en);
+	ret = wd_handle_msg_sync(wd_comp_setting.driver, &msg_handle, ctx->ctx,
+				 msg, NULL, config->epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 
 	return ret;
@@ -849,7 +847,7 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 	msg->tag = tag;
 	msg->stream_mode = WD_COMP_STATELESS;
 
-	ret = wd_comp_setting.driver->send(ctx->ctx, msg);
+	ret = wd_alg_driver_send(wd_comp_setting.driver, ctx->ctx, msg);
 	if (unlikely(ret < 0)) {
 		WD_ERR("wd comp send error, ret = %d!\n", ret);
 		goto fail_with_msg;

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -35,7 +35,6 @@ static struct wd_dh_setting {
 	struct wd_sched sched;
 	struct wd_async_msg_pool pool;
 	struct wd_alg_driver *driver;
-	void *priv;
 	void *dlhandle;
 	void *dlh_list;
 } wd_dh_setting;
@@ -112,8 +111,7 @@ static int wd_dh_common_init(struct wd_ctx_config *config, struct wd_sched *sche
 		goto out_clear_sched;
 
 	ret = wd_alg_init_driver(&wd_dh_setting.config,
-				 wd_dh_setting.driver,
-				 &wd_dh_setting.priv);
+				 wd_dh_setting.driver);
 	if (ret)
 		goto out_clear_pool;
 
@@ -130,19 +128,13 @@ out_clear_ctx_config:
 
 static int wd_dh_common_uninit(void)
 {
-	if (!wd_dh_setting.priv) {
-		WD_ERR("invalid: repeat uninit dh!\n");
-		return -WD_EINVAL;
-	}
-
 	/* uninit async request pool */
 	wd_uninit_async_request_pool(&wd_dh_setting.pool);
 
 	/* unset config, sched, driver */
 	wd_clear_sched(&wd_dh_setting.sched);
 	wd_alg_uninit_driver(&wd_dh_setting.config,
-			     wd_dh_setting.driver,
-			     &wd_dh_setting.priv);
+			     wd_dh_setting.driver);
 
 	return 0;
 }
@@ -367,8 +359,8 @@ int wd_do_dh_sync(handle_t sess, struct wd_dh_req *req)
 	msg_handle.recv = wd_dh_setting.driver->recv;
 
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_handle_msg_sync(&msg_handle, ctx->ctx, &msg, &balance,
-				 wd_dh_setting.config.epoll_en);
+	ret = wd_handle_msg_sync(wd_dh_setting.driver, &msg_handle, ctx->ctx,
+				 &msg, &balance, wd_dh_setting.config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 	if (unlikely(ret))
 		return ret;
@@ -412,7 +404,7 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 		goto fail_with_msg;
 	msg->tag = mid;
 
-	ret = wd_dh_setting.driver->send(ctx->ctx, msg);
+	ret = wd_alg_driver_send(wd_dh_setting.driver, ctx->ctx, msg);
 	if (unlikely(ret)) {
 		if (ret != -WD_EBUSY)
 			WD_ERR("failed to send dh BD, hw is err!\n");
@@ -463,7 +455,7 @@ int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	ctx = config->ctxs + idx;
 
 	do {
-		ret = wd_dh_setting.driver->recv(ctx->ctx, &rcv_msg);
+		ret = wd_alg_driver_recv(wd_dh_setting.driver, ctx->ctx, &rcv_msg);
 		if (ret == -WD_EAGAIN) {
 			return ret;
 		} else if (unlikely(ret)) {

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -76,7 +76,6 @@ static struct wd_rsa_setting {
 	struct wd_sched sched;
 	struct wd_async_msg_pool pool;
 	struct wd_alg_driver *driver;
-	void *priv;
 	void *dlhandle;
 	void *dlh_list;
 } wd_rsa_setting;
@@ -153,8 +152,7 @@ static int wd_rsa_common_init(struct wd_ctx_config *config, struct wd_sched *sch
 		goto out_clear_sched;
 
 	ret = wd_alg_init_driver(&wd_rsa_setting.config,
-				 wd_rsa_setting.driver,
-				 &wd_rsa_setting.priv);
+				 wd_rsa_setting.driver);
 	if (ret)
 		goto out_clear_pool;
 
@@ -171,19 +169,13 @@ out_clear_ctx_config:
 
 static int wd_rsa_common_uninit(void)
 {
-	if (!wd_rsa_setting.priv) {
-		WD_ERR("invalid: repeat uninit rsa!\n");
-		return -WD_EINVAL;
-	}
-
 	/* uninit async request pool */
 	wd_uninit_async_request_pool(&wd_rsa_setting.pool);
 
 	/* unset config, sched, driver */
 	wd_clear_sched(&wd_rsa_setting.sched);
 	wd_alg_uninit_driver(&wd_rsa_setting.config,
-			     wd_rsa_setting.driver,
-			     &wd_rsa_setting.priv);
+			     wd_rsa_setting.driver);
 
 	return 0;
 }
@@ -429,8 +421,8 @@ int wd_do_rsa_sync(handle_t h_sess, struct wd_rsa_req *req)
 	msg_handle.recv = wd_rsa_setting.driver->recv;
 
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_handle_msg_sync(&msg_handle, ctx->ctx, &msg, &balance,
-				 wd_rsa_setting.config.epoll_en);
+	ret = wd_handle_msg_sync(wd_rsa_setting.driver, &msg_handle, ctx->ctx, &msg,
+				 &balance, wd_rsa_setting.config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 	if (unlikely(ret))
 		return ret;
@@ -474,7 +466,7 @@ int wd_do_rsa_async(handle_t sess, struct wd_rsa_req *req)
 		goto fail_with_msg;
 	msg->tag = mid;
 
-	ret = wd_rsa_setting.driver->send(ctx->ctx, msg);
+	ret = wd_alg_driver_send(wd_rsa_setting.driver, ctx->ctx, msg);
 	if (unlikely(ret)) {
 		if (ret != -WD_EBUSY)
 			WD_ERR("failed to send rsa BD, hw is err!\n");
@@ -523,7 +515,7 @@ int wd_rsa_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	ctx = config->ctxs + idx;
 
 	do {
-		ret = wd_rsa_setting.driver->recv(ctx->ctx, &recv_msg);
+		ret = wd_alg_driver_recv(wd_rsa_setting.driver, ctx->ctx, &recv_msg);
 		if (ret == -WD_EAGAIN) {
 			return ret;
 		} else if (ret < 0) {


### PR DESCRIPTION
A driver should alloc and free resources by himself instead of the caller, considering multi-driver exists, the caller can not hold ctx for all drivers, so drv.init malloc private ctx and drv.exit free.

Add driver as para of alg ops, not only for getting private ctx, but easier for multi-driver support.