### PR TITLE
uadk_tool: use DT_RUNPATH instead of DT_RPATH

### DIFF
--- a/uadk_tool/Makefile.am
+++ b/uadk_tool/Makefile.am
@@ -32,7 +32,7 @@ uadk_tool_LDADD=-L../.libs -l:libwd.so.2 -l:libwd_crypto.so.2 \
 		-l:libwd_comp.so.2 -lnuma
 endif
 
-uadk_tool_LDFLAGS=-Wl,-rpath,'/usr/local/lib'
+uadk_tool_LDFLAGS=-Wl,-rpath,'/usr/local/lib',--enable-new-dtags
 
 if WITH_ZLIB_FSE_DIR
 AM_CFLAGS += -DZLIB_FSE


### PR DESCRIPTION
Search dynamic lib sequence
1. DT_RPATH: -Wl,-rpath,'/usr/local/lib'
2. LD_LIBRARY_PATH
3. DT_RUNPATH: -Wl,-rpath,'/usr/local/lib',--enable-new-dtags

If using DT_RPATH, LD_LIBRARY_PATH will be ignored, and uadk_tool will always search libwd.so under /usr/local/lib, except rm it.

If remove DT_RPATH, LD_LIBRARY_PATH has to be provided even when library is under /usr/local/lib

So use DT_RUNPATH, if LD_LIBRARY_PATH is provide, use it If LD_LIBRARY_PATH is not provide, use the default DT_RUNPAT.

Example
./test.sh
wd_get_lib_file_path file_path=/usr/local/lib/libwd_crypto.so.2

LD_LIBRARY_PATH=/tmp/build/lib ./test.sh
wd_get_lib_file_path file_path=/tmp/build/lib/libwd_crypto.so.2