### PR TITLE
uadk/comp: fix duplicate release of comp

### DIFF
--- a/wd_comp.c
+++ b/wd_comp.c
@@ -169,7 +169,8 @@ static int wd_comp_uninit_nolock(void)
 	wd_clear_sched(&wd_comp_setting.sched);
 
 	wd_alg_uninit_driver(&wd_comp_setting.config,
-		 wd_comp_setting.driver, &priv);
+		 wd_comp_setting.driver,
+		 &wd_comp_setting.priv);
 
 	return 0;
 }


### PR DESCRIPTION
In the current version, when the resource of comp is destroyed, there is no effective blanking operation for setting's priv

therefore, this operation needs to be performed directly on the priv of the setting.