### PR TITLE
This patchset fixes some issues of the uadk.

### DIFF
--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -387,10 +387,11 @@ int wd_init_param_check(struct wd_ctx_config *config, struct wd_sched *sched);
  * if need initialization.
  * @status: algorithm initialization status.
  *
- * Return true if need initialization and false if initialized, otherwise will wait
- * last initialization result.
+ * Return 0 if need initialization.
+ * Return -WD_EEXIST if the algorithm has been initialized.
+ * Return -WD_ETIMEDOUT if wait timeout.
  */
-bool wd_alg_try_init(enum wd_status *status);
+int wd_alg_try_init(enum wd_status *status);
 
 /**
  * wd_alg_set_init() - Set the algorithm status as WD_INIT.

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -452,14 +452,13 @@ out_clear_ctx_config:
 
 int wd_aead_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
-	bool flag;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_aead_clear_status);
 
-	flag = wd_alg_try_init(&wd_aead_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	ret = wd_alg_try_init(&wd_aead_setting.status);
+	if (ret)
+		return ret;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
@@ -524,14 +523,13 @@ int wd_aead_init2_(char *alg, __u32 sched_type, int task_type,
 {
 	struct wd_ctx_nums aead_ctx_num[WD_DIGEST_CIPHER_DECRYPTION + 1] = {0};
 	struct wd_ctx_params aead_ctx_params = {0};
-	int ret = -WD_EINVAL;
-	bool flag;
+	int state, ret = -WD_EINVAL;
 
 	pthread_atfork(NULL, NULL, wd_aead_clear_status);
 
-	flag = wd_alg_try_init(&wd_aead_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	state = wd_alg_try_init(&wd_aead_setting.status);
+	if (state)
+		return state;
 
 	if (!alg || sched_type >= SCHED_POLICY_BUTT ||
 	     task_type < 0 || task_type >= TASK_MAX_TYPE) {

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -353,14 +353,13 @@ static int wd_cipher_common_uninit(void)
 
 int wd_cipher_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
-	bool flag;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_cipher_clear_status);
 
-	flag = wd_alg_try_init(&wd_cipher_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	ret = wd_alg_try_init(&wd_cipher_setting.status);
+	if (ret)
+		return ret;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
@@ -401,14 +400,14 @@ int wd_cipher_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_p
 {
 	struct wd_ctx_nums cipher_ctx_num[WD_CIPHER_DECRYPTION + 1] = {0};
 	struct wd_ctx_params cipher_ctx_params = {0};
-	int ret = -WD_EINVAL;
+	int state, ret = -WD_EINVAL;
 	bool flag;
 
 	pthread_atfork(NULL, NULL, wd_cipher_clear_status);
 
-	flag = wd_alg_try_init(&wd_cipher_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	state = wd_alg_try_init(&wd_cipher_setting.status);
+	if (state)
+		return state;
 
 	if (!alg || sched_type >= SCHED_POLICY_BUTT ||
 	     task_type < 0 || task_type >= TASK_MAX_TYPE) {

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -173,14 +173,13 @@ static int wd_comp_uninit_nolock(void)
 
 int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
-	bool flag;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_comp_clear_status);
 
-	flag = wd_alg_try_init(&wd_comp_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	ret = wd_alg_try_init(&wd_comp_setting.status);
+	if (ret)
+		return ret;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
@@ -221,14 +220,14 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 {
 	struct wd_ctx_nums comp_ctx_num[WD_DIR_MAX] = {0};
 	struct wd_ctx_params comp_ctx_params = {0};
-	int ret = -WD_EINVAL;
+	int state, ret = -WD_EINVAL;
 	bool flag;
 
 	pthread_atfork(NULL, NULL, wd_comp_clear_status);
 
-	flag = wd_alg_try_init(&wd_comp_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	state = wd_alg_try_init(&wd_comp_setting.status);
+	if (state)
+		return state;
 
 	if (!alg || sched_type >= SCHED_POLICY_BUTT ||
 	    task_type < 0 || task_type >= TASK_MAX_TYPE) {

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -140,14 +140,13 @@ static int wd_dh_common_uninit(void)
 
 int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
-	bool flag;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_dh_clear_status);
 
-	flag = wd_alg_try_init(&wd_dh_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	ret = wd_alg_try_init(&wd_dh_setting.status);
+	if (ret)
+		return ret;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
@@ -188,14 +187,13 @@ int wd_dh_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_param
 {
 	struct wd_ctx_nums dh_ctx_num[WD_DH_PHASE2] = {0};
 	struct wd_ctx_params dh_ctx_params = {0};
-	int ret = -WD_EINVAL;
-	bool flag;
+	int state, ret = -WD_EINVAL;
 
 	pthread_atfork(NULL, NULL, wd_dh_clear_status);
 
-	flag = wd_alg_try_init(&wd_dh_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	state = wd_alg_try_init(&wd_dh_setting.status);
+	if (state)
+		return state;
 
 	if (!alg || sched_type >= SCHED_POLICY_BUTT ||
 	    task_type < 0 || task_type >= TASK_MAX_TYPE) {

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -266,14 +266,13 @@ out_clear_ctx_config:
 
 int wd_digest_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
-	bool flag;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_digest_clear_status);
 
-	flag = wd_alg_try_init(&wd_digest_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	ret = wd_alg_try_init(&wd_digest_setting.status);
+	if (ret)
+		return ret;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
@@ -334,14 +333,13 @@ int wd_digest_init2_(char *alg, __u32 sched_type, int task_type,
 {
 	struct wd_ctx_params digest_ctx_params = {0};
 	struct wd_ctx_nums digest_ctx_num = {0};
-	int ret = -WD_EINVAL;
-	bool flag;
+	int state, ret = -WD_EINVAL;
 
 	pthread_atfork(NULL, NULL, wd_digest_clear_status);
 
-	flag = wd_alg_try_init(&wd_digest_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	state = wd_alg_try_init(&wd_digest_setting.status);
+	if (state)
+		return state;
 
 	if (!alg || sched_type >= SCHED_POLICY_BUTT ||
 	     task_type < 0 || task_type >= TASK_MAX_TYPE) {

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -203,14 +203,13 @@ static int wd_ecc_common_uninit(void)
 
 int wd_ecc_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
-	bool flag;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_ecc_clear_status);
 
-	flag = wd_alg_try_init(&wd_ecc_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	ret = wd_alg_try_init(&wd_ecc_setting.status);
+	if (ret)
+		return ret;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
@@ -251,14 +250,14 @@ int wd_ecc_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_para
 {
 	struct wd_ctx_nums ecc_ctx_num[WD_EC_OP_MAX] = {0};
 	struct wd_ctx_params ecc_ctx_params = {0};
-	int ret = -WD_EINVAL;
+	int state, ret = -WD_EINVAL;
 	bool flag;
 
 	pthread_atfork(NULL, NULL, wd_ecc_clear_status);
 
-	flag = wd_alg_try_init(&wd_ecc_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	state = wd_alg_try_init(&wd_ecc_setting.status);
+	if (state)
+		return state;
 
 	if (!alg || sched_type >= SCHED_POLICY_BUTT ||
 	    task_type < 0 || task_type >= TASK_MAX_TYPE) {

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -178,14 +178,13 @@ static int wd_rsa_common_uninit(void)
 
 int wd_rsa_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
-	bool flag;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_rsa_clear_status);
 
-	flag = wd_alg_try_init(&wd_rsa_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	ret = wd_alg_try_init(&wd_rsa_setting.status);
+	if (ret)
+		return ret;
 
 	ret = wd_init_param_check(config, sched);
 	if (ret)
@@ -226,14 +225,13 @@ int wd_rsa_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_para
 {
 	struct wd_ctx_nums rsa_ctx_num[WD_RSA_GENKEY] = {0};
 	struct wd_ctx_params rsa_ctx_params = {0};
-	int ret = -WD_EINVAL;
-	bool flag;
+	int state, ret = -WD_EINVAL;
 
 	pthread_atfork(NULL, NULL, wd_rsa_clear_status);
 
-	flag = wd_alg_try_init(&wd_rsa_setting.status);
-	if (!flag)
-		return -WD_EEXIST;
+	state = wd_alg_try_init(&wd_rsa_setting.status);
+	if (state)
+		return state;
 
 	if (!alg || sched_type >= SCHED_POLICY_BUTT ||
 	    task_type < 0 || task_type >= TASK_MAX_TYPE) {


### PR DESCRIPTION
The first patch adds init wait timeout judgment to prevent deadlocks
when making loopback calls from the same thread.

The second and third patches add a key length validity check before
calculating the actual key length of the algorithm in xts mode. Because
if the key length is odd, it will result in incorrect calculation results.