### PR TITLE
uadk: support loading alg lib from the specified directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,8 +38,10 @@ pkginclude_HEADERS = include/wd.h include/wd_cipher.h include/wd_aead.h \
 nobase_pkginclude_HEADERS = v1/wd.h v1/wd_cipher.h v1/wd_aead.h v1/uacce.h v1/wd_dh.h \
 			 v1/wd_digest.h v1/wd_rsa.h v1/wd_bmm.h
 
-lib_LTLIBRARIES=libwd.la libwd_comp.la libwd_crypto.la libhisi_zip.la \
-		libhisi_hpre.la libhisi_sec.la
+lib_LTLIBRARIES=libwd.la libwd_comp.la libwd_crypto.la
+
+uadk_driversdir=$(libdir)/uadk
+uadk_drivers_LTLIBRARIES=libhisi_sec.la libhisi_hpre.la libhisi_zip.la
 
 libwd_la_SOURCES=wd.c wd_mempool.c wd.h	wd_alg.c wd_alg.h	\
 		 v1/wd.c v1/wd.h v1/wd_adapter.c v1/wd_adapter.h \


### PR DESCRIPTION
Solving the problem of traversing the entire library directory to load alg drv lib may result in unexpected results by specifying the loading directory 'uadk'.