### PR TITLE
Upstream :fix two zip module's software issues

### DIFF
--- a/include/wd_zlibwrapper.h
+++ b/include/wd_zlibwrapper.h
@@ -6,6 +6,8 @@
 #ifndef UADK_ZLIBWRAPPER_H
 #define UADK_ZLIBWRAPPER_H
 
+#include <asm/types.h>
+
 /*
  * These APIs are used to replace the ZLIB library. So if you don't use them.
  * Please do not use these. These APIs provide limited function, while the

--- a/wd_zlibwrapper.c
+++ b/wd_zlibwrapper.c
@@ -68,7 +68,7 @@ static int wd_zlib_uadk_init(void)
 		ctx_set_num[i].sync_ctx_num = WD_DIR_MAX;
 
 	ret = wd_comp_init2_("zlib", 0, 0, &cparams);
-	if (ret) {
+	if (ret && ret != -WD_EEXIST) {
 		ret = Z_STREAM_ERROR;
 		goto out_freebmp;
 	}


### PR DESCRIPTION
Fix two bugs.
1. Since the wd_alg_try_init change the return value, wd_zlibwrapper shoud add the return value check.
2. Support sqe_priv ops for hisilicon comp BD v3.