### PR TITLE
uadk/digest: optimize the zero byte packet checking for   hash

### DIFF
--- a/v1/drv/hisi_sec_udrv.c
+++ b/v1/drv/hisi_sec_udrv.c
@@ -992,9 +992,16 @@ static int fill_digest_bd2_alg(struct wcrypto_digest_msg *msg,
 	if (unlikely(ret))
 		return ret;
 
-	if (unlikely(msg->in_bytes == 0)) {
-		WD_ERR("digest bd2 not supports 0 packet!\n");
-		return -WD_EINVAL;
+	if(unlikely(msg->in_bytes == 0)) {
+		if ((msg->has_next && !msg->iv_bytes) || (msg->has_next && msg->iv_bytes)) {
+			/* Long hash first and middle BD */
+			WD_ERR("invalid: digest bd2 not supports 0 packet in first bd and middle bd!\n");
+			return -WD_EINVAL;
+		} else if (!msg->has_next && !msg->iv_bytes) {
+			/* Block hash BD */
+			WD_ERR("invalid: digest bd2 not supports 0 packet in block mode!\n");
+			return -WD_EINVAL;
+		}
 	}
 
 	sqe->type2.mac_len = msg->out_bytes / WORD_BYTES;
@@ -1382,6 +1389,14 @@ static int fill_digest_bd3_alg(struct wcrypto_digest_msg *msg,
 	ret = digest_param_check(msg);
 	if (unlikely(ret))
 		return ret;
+
+	if (unlikely(msg->in_bytes == 0)) {
+		if ((msg->has_next && !msg->iv_bytes) || (msg->has_next && msg->iv_bytes)) {
+			/* Long hash first and middle BD */
+				WD_ERR("invalid: digest bd3 not supports 0 packet in first bd and middle bd!\n");
+				return -WD_EINVAL;
+		}
+	}
 
 	sqe->mac_len = msg->out_bytes / WORD_BYTES;
 	if (msg->mode == WCRYPTO_DIGEST_NORMAL)

--- a/v1/wd_digest.c
+++ b/v1/wd_digest.c
@@ -199,7 +199,7 @@ void *wcrypto_create_digest_ctx(struct wd_queue *q,
 		}
 	}
 
-	if (setup->alg >= WCRYPTO_SHA512)
+	if (setup->alg >= WCRYPTO_SHA384)
 		ctx->align_sz = SEC_SHA512_ALIGN_SZ;
 	else
 		ctx->align_sz = SEC_SHA1_ALIGN_SZ;


### PR DESCRIPTION
 Optimize the zero byte packet checking in bd2 and
 add the zero byte packet checking in bd3.
  
 Hardware v2: long hash mode does not support 0 byte packet in the
 frist and middle bd. Block hash mode does not support 0 byte packet.

 Hardware v3: long hash mode does not support 0 byte packet in the
 frist and middle bd. But, block hash mode do support 0 byte packet.
