### PR TITLE
uadk: simplify msg_pool via removing ctx_id

### DIFF
--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -1031,7 +1031,7 @@ static int parse_zip_sqe(struct hisi_qp *qp, struct hisi_zip_sqe *sqe,
 	recv_msg->tag = tag;
 
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		recv_msg = wd_comp_get_msg(qp->q_info.idx, tag);
+		recv_msg = wd_comp_get_msg(tag);
 		if (unlikely(!recv_msg)) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u!\n",
 			       qp->q_info.idx, tag);

--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -656,7 +656,7 @@ static int rsa_recv(struct wd_alg_driver *drv, handle_t ctx, void *rsa_msg)
 
 	msg->tag = LW_U16(hw_msg.low_tag);
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		temp_msg = wd_rsa_get_msg(qp->q_info.idx, msg->tag);
+		temp_msg = wd_rsa_get_msg(msg->tag);
 		if (!temp_msg) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
 				qp->q_info.idx, msg->tag);
@@ -799,7 +799,7 @@ static int dh_recv(struct wd_alg_driver *drv, handle_t ctx, void *dh_msg)
 
 	msg->tag = LW_U16(hw_msg.low_tag);
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		temp_msg = wd_dh_get_msg(qp->q_info.idx, msg->tag);
+		temp_msg = wd_dh_get_msg(msg->tag);
 		if (!temp_msg) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
 				qp->q_info.idx, msg->tag);
@@ -2291,7 +2291,7 @@ static int ecc_sqe_parse(struct hisi_qp *qp, struct wd_ecc_msg *msg,
 
 	msg->tag = LW_U16(hw_msg->low_tag);
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		temp_msg = wd_ecc_get_msg(qp->q_info.idx, msg->tag);
+		temp_msg = wd_ecc_get_msg(msg->tag);
 		if (!temp_msg) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
 				qp->q_info.idx, msg->tag);

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -870,7 +870,7 @@ static void parse_cipher_bd2(struct hisi_qp *qp, struct hisi_sec_sqe *sqe,
 		recv_msg->data_fmt = get_data_fmt_v2(sqe->sds_sa_type);
 		recv_msg->in = (__u8 *)(uintptr_t)sqe->type2.data_src_addr;
 		recv_msg->out = (__u8 *)(uintptr_t)sqe->type2.data_dst_addr;
-		temp_msg = wd_cipher_get_msg(qp->q_info.idx, tag);
+		temp_msg = wd_cipher_get_msg(tag);
 		if (!temp_msg) {
 			recv_msg->result = WD_IN_EPARA;
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
@@ -1364,7 +1364,7 @@ static void parse_cipher_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		recv_msg->data_fmt = get_data_fmt_v3(sqe->bd_param);
 		recv_msg->in = (__u8 *)(uintptr_t)sqe->data_src_addr;
 		recv_msg->out = (__u8 *)(uintptr_t)sqe->data_dst_addr;
-		temp_msg = wd_cipher_get_msg(qp->q_info.idx, tag);
+		temp_msg = wd_cipher_get_msg(tag);
 		if (!temp_msg) {
 			recv_msg->result = WD_IN_EPARA;
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
@@ -1551,7 +1551,7 @@ static void parse_digest_bd2(struct hisi_qp *qp, struct hisi_sec_sqe *sqe,
 		recv_msg->alg_type = WD_DIGEST;
 		recv_msg->data_fmt = get_data_fmt_v2(sqe->sds_sa_type);
 		recv_msg->in = (__u8 *)(uintptr_t)sqe->type2.data_src_addr;
-		temp_msg = wd_digest_get_msg(qp->q_info.idx, recv_msg->tag);
+		temp_msg = wd_digest_get_msg(recv_msg->tag);
 		if (!temp_msg) {
 			recv_msg->result = WD_IN_EPARA;
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
@@ -1985,7 +1985,7 @@ static void parse_digest_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		recv_msg->alg_type = WD_DIGEST;
 		recv_msg->data_fmt = get_data_fmt_v3(sqe->bd_param);
 		recv_msg->in = (__u8 *)(uintptr_t)sqe->data_src_addr;
-		temp_msg = wd_digest_get_msg(qp->q_info.idx, recv_msg->tag);
+		temp_msg = wd_digest_get_msg(recv_msg->tag);
 		if (!temp_msg) {
 			recv_msg->result = WD_IN_EPARA;
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",

--- a/include/drv/wd_cipher_drv.h
+++ b/include/drv/wd_cipher_drv.h
@@ -50,7 +50,7 @@ struct wd_cipher_msg {
 	__u8 *out;
 };
 
-struct wd_cipher_msg *wd_cipher_get_msg(__u32 idx, __u32 tag);
+struct wd_cipher_msg *wd_cipher_get_msg(__u32 tag);
 
 #ifdef __cplusplus
 }

--- a/include/drv/wd_comp_drv.h
+++ b/include/drv/wd_comp_drv.h
@@ -55,7 +55,7 @@ struct wd_comp_msg {
 	__u32 tag;
 };
 
-struct wd_comp_msg *wd_comp_get_msg(__u32 idx, __u32 tag);
+struct wd_comp_msg *wd_comp_get_msg(__u32 tag);
 
 #ifdef __cplusplus
 }

--- a/include/drv/wd_dh_drv.h
+++ b/include/drv/wd_dh_drv.h
@@ -24,7 +24,7 @@ struct wd_dh_msg {
 	__u8 result; /* Data format, denoted by WD error code */
 };
 
-struct wd_dh_msg *wd_dh_get_msg(__u32 idx, __u32 tag);
+struct wd_dh_msg *wd_dh_get_msg(__u32 tag);
 
 #ifdef __cplusplus
 }

--- a/include/drv/wd_digest_drv.h
+++ b/include/drv/wd_digest_drv.h
@@ -51,7 +51,7 @@ struct wd_digest_msg {
 	__u64 long_data_len;
 };
 
-struct wd_digest_msg *wd_digest_get_msg(__u32 idx, __u32 tag);
+struct wd_digest_msg *wd_digest_get_msg(__u32 tag);
 
 #ifdef __cplusplus
 }

--- a/include/drv/wd_ecc_drv.h
+++ b/include/drv/wd_ecc_drv.h
@@ -175,7 +175,7 @@ struct wd_ecc_out {
 	char data[];
 };
 
-struct wd_ecc_msg *wd_ecc_get_msg(__u32 idx, __u32 tag);
+struct wd_ecc_msg *wd_ecc_get_msg(__u32 tag);
 
 #ifdef __cplusplus
 }

--- a/include/drv/wd_rsa_drv.h
+++ b/include/drv/wd_rsa_drv.h
@@ -49,7 +49,7 @@ struct wd_rsa_msg {
 	__u8 *key; /* Input key VA pointer, should be DMA buffer */
 };
 
-struct wd_rsa_msg *wd_rsa_get_msg(__u32 idx, __u32 tag);
+struct wd_rsa_msg *wd_rsa_get_msg(__u32 tag);
 
 #ifdef __cplusplus
 }

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -58,7 +58,7 @@ struct wd_cipher_setting {
 	enum wd_status status;
 	struct wd_ctx_config_internal config;
 	struct wd_sched sched;
-	struct wd_async_msg_pool pool;
+	struct msg_pool pool;
 	struct wd_alg_driver *driver;
 	void *dlhandle;
 	void *dlh_list;
@@ -685,8 +685,7 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req)
 
 	ctx = config->ctxs + idx;
 
-	msg_id = wd_get_msg_from_pool(&wd_cipher_setting.pool, idx,
-				   (void **)&msg);
+	msg_id = wd_get_msg_from_pool(&wd_cipher_setting.pool, (void **)&msg);
 	if (unlikely(msg_id < 0)) {
 		WD_ERR("busy, failed to get msg from pool!\n");
 		return -WD_EBUSY;
@@ -711,13 +710,13 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req)
 	return 0;
 
 fail_with_msg:
-	wd_put_msg_to_pool(&wd_cipher_setting.pool, idx, msg->tag);
+	wd_put_msg_to_pool(&wd_cipher_setting.pool, msg->tag);
 	return ret;
 }
 
-struct wd_cipher_msg *wd_cipher_get_msg(__u32 idx, __u32 tag)
+struct wd_cipher_msg *wd_cipher_get_msg(__u32 tag)
 {
-	return wd_find_msg_in_pool(&wd_cipher_setting.pool, idx, tag);
+	return wd_find_msg_in_pool(&wd_cipher_setting.pool, tag);
 }
 
 int wd_cipher_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
@@ -752,8 +751,7 @@ int wd_cipher_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 			return ret;
 		}
 		recv_count++;
-		msg = wd_find_msg_in_pool(&wd_cipher_setting.pool, idx,
-					  resp_msg.tag);
+		msg = wd_find_msg_in_pool(&wd_cipher_setting.pool, resp_msg.tag);
 		if (!msg) {
 			WD_ERR("failed to get msg from pool!\n");
 			return -WD_EINVAL;
@@ -765,8 +763,7 @@ int wd_cipher_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 
 		req->cb(req, req->cb_param);
 		/* free msg cache to msg_pool */
-		wd_put_msg_to_pool(&wd_cipher_setting.pool, idx,
-				   resp_msg.tag);
+		wd_put_msg_to_pool(&wd_cipher_setting.pool, resp_msg.tag);
 		*count = recv_count;
 	} while (--tmp);
 

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -49,7 +49,7 @@ struct wd_digest_setting {
 	struct wd_ctx_config_internal config;
 	struct wd_sched sched;
 	struct wd_alg_driver *driver;
-	struct wd_async_msg_pool pool;
+	struct msg_pool pool;
 	void *dlhandle;
 	void *dlh_list;
 } wd_digest_setting;
@@ -656,8 +656,7 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 
 	ctx = config->ctxs + idx;
 
-	msg_id = wd_get_msg_from_pool(&wd_digest_setting.pool, idx,
-				   (void **)&msg);
+	msg_id = wd_get_msg_from_pool(&wd_digest_setting.pool, (void **)&msg);
 	if (unlikely(msg_id < 0)) {
 		WD_ERR("busy, failed to get msg from pool!\n");
 		return -WD_EBUSY;
@@ -682,13 +681,13 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 	return 0;
 
 fail_with_msg:
-	wd_put_msg_to_pool(&wd_digest_setting.pool, idx, msg->tag);
+	wd_put_msg_to_pool(&wd_digest_setting.pool, msg->tag);
 	return ret;
 }
 
-struct wd_digest_msg *wd_digest_get_msg(__u32 idx, __u32 tag)
+struct wd_digest_msg *wd_digest_get_msg(__u32 tag)
 {
-	return wd_find_msg_in_pool(&wd_digest_setting.pool, idx, tag);
+	return wd_find_msg_in_pool(&wd_digest_setting.pool, tag);
 }
 
 int wd_digest_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
@@ -725,8 +724,7 @@ int wd_digest_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 
 		recv_cnt++;
 
-		msg = wd_find_msg_in_pool(&wd_digest_setting.pool, idx,
-					  recv_msg.tag);
+		msg = wd_find_msg_in_pool(&wd_digest_setting.pool, recv_msg.tag);
 		if (!msg) {
 			WD_ERR("failed to get msg from pool!\n");
 			return -WD_EINVAL;
@@ -737,8 +735,7 @@ int wd_digest_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 		if (likely(req))
 			req->cb(req);
 
-		wd_put_msg_to_pool(&wd_digest_setting.pool, idx,
-				   recv_msg.tag);
+		wd_put_msg_to_pool(&wd_digest_setting.pool, recv_msg.tag);
 		*count = recv_cnt;
 	} while (--tmp);
 


### PR DESCRIPTION
The msg_pool does not need two dimensions, one dimension is enough, get the first empty msg from the list and use the index as tag. So the hardware info ctx_id can be removed.