### PR TITLE
uadk: zlibwrapper - fix return value for wd_zlib_uadk_init

### DIFF
--- a/wd_zlibwrapper.c
+++ b/wd_zlibwrapper.c
@@ -73,6 +73,7 @@ static int wd_zlib_uadk_init(void)
 		goto out_freebmp;
 	}
 
+	ret = 0;
 	zlib_config.status = WD_ZLIB_INIT;
 
 out_freebmp:


### PR DESCRIPTION
It means the UADK compression library has been initialized when wd_comp_init2_ return -WD_EEXIST. Wd_zlibwrapper doesn't need to do it again. But WD_EEXIST is not a valid return value for zlib APIs. So change it to 0.