### PR TITLE
some bugfix and cleancode for uadk

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,9 +121,9 @@ libwd_crypto_la_LIBADD= -lwd -ldl -lnuma
 libwd_crypto_la_LDFLAGS=$(UADK_VERSION) $(UADK_CRYPTO_SYMBOL)
 libwd_crypto_la_DEPENDENCIES= libwd.la
 
-libhisi_zip_la_LIBADD= -lwd -ldl
+libhisi_zip_la_LIBADD= -lwd -ldl -lwd_comp
 libhisi_zip_la_LDFLAGS=$(UADK_VERSION)
-libhisi_zip_la_DEPENDENCIES= libwd.la
+libhisi_zip_la_DEPENDENCIES= libwd.la libwd_comp.la
 
 libhisi_sec_la_LIBADD= -lwd -lwd_crypto
 libhisi_sec_la_LDFLAGS=$(UADK_VERSION)

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -63,13 +63,6 @@
 #define SEC_MAC_LEN_MASK	0x1F
 #define SEC_AUTH_LEN_MASK	0x3F
 
-#define DES_KEY_SIZE		  8
-#define SEC_3DES_2KEY_SIZE	  (2 * DES_KEY_SIZE)
-#define SEC_3DES_3KEY_SIZE	  (3 * DES_KEY_SIZE)
-#define AES_KEYSIZE_128		  16
-#define AES_KEYSIZE_192		  24
-#define AES_KEYSIZE_256		  32
-
 #define DES3_BLOCK_SIZE		8
 #define AES_BLOCK_SIZE		16
 #define CTR_128BIT_COUNTER	16
@@ -823,9 +816,9 @@ static void update_iv_sgl(struct wd_cipher_msg *msg)
 
 static int get_3des_c_key_len(struct wd_cipher_msg *msg, __u8 *c_key_len)
 {
-	if (msg->key_bytes == SEC_3DES_2KEY_SIZE) {
+	if (msg->key_bytes == DES3_2KEY_SIZE) {
 		*c_key_len = CKEY_LEN_3DES_2KEY;
-	} else if (msg->key_bytes == SEC_3DES_3KEY_SIZE) {
+	} else if (msg->key_bytes == DES3_3KEY_SIZE) {
 		*c_key_len = CKEY_LEN_3DES_3KEY;
 	} else {
 		WD_ERR("failed to check 3des key size, size = %u\n",

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -2152,6 +2152,8 @@ static int fill_aead_bd2_alg(struct wd_aead_msg *msg,
 	case WD_CIPHER_AES:
 		sqe->type2.c_alg = C_ALG_AES;
 		ret = aead_get_aes_key_len(msg, &c_key_len);
+		if (ret)
+			return ret;
 		sqe->type2.icvw_kmode = (__u16)c_key_len << SEC_CKEY_OFFSET;
 		break;
 	default:
@@ -2721,6 +2723,8 @@ static int fill_aead_bd3_alg(struct wd_aead_msg *msg,
 	case WD_CIPHER_AES:
 		sqe->c_mode_alg |= C_ALG_AES << SEC_CALG_OFFSET_V3;
 		ret = aead_get_aes_key_len(msg, &c_key_len);
+		if (ret)
+			return ret;
 		sqe->c_icv_key |= (__u16)c_key_len << SEC_CKEY_OFFSET_V3;
 		break;
 	default:

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -517,12 +517,12 @@ struct hisi_sec_sqe3 {
 	__le32 counter;
 } __attribute__((packed, aligned(4)));
 
-static int g_digest_a_alg[WD_DIGEST_TYPE_MAX] = {
+static __u32 g_digest_a_alg[WD_DIGEST_TYPE_MAX] = {
 	A_ALG_SM3, A_ALG_MD5, A_ALG_SHA1, A_ALG_SHA256, A_ALG_SHA224,
 	A_ALG_SHA384, A_ALG_SHA512, A_ALG_SHA512_224, A_ALG_SHA512_256
 };
 
-static int g_hmac_a_alg[WD_DIGEST_TYPE_MAX] = {
+static __u32 g_hmac_a_alg[WD_DIGEST_TYPE_MAX] = {
 	A_ALG_HMAC_SM3, A_ALG_HMAC_MD5, A_ALG_HMAC_SHA1,
 	A_ALG_HMAC_SHA256, A_ALG_HMAC_SHA224, A_ALG_HMAC_SHA384,
 	A_ALG_HMAC_SHA512, A_ALG_HMAC_SHA512_224, A_ALG_HMAC_SHA512_256,
@@ -1518,7 +1518,7 @@ static int fill_digest_bd2_alg(struct wd_digest_msg *msg,
 
 	if (msg->mode == WD_DIGEST_NORMAL)
 		sqe->type2.mac_key_alg |=
-		(__u32)g_digest_a_alg[msg->alg] << AUTH_ALG_OFFSET;
+		g_digest_a_alg[msg->alg] << AUTH_ALG_OFFSET;
 	else if (msg->mode == WD_DIGEST_HMAC) {
 		if (msg->key_bytes & WORD_ALIGNMENT_MASK) {
 			WD_ERR("failed to check digest key_bytes, size = %u\n",
@@ -1530,7 +1530,7 @@ static int fill_digest_bd2_alg(struct wd_digest_msg *msg,
 		sqe->type2.a_key_addr = (__u64)(uintptr_t)msg->key;
 
 		sqe->type2.mac_key_alg |=
-		(__u32)g_hmac_a_alg[msg->alg] << AUTH_ALG_OFFSET;
+		g_hmac_a_alg[msg->alg] << AUTH_ALG_OFFSET;
 	} else {
 		WD_ERR("failed to check digest mode, mode = %u\n", msg->mode);
 		return -WD_EINVAL;
@@ -1887,7 +1887,7 @@ static int fill_digest_bd3_alg(struct wd_digest_msg *msg,
 
 	if (msg->mode == WD_DIGEST_NORMAL) {
 		sqe->auth_mac_key |=
-		(__u32)g_digest_a_alg[msg->alg] << SEC_AUTH_ALG_OFFSET_V3;
+		g_digest_a_alg[msg->alg] << SEC_AUTH_ALG_OFFSET_V3;
 	} else if (msg->mode == WD_DIGEST_HMAC) {
 		ret = hmac_key_len_check(msg);
 		if (ret)
@@ -1897,7 +1897,7 @@ static int fill_digest_bd3_alg(struct wd_digest_msg *msg,
 			WORD_BYTES) << SEC_AKEY_OFFSET_V3;
 		sqe->a_key_addr = (__u64)(uintptr_t)msg->key;
 		sqe->auth_mac_key |=
-		(__u32)g_hmac_a_alg[msg->alg] << SEC_AUTH_ALG_OFFSET_V3;
+		g_hmac_a_alg[msg->alg] << SEC_AUTH_ALG_OFFSET_V3;
 
 		if (msg->alg == WD_DIGEST_AES_GMAC) {
 			sqe->auth_mac_key |= AI_GEN_IVIN_ADDR << SEC_AI_GEN_OFFSET_V3;

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -539,12 +539,93 @@ static __u32 g_sec_hmac_full_len[WD_DIGEST_TYPE_MAX] = {
 static int hisi_sec_init(struct wd_alg_driver *drv, void *conf);
 static void hisi_sec_exit(struct wd_alg_driver *drv);
 
+static int hisi_sec_cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_cipher_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_cipher_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+
+static int hisi_sec_digest_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_digest_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_digest_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_digest_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+
+static int hisi_sec_aead_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_aead_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_aead_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+static int hisi_sec_aead_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg);
+
+static int cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
+	struct hisi_qm_queue_info q_info = qp->q_info;
+
+	if (q_info.hw_type == HISI_QM_API_VER2_BASE)
+		return hisi_sec_cipher_send(drv, ctx, msg);
+	return hisi_sec_cipher_send_v3(drv, ctx, msg);
+}
+
+static int cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
+	struct hisi_qm_queue_info q_info = qp->q_info;
+
+	if (q_info.hw_type == HISI_QM_API_VER2_BASE)
+		return hisi_sec_cipher_recv(drv, ctx, msg);
+	return hisi_sec_cipher_recv_v3(drv, ctx, msg);
+}
+
+static int digest_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
+	struct hisi_qm_queue_info q_info = qp->q_info;
+
+	if (q_info.hw_type == HISI_QM_API_VER2_BASE)
+		return hisi_sec_digest_send(drv, ctx, msg);
+	return hisi_sec_digest_send_v3(drv, ctx, msg);
+}
+
+static int digest_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
+	struct hisi_qm_queue_info q_info = qp->q_info;
+
+	if (q_info.hw_type == HISI_QM_API_VER2_BASE)
+		return hisi_sec_digest_recv(drv, ctx, msg);
+	return hisi_sec_digest_recv_v3(drv, ctx, msg);
+}
+
+static int aead_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
+	struct hisi_qm_queue_info q_info = qp->q_info;
+
+	if (q_info.hw_type == HISI_QM_API_VER2_BASE)
+		return hisi_sec_aead_send(drv, ctx, msg);
+	return hisi_sec_aead_send_v3(drv, ctx, msg);
+}
+
+static int aead_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
+	struct hisi_qm_queue_info q_info = qp->q_info;
+
+	if (q_info.hw_type == HISI_QM_API_VER2_BASE)
+		return hisi_sec_aead_recv(drv, ctx, msg);
+	return hisi_sec_aead_recv_v3(drv, ctx, msg);
+}
+
 static int hisi_sec_get_usage(void *param)
 {
 	return 0;
 }
 
-#define GEN_SEC_ALG_DRIVER(sec_alg_name) \
+#define GEN_SEC_ALG_DRIVER(sec_alg_name, alg_type) \
 {\
 	.drv_name = "hisi_sec2",\
 	.alg_name = (sec_alg_name),\
@@ -555,57 +636,59 @@ static int hisi_sec_get_usage(void *param)
 	.fallback = 0,\
 	.init = hisi_sec_init,\
 	.exit = hisi_sec_exit,\
+	.send = alg_type##_send,\
+	.recv = alg_type##_recv,\
 	.get_usage = hisi_sec_get_usage,\
 }
 
 static struct wd_alg_driver cipher_alg_driver[] = {
-	GEN_SEC_ALG_DRIVER("ecb(aes)"),
-	GEN_SEC_ALG_DRIVER("cbc(aes)"),
-	GEN_SEC_ALG_DRIVER("xts(aes)"),
-	GEN_SEC_ALG_DRIVER("ecb(sm4)"),
-	GEN_SEC_ALG_DRIVER("cbc(sm4)"),
-	GEN_SEC_ALG_DRIVER("ctr(sm4)"),
-	GEN_SEC_ALG_DRIVER("xts(sm4)"),
-	GEN_SEC_ALG_DRIVER("ecb(des)"),
-	GEN_SEC_ALG_DRIVER("cbc(des)"),
-	GEN_SEC_ALG_DRIVER("ecb(des3_ede)"),
-	GEN_SEC_ALG_DRIVER("cbc(des3_ede)"),
+	GEN_SEC_ALG_DRIVER("ecb(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("xts(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("ecb(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("ctr(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("xts(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("ecb(des)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc(des)", cipher),
+	GEN_SEC_ALG_DRIVER("ecb(des3_ede)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc(des3_ede)", cipher),
 
-	GEN_SEC_ALG_DRIVER("ctr(aes)"),
-	GEN_SEC_ALG_DRIVER("ofb(aes)"),
-	GEN_SEC_ALG_DRIVER("cfb(aes)"),
-	GEN_SEC_ALG_DRIVER("cbc-cs1(aes)"),
-	GEN_SEC_ALG_DRIVER("cbc-cs2(aes)"),
-	GEN_SEC_ALG_DRIVER("cbc-cs3(aes)"),
-	GEN_SEC_ALG_DRIVER("ofb(sm4)"),
-	GEN_SEC_ALG_DRIVER("cfb(sm4)"),
-	GEN_SEC_ALG_DRIVER("cbc-cs1(sm4)"),
-	GEN_SEC_ALG_DRIVER("cbc-cs2(sm4)"),
-	GEN_SEC_ALG_DRIVER("cbc-cs3(sm4)"),
+	GEN_SEC_ALG_DRIVER("ctr(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("ofb(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("cfb(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc-cs1(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc-cs2(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc-cs3(aes)", cipher),
+	GEN_SEC_ALG_DRIVER("ofb(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("cfb(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc-cs1(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc-cs2(sm4)", cipher),
+	GEN_SEC_ALG_DRIVER("cbc-cs3(sm4)", cipher),
 };
 
 static struct wd_alg_driver digest_alg_driver[] = {
-	GEN_SEC_ALG_DRIVER("sm3"),
-	GEN_SEC_ALG_DRIVER("md5"),
-	GEN_SEC_ALG_DRIVER("sha1"),
-	GEN_SEC_ALG_DRIVER("sha224"),
-	GEN_SEC_ALG_DRIVER("sha256"),
-	GEN_SEC_ALG_DRIVER("sha384"),
-	GEN_SEC_ALG_DRIVER("sha512"),
-	GEN_SEC_ALG_DRIVER("sha512-224"),
-	GEN_SEC_ALG_DRIVER("sha512-256"),
-	GEN_SEC_ALG_DRIVER("xcbc-mac-96(aes)"),
-	GEN_SEC_ALG_DRIVER("xcbc-prf-128(aes)"),
-	GEN_SEC_ALG_DRIVER("cmac(aes)"),
-	GEN_SEC_ALG_DRIVER("gmac(aes)"),
+	GEN_SEC_ALG_DRIVER("sm3", digest),
+	GEN_SEC_ALG_DRIVER("md5", digest),
+	GEN_SEC_ALG_DRIVER("sha1", digest),
+	GEN_SEC_ALG_DRIVER("sha224", digest),
+	GEN_SEC_ALG_DRIVER("sha256", digest),
+	GEN_SEC_ALG_DRIVER("sha384", digest),
+	GEN_SEC_ALG_DRIVER("sha512", digest),
+	GEN_SEC_ALG_DRIVER("sha512-224", digest),
+	GEN_SEC_ALG_DRIVER("sha512-256", digest),
+	GEN_SEC_ALG_DRIVER("xcbc-mac-96(aes)", digest),
+	GEN_SEC_ALG_DRIVER("xcbc-prf-128(aes)", digest),
+	GEN_SEC_ALG_DRIVER("cmac(aes)", digest),
+	GEN_SEC_ALG_DRIVER("gmac(aes)", digest),
 };
 
 static struct wd_alg_driver aead_alg_driver[] = {
-	GEN_SEC_ALG_DRIVER("ccm(aes)"),
-	GEN_SEC_ALG_DRIVER("gcm(aes)"),
-	GEN_SEC_ALG_DRIVER("authenc(hmac(sha256),cbc(aes))"),
-	GEN_SEC_ALG_DRIVER("ccm(sm4)"),
-	GEN_SEC_ALG_DRIVER("gcm(sm4)"),
+	GEN_SEC_ALG_DRIVER("ccm(aes)", aead),
+	GEN_SEC_ALG_DRIVER("gcm(aes)", aead),
+	GEN_SEC_ALG_DRIVER("authenc(hmac(sha256),cbc(aes))", aead),
+	GEN_SEC_ALG_DRIVER("ccm(sm4)", aead),
+	GEN_SEC_ALG_DRIVER("gcm(sm4)", aead),
 };
 
 static void dump_sec_msg(void *msg, const char *alg)
@@ -1092,10 +1175,10 @@ static int fill_cipher_bd2(struct wd_cipher_msg *msg, struct hisi_sec_sqe *sqe)
 	return 0;
 }
 
-int hisi_sec_cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
+static int hisi_sec_cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_cipher_msg *msg = cipher_msg;
+	struct wd_cipher_msg *msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -1137,10 +1220,10 @@ int hisi_sec_cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *cipher_m
 	return 0;
 }
 
-int hisi_sec_cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
+static int hisi_sec_cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_cipher_msg *recv_msg = cipher_msg;
+	struct wd_cipher_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -1295,10 +1378,10 @@ static int fill_cipher_bd3(struct wd_cipher_msg *msg, struct hisi_sec_sqe3 *sqe)
 	return 0;
 }
 
-int hisi_sec_cipher_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
+static int hisi_sec_cipher_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_cipher_msg *msg = cipher_msg;
+	struct wd_cipher_msg *msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -1385,10 +1468,10 @@ static void parse_cipher_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		dump_sec_msg(temp_msg, "cipher");
 }
 
-int hisi_sec_cipher_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *cipher_msg)
+static int hisi_sec_cipher_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_cipher_msg *recv_msg = cipher_msg;
+	struct wd_cipher_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -1658,10 +1741,10 @@ static int digest_len_check(struct wd_digest_msg *msg,  enum sec_bd_type type)
 	return 0;
 }
 
-int hisi_sec_digest_send(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
+static int hisi_sec_digest_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_digest_msg *msg = digest_msg;
+	struct wd_digest_msg *msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	__u8 scene;
@@ -1725,10 +1808,10 @@ put_sgl:
 	return ret;
 }
 
-int hisi_sec_digest_recv(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
+static int hisi_sec_digest_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_digest_msg *recv_msg = digest_msg;
+	struct wd_digest_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -1902,10 +1985,10 @@ static void fill_digest_v3_scene(struct hisi_sec_sqe3 *sqe,
 	sqe->bd_param |= (__u16)(de | scene);
 }
 
-int hisi_sec_digest_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
+static int hisi_sec_digest_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_digest_msg *msg = digest_msg;
+	struct wd_digest_msg *msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -2001,10 +2084,10 @@ static void parse_digest_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		dump_sec_msg(temp_msg, "digest");
 }
 
-int hisi_sec_digest_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *digest_msg)
+static int hisi_sec_digest_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_digest_msg *recv_msg = digest_msg;
+	struct wd_digest_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -2473,10 +2556,10 @@ int aead_msg_state_check(struct wd_aead_msg *msg)
 	return 0;
 }
 
-int hisi_sec_aead_send(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
+static int hisi_sec_aead_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_aead_msg *msg = aead_msg;
+	struct wd_aead_msg *msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -2595,10 +2678,10 @@ static bool soft_compute_check(struct hisi_qp *qp, struct wd_aead_msg *msg)
 		qp->q_info.qp_mode == CTX_MODE_SYNC;
 }
 
-int hisi_sec_aead_recv(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
+static int hisi_sec_aead_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_aead_msg *recv_msg = aead_msg;
+	struct wd_aead_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
 	int ret;
@@ -2857,10 +2940,10 @@ static int fill_aead_bd3(struct wd_aead_msg *msg, struct hisi_sec_sqe3 *sqe)
 	return 0;
 }
 
-int hisi_sec_aead_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
+static int hisi_sec_aead_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_aead_msg *msg = aead_msg;
+	struct wd_aead_msg *msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -2957,10 +3040,10 @@ static void parse_aead_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 		dump_sec_msg(temp_msg, "aead");
 }
 
-int hisi_sec_aead_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *aead_msg)
+static int hisi_sec_aead_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
-	struct wd_aead_msg *recv_msg = aead_msg;
+	struct wd_aead_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
 	int ret;
@@ -2983,50 +3066,6 @@ int hisi_sec_aead_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *aead_ms
 			recv_msg->in, recv_msg->out);
 
 	return 0;
-}
-
-static void hisi_sec_driver_adapter(struct hisi_qp *qp)
-{
-	struct hisi_qm_queue_info q_info = qp->q_info;
-	int alg_num, i;
-
-	if (q_info.hw_type == HISI_QM_API_VER2_BASE) {
-		WD_INFO("hisi sec init HIP08!\n");
-		alg_num = ARRAY_SIZE(cipher_alg_driver);
-		for (i = 0; i < alg_num; i++) {
-			cipher_alg_driver[i].send = hisi_sec_cipher_send;
-			cipher_alg_driver[i].recv = hisi_sec_cipher_recv;
-		}
-
-		alg_num = ARRAY_SIZE(digest_alg_driver);
-		for (i = 0; i < alg_num; i++) {
-			digest_alg_driver[i].send = hisi_sec_digest_send;
-			digest_alg_driver[i].recv = hisi_sec_digest_recv;
-		}
-		alg_num = ARRAY_SIZE(aead_alg_driver);
-		for (i = 0; i < alg_num; i++) {
-			aead_alg_driver[i].send = hisi_sec_aead_send;
-			aead_alg_driver[i].recv = hisi_sec_aead_recv;
-		}
-	} else {
-		WD_INFO("hisi sec init HIP09!\n");
-		alg_num = ARRAY_SIZE(cipher_alg_driver);
-		for (i = 0; i < alg_num; i++) {
-			cipher_alg_driver[i].send = hisi_sec_cipher_send_v3;
-			cipher_alg_driver[i].recv = hisi_sec_cipher_recv_v3;
-		}
-
-		alg_num = ARRAY_SIZE(digest_alg_driver);
-		for (i = 0; i < alg_num; i++) {
-			digest_alg_driver[i].send = hisi_sec_digest_send_v3;
-			digest_alg_driver[i].recv = hisi_sec_digest_recv_v3;
-		}
-		alg_num = ARRAY_SIZE(aead_alg_driver);
-		for (i = 0; i < alg_num; i++) {
-			aead_alg_driver[i].send = hisi_sec_aead_send_v3;
-			aead_alg_driver[i].recv = hisi_sec_aead_recv_v3;
-		}
-	}
 }
 
 static int hisi_sec_init(struct wd_alg_driver *drv, void *conf)
@@ -3069,7 +3108,6 @@ static int hisi_sec_init(struct wd_alg_driver *drv, void *conf)
 		config->ctxs[i].sqn = qm_priv.sqn;
 	}
 	memcpy(&priv->config, config, sizeof(struct wd_ctx_config_internal));
-	hisi_sec_driver_adapter((struct hisi_qp *)h_qp);
 	drv->priv = priv;
 
 	return 0;

--- a/include/wd.h
+++ b/include/wd.h
@@ -7,6 +7,7 @@
 #ifndef __WD_H
 #define __WD_H
 #include <errno.h>
+#include <numa.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -9,6 +9,7 @@
 
 #include <pthread.h>
 #include <stdbool.h>
+#include <numa.h>
 #include "wd.h"
 #include "wd_alg.h"
 

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -29,6 +29,19 @@ extern "C" {
 #define CTX_TYPE_INVALID	9999
 #define POLL_TIME		1000
 
+/* Key size of chiper */
+#define MAX_CIPHER_KEY_SIZE	64
+#define AES_KEYSIZE_128		16
+#define AES_KEYSIZE_192		24
+#define AES_KEYSIZE_256		32
+#define SM4_KEY_SIZE		16
+#define DES_KEY_SIZE		8
+#define DES3_2KEY_SIZE		(2 * DES_KEY_SIZE)
+#define DES3_3KEY_SIZE		(3 * DES_KEY_SIZE)
+
+/* Key size of digest */
+#define MAX_HMAC_KEY_SIZE	128U
+
 enum alg_task_type {
 	TASK_MIX = 0x0,
 	TASK_HW,

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -8,6 +8,7 @@
 #define __WD_CIPHER_H
 
 #include <dlfcn.h>
+#include <asm/types.h>
 #include "wd_alg_common.h"
 
 #ifdef __cplusplus

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -18,7 +18,6 @@ extern "C" {
 #define AES_BLOCK_SIZE	16
 #define GCM_IV_SIZE	12
 #define DES3_BLOCK_SIZE	8
-#define MAX_CIPHER_KEY_SIZE	64
 #define MAX_IV_SIZE	AES_BLOCK_SIZE
 
 /**

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -14,8 +14,6 @@
 extern "C" {
 #endif
 
-#define MAX_HMAC_KEY_SIZE	128U
-
 /**
  * wd_digest_type - Algorithm type of digest
  * algorithm should be offered by struct wd_digest_arg

--- a/include/wd_sched.h
+++ b/include/wd_sched.h
@@ -6,6 +6,7 @@
 
 #ifndef SCHED_SAMPLE_h
 #define SCHED_SAMPLE_h
+#include <asm/types.h>
 #include "wd_alg_common.h"
 
 #ifdef __cplusplus

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -13,7 +13,9 @@
 #include <sys/shm.h>
 #include <asm/types.h>
 
+#include "wd.h"
 #include "wd_sched.h"
+#include "wd_alg.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -236,6 +236,18 @@ void *wd_find_msg_in_pool(struct wd_async_msg_pool *pool, int ctx_idx,
 			  __u32 tag);
 
 /*
+ * wd_check_src_dst() - Check the request input and output
+ * @src: input data pointer.
+ * @in_bytes: input data length.
+ * @dst: output data pointer.
+ * @out_bytes: output data length.
+ *
+ * Return -WD_EINVAL when in_bytes or out_bytes is non-zero, the
+ * corresponding input or output pointers is NULL, otherwise return 0.
+ */
+int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes);
+
+/*
  * wd_check_datalist() - Check the data list length
  * @head: Data list's head pointer.
  * @size: The size which is expected.

--- a/v1/drv/hisi_sec_udrv.c
+++ b/v1/drv/hisi_sec_udrv.c
@@ -31,10 +31,6 @@
 #include "config.h"
 #include "hisi_sec_udrv.h"
 
-#define DES_KEY_SIZE 8
-#define SEC_3DES_2KEY_SIZE (2 * DES_KEY_SIZE)
-#define SEC_3DES_3KEY_SIZE (3 * DES_KEY_SIZE)
-
 #define SEC_HW_TASK_DONE	1
 #define SEC_HW_ICV_ERR		0x2
 #define SEC_SM4_XTS_GB_V3	0x1
@@ -47,11 +43,8 @@
 #define CTR_128BIT_COUNTER	16
 #define CTR_128BIT_FLIP		0x2
 #define DIF_VERIFY_FAIL		2
-#define AES_BLOCK_SIZE		16
 #define WCRYPTO_CIPHER_THEN_DIGEST	0
 #define WCRYPTO_DIGEST_THEN_CIPHER	1
-#define CBC_3DES_BLOCK_SIZE	8
-#define CBC_AES_BLOCK_SIZE	16
 #define AEAD_IV_MAX_BYTES	64
 #define MAX_CCM_AAD_LEN		65279
 #define SEC_GMAC_IV_LEN	16
@@ -111,9 +104,9 @@ static int get_aes_c_key_len(__u8 mode, __u16 key_bytes, __u8 *c_key_len)
 
 static int get_3des_c_key_len(struct wcrypto_cipher_msg *msg, __u8 *c_key_len)
 {
-	if (msg->key_bytes == SEC_3DES_2KEY_SIZE)
+	if (msg->key_bytes == DES3_2KEY_SIZE)
 		*c_key_len = CKEY_LEN_3DES_2KEY;
-	else if (msg->key_bytes == SEC_3DES_3KEY_SIZE)
+	else if (msg->key_bytes == DES3_3KEY_SIZE)
 		*c_key_len = CKEY_LEN_3DES_3KEY;
 	else {
 		WD_ERR("Invalid 3DES key size!\n");

--- a/v1/wd_adapter.c
+++ b/v1/wd_adapter.c
@@ -209,9 +209,7 @@ void *drv_reserve_mem(struct wd_queue *q, size_t size)
 
 	ptr = wd_drv_mmap_qfr(q, WD_UACCE_QFRT_SS, tmp);
 	if (ptr == MAP_FAILED) {
-		int value = errno;
-
-		WD_ERR("wd drv mmap fail!(err =%d)\n", value);
+		WD_ERR("wd drv mmap fail!(err = %d)\n", errno);
 		return NULL;
 	}
 
@@ -219,7 +217,7 @@ void *drv_reserve_mem(struct wd_queue *q, size_t size)
 	qinfo->ss_size = tmp;
 	tmp = 0;
 	while (ret > 0) {
-		info = (unsigned long)i;
+		info = i;
 		ret = ioctl(qinfo->fd, WD_UACCE_CMD_GET_SS_DMA, &info);
 		if (ret < 0) {
 			drv_show_ss_slices(q);

--- a/v1/wd_aead.c
+++ b/v1/wd_aead.c
@@ -593,10 +593,8 @@ int wcrypto_burst_aead(void *a_ctx, struct wcrypto_aead_op_data **opdata,
 		return -WD_EINVAL;
 
 	ret = wd_get_cookies(&ctxt->pool, (void **)cookies, num);
-	if (unlikely(ret)) {
-		WD_ERR("failed to get cookies %d!\n", ret);
+	if (unlikely(ret))
 		return ret;
-	}
 
 	for (i = 0; i < num; i++) {
 		cookies[i]->tag.priv = opdata[i]->priv;

--- a/v1/wd_aead.c
+++ b/v1/wd_aead.c
@@ -540,7 +540,7 @@ static int param_check(struct wcrypto_aead_ctx *a_ctx,
 			return -WD_EINVAL;
 		}
 
-		ret = wd_check_src_dst(a_opdata[i]->in, a_opdata[i]->in_bytes, a_opdata[i]->out, a_opdata[i]->out_bytes);
+		ret = wd_check_src_dst_ptr(a_opdata[i]->in, a_opdata[i]->in_bytes, a_opdata[i]->out, a_opdata[i]->out_bytes);
 		if (unlikely(ret)) {
 			WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 			return -WD_EINVAL;

--- a/v1/wd_aead.c
+++ b/v1/wd_aead.c
@@ -26,23 +26,8 @@
 #include "wd_util.h"
 #include "wd_aead.h"
 
-#define MAX_AEAD_KEY_SIZE		64
-#define MAX_AEAD_MAC_SIZE		64
-#define MAX_CIPHER_KEY_SIZE		64
 #define MAX_AEAD_AUTH_SIZE		64
-#define MAX_AEAD_ASSOC_SIZE		65536
-#define MAX_HMAC_KEY_SIZE		128
 #define MAX_AEAD_RETRY_CNT		20000000
-
-#define DES_KEY_SIZE 8
-#define SM4_KEY_SIZE 16
-#define SEC_3DES_2KEY_SIZE (2 * DES_KEY_SIZE)
-#define SEC_3DES_3KEY_SIZE (3 * DES_KEY_SIZE)
-
-#define AES_BLOCK_SIZE 16
-#define GCM_BLOCK_SIZE 12
-
-#define MAX_BURST_NUM	16
 
 static int g_aead_mac_len[WCRYPTO_MAX_DIGEST_TYPE] = {
 	WCRYPTO_SM3_LEN, WCRYPTO_MD5_LEN, WCRYPTO_SHA1_LEN,

--- a/v1/wd_cipher.c
+++ b/v1/wd_cipher.c
@@ -26,17 +26,10 @@
 #include "v1/wd_util.h"
 #include "v1/wd_cipher.h"
 
-#define MAX_CIPHER_KEY_SIZE		64
 #define MAX_CIPHER_RETRY_CNT		20000000
 
 #define XTS_MODE_KEY_LEN_MASK 0x1
-#define DES_KEY_SIZE 8
-#define SM4_KEY_SIZE 16
-#define SEC_3DES_2KEY_SIZE (2 * DES_KEY_SIZE)
-#define SEC_3DES_3KEY_SIZE (3 * DES_KEY_SIZE)
 
-#define CBC_3DES_BLOCK_SIZE 8
-#define CBC_AES_BLOCK_SIZE 16
 #define DES_WEAK_KEY_NUM 4
 static __u64 des_weak_key[DES_WEAK_KEY_NUM] = {0x0101010101010101, 0xFEFEFEFEFEFEFEFE,
 	0xE0E0E0E0F1F1F1F1, 0x1F1F1F1F0E0E0E0E};
@@ -300,7 +293,7 @@ static int cipher_key_len_check(struct wcrypto_cipher_ctx_setup *setup,
 			ret = -WD_EINVAL;
 		break;
 	case WCRYPTO_CIPHER_3DES:
-		if ((key_len != SEC_3DES_2KEY_SIZE) && (key_len != SEC_3DES_3KEY_SIZE))
+		if ((key_len != DES3_2KEY_SIZE) && (key_len != DES3_3KEY_SIZE))
 			ret = -WD_EINVAL;
 		break;
 	default:

--- a/v1/wd_cipher.c
+++ b/v1/wd_cipher.c
@@ -432,7 +432,7 @@ static int param_check(struct wcrypto_cipher_ctx *c_ctx,
 			return -WD_EINVAL;
 		}
 
-		ret = wd_check_src_dst(c_opdata[i]->in, c_opdata[i]->in_bytes, c_opdata[i]->out, c_opdata[i]->out_bytes);
+		ret = wd_check_src_dst_ptr(c_opdata[i]->in, c_opdata[i]->in_bytes, c_opdata[i]->out, c_opdata[i]->out_bytes);
 		if (unlikely(ret)) {
 			WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 			return -WD_EINVAL;

--- a/v1/wd_cipher.c
+++ b/v1/wd_cipher.c
@@ -477,10 +477,8 @@ int wcrypto_burst_cipher(void *ctx, struct wcrypto_cipher_op_data **c_opdata,
 		return -WD_EINVAL;
 
 	ret = wd_get_cookies(&ctxt->pool, (void **)cookies, num);
-	if (unlikely(ret)) {
-		WD_ERR("failed to get cookies %d!\n", ret);
+	if (unlikely(ret))
 		return ret;
-	}
 
 	for (i = 0; i < num; i++) {
 		cookies[i]->tag.priv = c_opdata[i]->priv;

--- a/v1/wd_cipher.c
+++ b/v1/wd_cipher.c
@@ -107,7 +107,7 @@ static __u32 get_iv_block_size(int alg, int mode)
 static int create_ctx_para_check(struct wd_queue *q,
 	struct wcrypto_cipher_ctx_setup *setup)
 {
-	if (!q || !setup) {
+	if (!q || !q->qinfo || !setup) {
 		WD_ERR("%s: input param err!\n", __func__);
 		return -WD_EINVAL;
 	}
@@ -426,26 +426,38 @@ static int param_check(struct wcrypto_cipher_ctx *c_ctx,
 		       void **tag, __u32 num)
 {
 	__u32 i;
+	int ret;
 
 	if (unlikely(!c_ctx || !c_opdata || !num || num > WCRYPTO_MAX_BURST_NUM)) {
-		WD_ERR("input param err!\n");
+		WD_ERR("invalid: input param err!\n");
 		return -WD_EINVAL;
 	}
 
 	for (i = 0; i < num; i++) {
 		if (unlikely(!c_opdata[i])) {
-			WD_ERR("cipher opdata[%u] is NULL!\n", i);
+			WD_ERR("invalid: cipher opdata[%u] is NULL!\n", i);
+			return -WD_EINVAL;
+		}
+
+		ret = wd_check_src_dst(c_opdata[i]->in, c_opdata[i]->in_bytes, c_opdata[i]->out, c_opdata[i]->out_bytes);
+		if (unlikely(ret)) {
+			WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
+			return -WD_EINVAL;
+		}
+
+		if (c_ctx->setup.mode != WCRYPTO_CIPHER_ECB && !c_opdata[i]->iv) {
+			WD_ERR("invalid: cipher input iv is NULL!\n");
 			return -WD_EINVAL;
 		}
 
 		if (unlikely(tag && !tag[i])) {
-			WD_ERR("tag[%u] is NULL!\n", i);
+			WD_ERR("invalid: tag[%u] is NULL!\n", i);
 			return -WD_EINVAL;
 		}
 	}
 
 	if (unlikely(tag && !c_ctx->setup.cb)) {
-		WD_ERR("cipher ctx call back is NULL!\n");
+		WD_ERR("invalid: cipher ctx call back is NULL!\n");
 		return -WD_EINVAL;
 	}
 

--- a/v1/wd_comp.c
+++ b/v1/wd_comp.c
@@ -60,8 +60,8 @@ static int ctx_params_check(struct wd_queue *q, struct wcrypto_comp_ctx_setup *s
 {
 	struct q_info *qinfo;
 
-	if (!q || !setup) {
-		WD_ERR("err: q or setup is NULL!\n");
+	if (!q || !q->qinfo || !setup) {
+		WD_ERR("%s: input param err!\n", __func__);
 		return -WD_EINVAL;
 	}
 
@@ -255,8 +255,8 @@ int wcrypto_do_comp(void *ctx, struct wcrypto_comp_op_data *opdata, void *tag)
 	__u64 recv_count = 0;
 	int ret;
 
-	if (!ctx || !opdata) {
-		WD_ERR("input parameter err!\n");
+	if (unlikely(!ctx || !opdata || !opdata->in || !opdata->out)) {
+		WD_ERR("invalid: comp input parameter err!\n");
 		return -EINVAL;
 	}
 
@@ -267,7 +267,7 @@ int wcrypto_do_comp(void *ctx, struct wcrypto_comp_op_data *opdata, void *tag)
 	msg = &cookie->msg;
 	if (tag) {
 		if (!cctx->cb) {
-			WD_ERR("ctx call back is null!\n");
+			WD_ERR("invalid: ctx call back is null!\n");
 			ret = -WD_EINVAL;
 			goto err_put_cookie;
 		}

--- a/v1/wd_dh.c
+++ b/v1/wd_dh.c
@@ -188,6 +188,10 @@ void *wcrypto_create_dh_ctx(struct wd_queue *q, struct wcrypto_dh_ctx_setup *set
 		goto free_ctx;
 	}
 	ctx->g.data = ctx->setup.br.alloc(ctx->setup.br.usr, ctx->key_size);
+	if (!ctx->g.data) {
+		WD_ERR("failed to alloc ctx->g.data memory!\n");
+		goto free_ctx;
+	}
 	ctx->g.bsize = ctx->key_size;
 
 	ret = wcrypto_init_dh_cookie(ctx);

--- a/v1/wd_dh.c
+++ b/v1/wd_dh.c
@@ -56,7 +56,7 @@ struct wcrypto_dh_ctx {
 static int create_ctx_param_check(struct wd_queue *q,
 				  struct wcrypto_dh_ctx_setup *setup)
 {
-	if (!q || !setup) {
+	if (!q || !q->qinfo || !setup) {
 		WD_ERR("%s(): input parameter err!\n", __func__);
 		return -WD_EINVAL;
 	}
@@ -299,12 +299,12 @@ static int do_dh_prepare(struct wcrypto_dh_op_data *opdata,
 	int ret;
 
 	if (unlikely(!ctxt || !opdata)) {
-		WD_ERR("input parameter err!\n");
+		WD_ERR("invalid: dh input parameter err!\n");
 		return -WD_EINVAL;
 	}
 
 	if (unlikely(tag && !ctxt->setup.cb)) {
-		WD_ERR("ctx call back is null!\n");
+		WD_ERR("invalid: ctx call back is null!\n");
 		return -WD_EINVAL;
 	}
 

--- a/v1/wd_digest.c
+++ b/v1/wd_digest.c
@@ -456,10 +456,8 @@ int wcrypto_burst_digest(void *d_ctx, struct wcrypto_digest_op_data **opdata,
 		return -WD_EINVAL;
 
 	ret = wd_get_cookies(&ctxt->pool, (void **)cookies, num);
-	if (unlikely(ret)) {
-		WD_ERR("failed to get cookies %d!\n", ret);
+	if (unlikely(ret))
 		return ret;
-	}
 
 	for (i = 0; i < num; i++) {
 		cookies[i]->tag.priv = opdata[i]->priv;

--- a/v1/wd_digest.c
+++ b/v1/wd_digest.c
@@ -437,7 +437,7 @@ static int param_check(struct wcrypto_digest_ctx *d_ctx,
 			return -WD_EINVAL;
 		}
 
-		ret = wd_check_src_dst(d_opdata[i]->in, d_opdata[i]->in_bytes,
+		ret = wd_check_src_dst_ptr(d_opdata[i]->in, d_opdata[i]->in_bytes,
 				       d_opdata[i]->out, d_opdata[i]->out_bytes);
 		if (unlikely(ret)) {
 			WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");

--- a/v1/wd_digest.c
+++ b/v1/wd_digest.c
@@ -26,7 +26,6 @@
 #include "wd_util.h"
 #include "wd_digest.h"
 
-#define MAX_HMAC_KEY_SIZE	128
 #define MAX_DIGEST_RETRY_CNT	20000000
 #define SEC_SHA1_ALIGN_SZ	64
 #define SEC_SHA512_ALIGN_SZ	128

--- a/v1/wd_ecc.c
+++ b/v1/wd_ecc.c
@@ -1006,7 +1006,7 @@ static bool is_key_width_support(__u32 key_bits)
 
 static int param_check(struct wd_queue *q, struct wcrypto_ecc_ctx_setup *setup)
 {
-	if (unlikely(!q || !setup)) {
+	if (unlikely(!q || !q->qinfo || !setup)) {
 		WD_ERR("input parameter error!\n");
 		return -WD_EINVAL;
 	}
@@ -1663,7 +1663,7 @@ static int ecc_poll(struct wd_queue *q, unsigned int num)
 int wcrypto_do_ecxdh(void *ctx, struct wcrypto_ecc_op_data *opdata, void *tag)
 {
 	if (unlikely(!opdata)) {
-		WD_ERR("do ecxdh: opdata null!\n");
+		WD_ERR("invalid: do ecxdh: opdata null!\n");
 		return -WD_EINVAL;
 	}
 
@@ -2176,7 +2176,7 @@ void wcrypto_get_ecdsa_sign_in_params(struct wcrypto_ecc_in *in,
 int wcrypto_do_ecdsa(void *ctx, struct wcrypto_ecc_op_data *opdata, void *tag)
 {
 	if (unlikely(!opdata)) {
-		WD_ERR("do ecdsa: opdata null!\n");
+		WD_ERR("invalid: do ecdsa: opdata null!\n");
 		return -WD_EINVAL;
 	}
 
@@ -2463,7 +2463,7 @@ int wcrypto_do_sm2(void *ctx, struct wcrypto_ecc_op_data *opdata, void *tag)
 	struct wcrypto_ecc_in *in;
 
 	if (unlikely(!opdata)) {
-		WD_ERR("do sm2: opdata null!\n");
+		WD_ERR("invalid: do sm2: opdata null!\n");
 		return -WD_EINVAL;
 	}
 

--- a/v1/wd_rng.c
+++ b/v1/wd_rng.c
@@ -48,7 +48,7 @@ static int wcrypto_setup_qinfo(struct wcrypto_rng_ctx_setup *setup,
 	struct q_info *qinfo;
 	int ret = -WD_EINVAL;
 
-	if (!q || !setup) {
+	if (!q || !q->qinfo || !setup) {
 		WD_ERR("input parameter err!\n");
 		return ret;
 	}
@@ -202,8 +202,13 @@ static int wcrypto_do_prepare(struct wcrypto_rng_cookie **cookie_addr,
 	struct wcrypto_rng_msg *req;
 	int ret;
 
-	if (!ctxt || !opdata) {
-		WD_ERR("input parameter err!\n");
+	if (unlikely(!ctxt || !opdata)) {
+		WD_ERR("invalid: rng input parameter err!\n");
+		return -WD_EINVAL;
+	}
+
+	if (unlikely((opdata->in_bytes && !opdata->out))) {
+		WD_ERR("invalid: dst addr is NULL when in_bytes is non-zero!!\n");
 		return -WD_EINVAL;
 	}
 
@@ -213,7 +218,7 @@ static int wcrypto_do_prepare(struct wcrypto_rng_cookie **cookie_addr,
 
 	if (tag) {
 		if (!ctxt->setup.cb) {
-			WD_ERR("ctx call back is null!\n");
+			WD_ERR("invalid: ctx call back is null!\n");
 			wd_put_cookies(&ctxt->pool, (void **)&cookie, 1);
 			return -WD_EINVAL;
 		}

--- a/v1/wd_rng.c
+++ b/v1/wd_rng.c
@@ -144,14 +144,14 @@ void wcrypto_del_rng_ctx(void *ctx)
 
 	wd_uninit_cookie_pool(&cx->pool);
 	wd_spinlock(&qinfo->qlock);
-	wd_free_id(qinfo->ctx_id, WD_MAX_CTX_NUM, cx->ctx_id - 1,
-		WD_MAX_CTX_NUM);
-	qinfo->ctx_num--;
-	if (qinfo->ctx_num < 0) {
+	if (qinfo->ctx_num <= 0) {
 		wd_unspinlock(&qinfo->qlock);
 		WD_ERR("repeat delete trng ctx!\n");
 		return;
 	}
+	qinfo->ctx_num--;
+	wd_free_id(qinfo->ctx_id, WD_MAX_CTX_NUM, cx->ctx_id - 1,
+		WD_MAX_CTX_NUM);
 	wd_unspinlock(&qinfo->qlock);
 
 	free(ctx);

--- a/v1/wd_rsa.c
+++ b/v1/wd_rsa.c
@@ -549,7 +549,7 @@ static void del_ctx(struct wcrypto_rsa_ctx *c)
 
 static int check_q_setup(struct wd_queue *q, struct wcrypto_rsa_ctx_setup *setup)
 {
-	if (!q || !setup) {
+	if (!q || !q->qinfo || !setup) {
 		WD_ERR("create rsa ctx input parameter err!\n");
 		return -WD_EINVAL;
 	}
@@ -957,12 +957,18 @@ static int do_rsa_prepare(struct wcrypto_rsa_ctx *ctxt,
 	int ret;
 
 	if (unlikely(!ctxt || !opdata)) {
-		WD_ERR("input parameter err!\n");
+		WD_ERR("invalid: input parameter err!\n");
+		return -WD_EINVAL;
+	}
+
+	ret = wd_check_src_dst(opdata->in, opdata->in_bytes, opdata->out, opdata->out_bytes);
+	if (unlikely(ret)) {
+		WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 		return -WD_EINVAL;
 	}
 
 	if (unlikely(tag && !ctxt->setup.cb)) {
-		WD_ERR("ctx call back is null!\n");
+		WD_ERR("invalid: ctx call back is null!\n");
 		return -WD_EINVAL;
 	}
 

--- a/v1/wd_rsa.c
+++ b/v1/wd_rsa.c
@@ -961,7 +961,7 @@ static int do_rsa_prepare(struct wcrypto_rsa_ctx *ctxt,
 		return -WD_EINVAL;
 	}
 
-	ret = wd_check_src_dst(opdata->in, opdata->in_bytes, opdata->out, opdata->out_bytes);
+	ret = wd_check_src_dst_ptr(opdata->in, opdata->in_bytes, opdata->out, opdata->out_bytes);
 	if (unlikely(ret)) {
 		WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 		return -WD_EINVAL;

--- a/v1/wd_util.c
+++ b/v1/wd_util.c
@@ -183,7 +183,7 @@ int wd_burst_recv(struct wd_queue *q, void **resp, __u32 num)
 	return drv_recv(q, resp, num);
 }
 
-int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes)
+int wd_check_src_dst_ptr(void *src, __u32 in_bytes, void *dst, __u32 out_bytes)
 {
 	if (unlikely((in_bytes && !src) || (out_bytes && !dst)))
 		return -WD_EINVAL;

--- a/v1/wd_util.c
+++ b/v1/wd_util.c
@@ -182,3 +182,10 @@ int wd_burst_recv(struct wd_queue *q, void **resp, __u32 num)
 {
 	return drv_recv(q, resp, num);
 }
+
+int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes)
+{
+	if (unlikely((in_bytes && !src) || (out_bytes && !dst)))
+		return -WD_EINVAL;
+	return 0;
+}

--- a/v1/wd_util.h
+++ b/v1/wd_util.h
@@ -76,6 +76,23 @@
 #define X_DH_OUT_PARAM_NUM		1
 #define X_DH_HW_KEY_PARAM_NUM		3
 
+/* Key size and block size of aead */
+#define MAX_AEAD_KEY_SIZE		64
+#define GCM_BLOCK_SIZE			12
+
+/* Key size and block size of chiper */
+#define MAX_CIPHER_KEY_SIZE		64
+#define AES_BLOCK_SIZE			16
+#define DES_KEY_SIZE			8
+#define SM4_KEY_SIZE			16
+#define DES3_2KEY_SIZE			(2 * DES_KEY_SIZE)
+#define DES3_3KEY_SIZE			(3 * DES_KEY_SIZE)
+#define CBC_AES_BLOCK_SIZE		16
+#define CBC_3DES_BLOCK_SIZE		8
+
+/* Key size and block size of digest */
+#define MAX_HMAC_KEY_SIZE		128
+
 #define X_DH_OUT_PARAMS_SZ(hsz)		((hsz) * X_DH_OUT_PARAM_NUM)
 #define X_DH_HW_KEY_SZ(hsz)		((hsz) * X_DH_HW_KEY_PARAM_NUM)
 #define SM2_KG_OUT_PARAMS_SZ(hsz)	((hsz) * SM2_KG_OUT_PARAM_NUM)

--- a/v1/wd_util.h
+++ b/v1/wd_util.h
@@ -421,6 +421,6 @@ void drv_set_sgl_pri(struct wd_sgl *sgl, void *priv);
 void *drv_get_sgl_pri(struct wd_sgl *sgl);
 struct wd_mm_br *drv_get_br(void *pool);
 void wd_sgl_memset(struct wd_sgl *sgl, int ch);
-int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes);
+int wd_check_src_dst_ptr(void *src, __u32 in_bytes, void *dst, __u32 out_bytes);
 
 #endif

--- a/v1/wd_util.h
+++ b/v1/wd_util.h
@@ -404,5 +404,6 @@ void drv_set_sgl_pri(struct wd_sgl *sgl, void *priv);
 void *drv_get_sgl_pri(struct wd_sgl *sgl);
 struct wd_mm_br *drv_get_br(void *pool);
 void wd_sgl_memset(struct wd_sgl *sgl, int ch);
+int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes);
 
 #endif

--- a/wd.c
+++ b/wd.c
@@ -228,7 +228,7 @@ static int get_dev_info(struct uacce_dev *dev)
 			return ret;
 		else if (value == 1) {
 			WD_ERR("skip isolated uacce device!\n");
-			return -ENODEV;
+			return -WD_ENODEV;
 		}
 	}
 
@@ -237,7 +237,7 @@ static int get_dev_info(struct uacce_dev *dev)
 		return ret;
 	else if (!((unsigned int)dev->flags & UACCE_DEV_SVA)) {
 		WD_ERR("skip none sva uacce device!\n");
-		return -ENODEV;
+		return -WD_ENODEV;
 	}
 
 	ret = get_int_attr(dev, "region_mmio_size", &value);

--- a/wd.c
+++ b/wd.c
@@ -426,7 +426,7 @@ handle_t wd_request_ctx(struct uacce_dev *dev)
 
 	wd_ctx_init_qfrs_offs(ctx);
 
-	strncpy(ctx->dev_path, dev->char_dev_path, MAX_DEV_NAME_LEN);
+	memcpy(ctx->dev_path, dev->char_dev_path, MAX_DEV_NAME_LEN);
 	ctx->dev_path[MAX_DEV_NAME_LEN - 1] = '\0';
 
 	return (handle_t)ctx;

--- a/wd.c
+++ b/wd.c
@@ -756,7 +756,7 @@ struct uacce_dev *wd_find_dev_by_numa(struct uacce_dev_list *list, int numa_id)
 	}
 
 	while (p) {
-		if (numa_id != p->dev->numa_id) {
+		if (p->dev && numa_id != p->dev->numa_id) {
 			p = p->next;
 			continue;
 		}

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -361,6 +361,11 @@ static int wd_aead_param_check(struct wd_aead_sess *sess,
 		return -WD_EINVAL;
 	}
 
+	if (unlikely(!req->iv || !req->mac)) {
+		WD_ERR("invalid: aead input iv or mac is NULL!\n");
+		return -WD_EINVAL;
+	}
+
 	if (unlikely(sess->cmode == WD_CIPHER_CBC && req->in_bytes == 0)) {
 		WD_ERR("aead input data length is zero!\n");
 		return -WD_EINVAL;
@@ -381,6 +386,12 @@ static int wd_aead_param_check(struct wd_aead_sess *sess,
 
 	if (unlikely(req->mac_bytes < sess->auth_bytes)) {
 		WD_ERR("failed to check aead mac length, size = %u\n", req->mac_bytes);
+		return -WD_EINVAL;
+	}
+
+	ret = wd_check_src_dst(req->src, req->in_bytes, req->dst, req->out_bytes);
+	if (unlikely(ret)) {
+		WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -816,7 +816,7 @@ int wd_aead_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	__u32 tmp = expt;
 	int ret;
 
-	if (unlikely(!count)) {
+	if (unlikely(!count || !expt)) {
 		WD_ERR("invalid: aead poll ctx input param is NULL!\n");
 		return -WD_EINVAL;
 	}

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -10,15 +10,6 @@
 #include "include/drv/wd_aead_drv.h"
 #include "wd_aead.h"
 
-#define XTS_MODE_KEY_DIVISOR	2
-#define SM4_KEY_SIZE		16
-#define DES_KEY_SIZE		8
-#define DES3_2KEY_SIZE		(2 * DES_KEY_SIZE)
-#define DES3_3KEY_SIZE		(3 * DES_KEY_SIZE)
-#define AES_KEYSIZE_128		16
-#define AES_KEYSIZE_192		24
-#define AES_KEYSIZE_256		32
-
 #define WD_AEAD_CCM_GCM_MIN	4U
 #define WD_AEAD_CCM_GCM_MAX	16
 

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -730,7 +730,7 @@ int wd_cipher_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	__u32 tmp = expt;
 	int ret;
 
-	if (unlikely(!count)) {
+	if (unlikely(!count || !expt)) {
 		WD_ERR("invalid: cipher poll ctx input param is NULL!\n");
 		return -WD_EINVAL;
 	}

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -13,13 +13,6 @@
 
 #define XTS_MODE_KEY_SHIFT	1
 #define XTS_MODE_KEY_LEN_MASK	0x1
-#define SM4_KEY_SIZE		16
-#define DES_KEY_SIZE		8
-#define DES3_2KEY_SIZE		(2 * DES_KEY_SIZE)
-#define DES3_3KEY_SIZE		(3 * DES_KEY_SIZE)
-#define AES_KEYSIZE_128		16
-#define AES_KEYSIZE_192		24
-#define AES_KEYSIZE_256		32
 
 #define DES_WEAK_KEY_NUM	16
 

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -542,6 +542,11 @@ static int cipher_iv_len_check(struct wd_cipher_req *req,
 	if (sess->mode == WD_CIPHER_ECB)
 		return 0;
 
+	if (!req->iv) {
+		WD_ERR("invalid: cipher input iv is NULL!\n");
+		ret = -WD_EINVAL;
+	}
+
 	switch (sess->alg) {
 	case WD_CIPHER_AES:
 	case WD_CIPHER_SM4:
@@ -586,6 +591,12 @@ static int wd_cipher_check_params(handle_t h_sess,
 	if (unlikely(req->out_buf_bytes < req->in_bytes)) {
 		WD_ERR("cipher set out_buf_bytes is error, size = %u\n",
 			req->out_buf_bytes);
+		return -WD_EINVAL;
+	}
+
+	ret = wd_check_src_dst(req->src, req->in_bytes, req->dst, req->out_bytes);
+	if (unlikely(ret)) {
+		WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -340,8 +340,8 @@ int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	__u32 tmp = expt;
 	int ret;
 
-	if (unlikely(!count)) {
-		WD_ERR("invalid: comp poll count is 0!\n");
+	if (unlikely(!count || !expt)) {
+		WD_ERR("invalid: comp poll count or expt is 0!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -438,8 +438,8 @@ int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	__u32 tmp = expt;
 	int ret;
 
-	if (unlikely(!count)) {
-		WD_ERR("invalid: count is NULL!\n");
+	if (unlikely(!count || !expt)) {
+		WD_ERR("invalid: dh poll count or expt is NULL!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -514,9 +514,15 @@ static int wd_digest_param_check(struct wd_digest_sess *sess,
 		return ret;
 
 	if (unlikely(sess->alg == WD_DIGEST_AES_GMAC &&
-	    req->iv_bytes != GMAC_IV_LEN)) {
+	    (!req->iv || req->iv_bytes != GMAC_IV_LEN))) {
 		WD_ERR("failed to check digest aes_gmac iv length, iv_bytes = %u\n",
 			req->iv_bytes);
+		return -WD_EINVAL;
+	}
+
+	ret = wd_check_src_dst(req->in, req->in_bytes, req->out, req->out_bytes);
+	if (unlikely(ret)) {
+		WD_ERR("invalid: in/out addr is NULL when in/out size is non-zero!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -701,7 +701,7 @@ int wd_digest_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	__u32 tmp = expt;
 	int ret;
 
-	if (unlikely(!count)) {
+	if (unlikely(!count || !expt)) {
 		WD_ERR("invalid: digest poll ctx input param is NULL!\n");
 		return -WD_EINVAL;
 	}

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -131,7 +131,7 @@ int wd_digest_set_key(handle_t h_sess, const __u8 *key, __u32 key_len)
 	int ret;
 
 	if (!key || !sess) {
-		WD_ERR("failed to check key param!\n");
+		WD_ERR("invalid: failed to check input param, sess or key is NULL!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -10,16 +10,7 @@
 #include "include/drv/wd_digest_drv.h"
 #include "wd_digest.h"
 
-#define XTS_MODE_KEY_DIVISOR	2
-#define SM4_KEY_SIZE		16
-#define DES_KEY_SIZE		8
-#define DES3_3KEY_SIZE		(3 * DES_KEY_SIZE)
 #define GMAC_IV_LEN		16
-#define AES_KEYSIZE_128		16
-#define AES_KEYSIZE_192		24
-#define AES_KEYSIZE_256		32
-
-#define DES_WEAK_KEY_NUM	4
 
 static __u32 g_digest_mac_len[WD_DIGEST_TYPE_MAX] = {
 	WD_DIGEST_SM3_LEN, WD_DIGEST_MD5_LEN, WD_DIGEST_SHA1_LEN,

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -2272,8 +2272,8 @@ int wd_ecc_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	__u32 tmp = expt;
 	int ret;
 
-	if (unlikely(!count)) {
-		WD_ERR("invalid: param count is NULL!\n");
+	if (unlikely(!count || !expt)) {
+		WD_ERR("invalid: ecc poll param count or expt is NULL!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_mempool.c
+++ b/wd_mempool.c
@@ -573,7 +573,7 @@ handle_t wd_blockpool_create(handle_t mempool, size_t block_size,
 	bp = calloc(1, sizeof(struct blkpool));
 	if (!bp) {
 		WD_ERR("failed to alloc memory for blkpool!\n");
-		return (handle_t)(-WD_ENOMEM);
+		goto err_sub_ref;
 	}
 
 	bp->top = block_num;
@@ -597,6 +597,7 @@ err_free_mem:
 	free_mem_to_mempool(bp);
 err_free_bp:
 	free(bp);
+err_sub_ref:
 	wd_atomic_sub(&mp->ref, 1);
 	return (handle_t)(-WD_ENOMEM);
 }

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -495,8 +495,8 @@ int wd_rsa_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 	__u32 tmp = expt;
 	int ret;
 
-	if (unlikely(!count)) {
-		WD_ERR("invalid: param count is NULL!\n");
+	if (unlikely(!count || !expt)) {
+		WD_ERR("invalid: rsa poll count or expt is NULL!\n");
 		return -WD_EINVAL;
 	}
 

--- a/wd_sched.c
+++ b/wd_sched.c
@@ -311,8 +311,8 @@ static int session_sched_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *
 	__u16 i;
 	int ret;
 
-	if (unlikely(!count || !sched_ctx)) {
-		WD_ERR("invalid: sched ctx is NULL or count is zero!\n");
+	if (unlikely(!count || !sched_ctx || !sched_ctx->poll_func)) {
+		WD_ERR("invalid: sched ctx or poll_func is NULL or count is zero!\n");
 		return -WD_EINVAL;
 	}
 
@@ -375,6 +375,11 @@ static int sched_none_poll_policy(handle_t h_sched_ctx,
 	__u32 poll_num = 0;
 	int ret;
 
+	if (!sched_ctx || !sched_ctx->poll_func) {
+		WD_ERR("invalid: sched ctx or poll_func is NULL!\n");
+		return -WD_EINVAL;
+	}
+
 	while (loop_times > 0) {
 		/* Default use ctx 0 */
 		loop_times--;
@@ -416,6 +421,11 @@ static int sched_single_poll_policy(handle_t h_sched_ctx,
 	__u32 loop_times = MAX_POLL_TIMES + expect;
 	__u32 poll_num = 0;
 	int ret;
+
+	if (!sched_ctx || !sched_ctx->poll_func) {
+		WD_ERR("invalid: sched ctx or poll_func is NULL!\n");
+		return -WD_EINVAL;
+	}
 
 	while (loop_times > 0) {
 		/* Default async mode use ctx 0 */

--- a/wd_sched.c
+++ b/wd_sched.c
@@ -642,6 +642,7 @@ struct wd_sched *wd_sched_rr_alloc(__u8 sched_type, __u8 type_num,
 		WD_ERR("failed to alloc memory for sched_ctx!\n");
 		goto err_out;
 	}
+	sched_ctx->numa_num = numa_num;
 
 	sched->h_sched_ctx = (handle_t)sched_ctx;
 	if (sched_type == SCHED_POLICY_NONE ||
@@ -662,7 +663,6 @@ simple_ok:
 	sched_ctx->poll_func = func;
 	sched_ctx->policy = sched_type;
 	sched_ctx->type_num = type_num;
-	sched_ctx->numa_num = numa_num;
 	memset(sched_ctx->numa_map, -1, sizeof(int) * NUMA_NUM_NODES);
 
 	sched->sched_init = sched_table[sched_type].sched_init;

--- a/wd_util.c
+++ b/wd_util.c
@@ -408,7 +408,6 @@ void wd_uninit_async_request_pool(struct wd_async_msg_pool *pool)
 	pool->pool_num = 0;
 }
 
-/* fix me: this is old wd_get_req_from_pool */
 void *wd_find_msg_in_pool(struct wd_async_msg_pool *pool,
 			  int ctx_idx, __u32 tag)
 {
@@ -1344,7 +1343,6 @@ static struct async_task_queue *find_async_queue(struct wd_env_config *config,
 	return head + offset;
 }
 
-/* fix me: all return value here, and no config input */
 int wd_add_task_to_async_queue(struct wd_env_config *config, __u32 idx)
 {
 	struct async_task_queue *task_queue;

--- a/wd_util.c
+++ b/wd_util.c
@@ -1398,6 +1398,7 @@ err_out:
 	task_queue->cur_task--;
 	task_queue->prod = curr_prod;
 	pthread_mutex_unlock(&task_queue->lock);
+	sem_post(&task_queue->empty_sem);
 
 	return ret;
 }

--- a/wd_util.c
+++ b/wd_util.c
@@ -459,6 +459,14 @@ void wd_put_msg_to_pool(struct wd_async_msg_pool *pool, int ctx_idx, __u32 tag)
 	__atomic_clear(&p->used[tag - 1], __ATOMIC_RELEASE);
 }
 
+int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes)
+{
+	if ((in_bytes && !src) || (out_bytes && !dst))
+		return -WD_EINVAL;
+
+	return 0;
+}
+
 int wd_check_datalist(struct wd_datalist *head, __u32 size)
 {
 	struct wd_datalist *tmp = head;


### PR DESCRIPTION
Chenghai Huang (13):
  uadk: code cleanup
  uadk: code cleanup for error codes and variable type
  uadk: Add file association
  uadk: fix the failure process bug
  uadk: fix the failure process bug
  uadk: fix the failure process bug
  uadk: bugfix
  uadk v1: adapter code cleanup
  uadk v1: fix wd_rng resource release bug
  uadk v1: code cleanup for error codes and header files
  uadk: concentrate the same definitions
  uadk v1: optimize the function length
  uadk v1: concentrate the same definitions

Longfang Liu (1):
  uadk: fixed some input parameter checking issues

Qi Tao (4):
  uadk/v1: check whether the data address pointer is not null
  uadk: modify improper comments.
  uadk/v1: add null pointer check.
  uadk/v1: fix static compilation error

Wenkai Lin (3):
  uadk/v1: remove print actions after wd_get_cookies
  uadk: fix header file is not self contained
  uadk: fix sec send and recv check failed

Yang Shen (1):
  uadk/v1/comp: add comp ctx parameters check

Zhiqi Song (1):
  uadk/sec: add a return value judgement