### PR TITLE
Revert "uadk/wd_alg - add registering driver parameters check"

### DIFF
--- a/wd_alg.c
+++ b/wd_alg.c
@@ -139,11 +139,6 @@ int wd_alg_driver_register(struct wd_alg_driver *drv)
 		return -WD_EINVAL;
 	}
 
-	if (!drv->init || !drv->exit || !drv->send || !drv->recv) {
-		WD_ERR("invalid: driver's parameter is NULL!\n");
-		return -WD_EINVAL;
-	}
-
 	new_alg = calloc(1, sizeof(struct wd_alg_list));
 	if (!new_alg) {
 		WD_ERR("failed to alloc alg driver memory!\n");


### PR DESCRIPTION
This reverts commit f84772417e6f7ec71539bf3ef8512055d9a659be. The patch cause uadk_engine sanity_test fail and switch to sw. The sec2 drv has no send & recv causes parameters check fail.