### PR TITLE
test: decrease the source file size from 16MB to 12MB

### DIFF
--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -359,7 +359,7 @@ run_zip_test_v2()
 	# test without environment variables
 	# limit test file in 64MB
 	rm -fr /tmp/syslog
-	dd if=/var/log/syslog of=/tmp/syslog bs=1M count=16 >& /dev/null
+	dd if=/var/log/syslog of=/tmp/syslog bs=1M count=12 >& /dev/null
 	sw_dfl_hw_ifl /tmp/syslog
 	hw_dfl_sw_ifl /tmp/syslog
 	WD_COMP_EPOLL_EN=1 hw_dfl_hw_ifl /tmp/syslog


### PR DESCRIPTION
While decompress a compressed file, it's risky if the plain text file is 16MB. So downgrade it to 12MB.

with text file /tmp/syslog
double free or corruption (!prev)
/home/hzhuang1/test/uadk/test/sanity_test.sh: line 63: 398814 Aborted                 (core dumped) $@
Fail to run UADK tests with static build.