### PR TITLE
Sched 12.25

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,10 @@ lib_LTLIBRARIES=libwd.la libwd_comp.la libwd_crypto.la
 uadk_driversdir=$(libdir)/uadk
 uadk_drivers_LTLIBRARIES=libhisi_sec.la libhisi_hpre.la libhisi_zip.la
 
+if HAVE_ZLIB
+uadk_drivers_LTLIBRARIES+=libhisi_zlib.la
+endif
+
 libwd_la_SOURCES=wd.c wd_mempool.c wd.h	wd_alg.c wd_alg.h	\
 		 v1/wd.c v1/wd.h v1/wd_adapter.c v1/wd_adapter.h \
 		 v1/wd_rng.c v1/wd_rng.h	\
@@ -68,6 +72,8 @@ libwd_comp_la_SOURCES=wd_comp.c wd_comp.h wd_comp_drv.h wd_util.c wd_util.h \
 
 libhisi_zip_la_SOURCES=drv/hisi_comp.c hisi_comp.h drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h wd_comp_drv.h
+
+libhisi_zlib_la_SOURCES=drv/hisi_zlib.c
 
 libwd_crypto_la_SOURCES=wd_cipher.c wd_cipher.h wd_cipher_drv.h \
 			wd_aead.c wd_aead.h wd_aead_drv.h \
@@ -95,6 +101,8 @@ libwd_comp_la_LIBADD = $(libwd_la_OBJECTS) -ldl -lnuma
 libwd_comp_la_DEPENDENCIES = libwd.la
 
 libhisi_zip_la_LIBADD = -ldl
+
+libhisi_zlib_la_LIBADD = -ldl -lz
 
 libwd_crypto_la_LIBADD = $(libwd_la_OBJECTS) -ldl -lnuma
 libwd_crypto_la_DEPENDENCIES = libwd.la
@@ -124,6 +132,9 @@ libwd_crypto_la_DEPENDENCIES= libwd.la
 libhisi_zip_la_LIBADD= -lwd -ldl -lwd_comp
 libhisi_zip_la_LDFLAGS=$(UADK_VERSION)
 libhisi_zip_la_DEPENDENCIES= libwd.la libwd_comp.la
+
+libhisi_zlib_la_LIBADD= -ldl -lz
+libhisi_zlib_la_LDFLAGS=$(UADK_VERSION)
 
 libhisi_sec_la_LIBADD= -lwd -lwd_crypto
 libhisi_sec_la_LDFLAGS=$(UADK_VERSION)

--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -937,7 +937,8 @@ static void free_hw_sgl(handle_t h_qp, struct hisi_zip_sqe *sqe,
 
 static int hisi_zip_comp_send(struct wd_alg_driver *drv, handle_t ctx, void *comp_msg)
 {
-	struct hisi_qp *qp = wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	struct hisi_qp *qp = wd_ctx_get_priv(op->ctx);
 	struct wd_comp_msg *msg = comp_msg;
 	handle_t h_qp = (handle_t)qp;
 	struct hisi_zip_sqe sqe = {0};
@@ -1077,7 +1078,8 @@ static int parse_zip_sqe(struct hisi_qp *qp, struct hisi_zip_sqe *sqe,
 
 static int hisi_zip_comp_recv(struct wd_alg_driver *drv, handle_t ctx, void *comp_msg)
 {
-	struct hisi_qp *qp = wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	struct hisi_qp *qp = wd_ctx_get_priv(op->ctx);
 	struct wd_comp_msg *recv_msg = comp_msg;
 	handle_t h_qp = (handle_t)qp;
 	struct hisi_zip_sqe sqe = {0};

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -549,7 +549,8 @@ static int hisi_sec_aead_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *
 
 static int cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
 	struct hisi_qm_queue_info q_info = qp->q_info;
 
@@ -560,7 +561,8 @@ static int cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
 
 static int cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
 	struct hisi_qm_queue_info q_info = qp->q_info;
 
@@ -1170,7 +1172,8 @@ static int fill_cipher_bd2(struct wd_cipher_msg *msg, struct hisi_sec_sqe *sqe)
 
 static int hisi_sec_cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_cipher_msg *msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
@@ -1215,7 +1218,8 @@ static int hisi_sec_cipher_send(struct wd_alg_driver *drv, handle_t ctx, void *w
 
 static int hisi_sec_cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_cipher_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
@@ -1373,7 +1377,8 @@ static int fill_cipher_bd3(struct wd_cipher_msg *msg, struct hisi_sec_sqe3 *sqe)
 
 static int hisi_sec_cipher_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_cipher_msg *msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
@@ -1463,7 +1468,8 @@ static void parse_cipher_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 
 static int hisi_sec_cipher_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_cipher_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -573,7 +573,8 @@ static int cipher_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
 
 static int digest_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
 	struct hisi_qm_queue_info q_info = qp->q_info;
 
@@ -584,7 +585,8 @@ static int digest_send(struct wd_alg_driver *drv, handle_t ctx, void *msg)
 
 static int digest_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
 	struct hisi_qm_queue_info q_info = qp->q_info;
 
@@ -1742,7 +1744,8 @@ static int digest_len_check(struct wd_digest_msg *msg,  enum sec_bd_type type)
 
 static int hisi_sec_digest_send(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_digest_msg *msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
@@ -1809,7 +1812,8 @@ put_sgl:
 
 static int hisi_sec_digest_recv(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_digest_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe sqe;
 	__u16 count = 0;
@@ -1986,7 +1990,8 @@ static void fill_digest_v3_scene(struct hisi_sec_sqe3 *sqe,
 
 static int hisi_sec_digest_send_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_digest_msg *msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;
@@ -2085,7 +2090,8 @@ static void parse_digest_bd3(struct hisi_qp *qp, struct hisi_sec_sqe3 *sqe,
 
 static int hisi_sec_digest_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *wd_msg)
 {
-	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
+	struct op_ctx *op = (struct op_ctx *)ctx;
+	handle_t h_qp = (handle_t)wd_ctx_get_priv(op->ctx);
 	struct wd_digest_msg *recv_msg = wd_msg;
 	struct hisi_sec_sqe3 sqe;
 	__u16 count = 0;

--- a/drv/hisi_zlib.c
+++ b/drv/hisi_zlib.c
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright 2023-2024 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2023-2024 Linaro ltd.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <zlib.h>
+
+#include "drv/wd_comp_drv.h"
+
+struct hisi_zlib_priv {
+	int windowbits;
+};
+
+static int hisi_zlib_init(struct wd_alg_driver *drv, void *conf)
+{
+	struct hisi_zlib_priv *priv;
+
+	priv = malloc(sizeof(struct hisi_zlib_priv));
+	if (!priv)
+		return -ENOMEM;
+
+	if (strcmp(drv->alg_name, "zlib") == 0)
+		priv->windowbits = 15;
+	else if (strcmp(drv->alg_name, "deflate") == 0)
+		priv->windowbits = -15;
+	else if (strcmp(drv->alg_name, "gzip") == 0)
+		priv->windowbits = 15 + 16;
+
+	drv->priv = priv;
+
+	return 0;
+}
+static void hisi_zlib_exit(struct wd_alg_driver *drv)
+{
+	struct hisi_zlib_priv *priv = (struct hisi_zlib_priv *)drv->priv;
+
+	free(priv);
+}
+
+static int hisi_zlib_send(struct wd_alg_driver *drv, handle_t ctx, void *comp_msg)
+{
+	struct hisi_zlib_priv *priv = (struct hisi_zlib_priv *)drv->priv;
+	struct wd_comp_msg *msg = comp_msg;
+	z_stream strm;
+	int ret;
+
+	memset(&strm, 0, sizeof(z_stream));
+
+	strm.next_in = msg->req.src;
+	strm.avail_in = msg->req.src_len;
+	strm.next_out = msg->req.dst;
+	strm.avail_out = msg->req.dst_len;
+
+	if (msg->req.op_type == WD_DIR_COMPRESS) {
+		/* deflate */
+
+		ret = deflateInit2(&strm, Z_BEST_SPEED, Z_DEFLATED, priv->windowbits,
+				8, Z_DEFAULT_STRATEGY);
+		if (ret != Z_OK) {
+			printf("deflateInit2: %d\n", ret);
+			return -EINVAL;
+		}
+
+		do {
+			ret = deflate(&strm, Z_FINISH);
+			if ((ret == Z_STREAM_ERROR) || (ret == Z_BUF_ERROR)) {
+				printf("defalte error %d - %s\n", ret, strm.msg);
+				ret = -ENOSR;
+				break;
+			} else if (!strm.avail_in) {
+				if (ret != Z_STREAM_END)
+					printf("deflate unexpected return: %d\n", ret);
+				ret = 0;
+				break;
+			} else if (!strm.avail_out) {
+				printf("deflate out of memory\n");
+				ret = -ENOSPC;
+				break;
+			}
+		} while (ret == Z_OK);
+
+		deflateEnd(&strm);
+
+	} else {
+		/* inflate */
+
+		/* Window size of 15, +32 for auto-decoding gzip/zlib */
+		ret = inflateInit2(&strm, 15 + 32);
+		if (ret != Z_OK) {
+			printf("zlib inflateInit: %d\n", ret);
+			return -EINVAL;
+		}
+
+		do {
+			ret = inflate(&strm, Z_NO_FLUSH);
+			if ((ret < 0) || (ret == Z_NEED_DICT)) {
+				printf("zlib error %d - %s\n", ret, strm.msg);
+				ret = -EINVAL;
+				break;
+			}
+			if (!strm.avail_out) {
+				if (!strm.avail_in || (ret == Z_STREAM_END)) {
+					ret = 0;
+					break;
+				}
+				printf("%s: avail_out is empty!\n", __func__);
+				ret = -EINVAL;
+				break;
+			}
+		} while (strm.avail_in && (ret != Z_STREAM_END));
+		inflateEnd(&strm);
+	}
+
+	msg->produced = msg->req.dst_len - strm.avail_out;
+	msg->in_cons = msg->req.src_len;
+
+	return ret;
+}
+static int hisi_zlib_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	/*
+	 * recv just return since cpu does not support async,
+	 * once send func return, the operation is done
+	 */
+	return 0;
+}
+
+#define GEN_ZLIB_ALG_DRIVER(zlib_alg_name) \
+{\
+	.drv_name = "hisi_zlib",\
+	.alg_name = zlib_alg_name,\
+	.calc_type = UADK_ALG_SOFT,\
+	.priority = 0,\
+	.init = hisi_zlib_init,\
+	.exit = hisi_zlib_exit,\
+	.send = hisi_zlib_send,\
+	.recv = hisi_zlib_recv,\
+}
+
+static struct wd_alg_driver zlib_alg_driver[] = {
+	GEN_ZLIB_ALG_DRIVER("zlib"),
+	GEN_ZLIB_ALG_DRIVER("gzip"),
+	GEN_ZLIB_ALG_DRIVER("deflate"),
+};
+
+static void __attribute__((constructor)) hisi_zlib_probe(void)
+{
+	int alg_num = ARRAY_SIZE(zlib_alg_driver);
+	int i, ret;
+
+	for (i = 0; i < alg_num; i++) {
+		ret = wd_alg_driver_register(&zlib_alg_driver[i]);
+		if (ret)
+			fprintf(stderr, "Error: register zlib %s failed!\n",
+				zlib_alg_driver[i].alg_name);
+	}
+}
+
+static void __attribute__((destructor)) hisi_zlib_remove(void)
+{
+	int alg_num = ARRAY_SIZE(zlib_alg_driver);
+	int i;
+
+	for (i = 0; i < alg_num; i++)
+		wd_alg_driver_unregister(&zlib_alg_driver[i]);
+}

--- a/include/wd_alg.h
+++ b/include/wd_alg.h
@@ -150,6 +150,7 @@ void wd_enable_drv(struct wd_alg_driver *drv);
 void wd_disable_drv(struct wd_alg_driver *drv);
 
 struct wd_alg_list *wd_get_alg_head(void);
+struct wd_alg_driver *wd_find_drv(char *drv_name, char *alg_name, int idx);
 
 #ifdef __cplusplus
 }

--- a/include/wd_alg.h
+++ b/include/wd_alg.h
@@ -125,11 +125,11 @@ struct wd_alg_list {
 /**
  * wd_request_drv() - Apply for an algorithm driver.
  * @alg_name: task algorithm name.
- * @hw_mask: the flag of shield hardware device drivers.
+ * @task_type: task_type required from user.
  *
  * Returns the applied algorithm driver, non means error.
  */
-struct wd_alg_driver *wd_request_drv(const char	*alg_name, bool hw_mask);
+struct wd_alg_driver *wd_request_drv(const char	*alg_name, int task_type);
 void wd_release_drv(struct wd_alg_driver *drv);
 
 /**

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -55,6 +55,11 @@ enum wd_ctx_mode {
 	CTX_MODE_MAX,
 };
 
+struct wd_sess_para {
+	enum alg_task_type type;
+	char *alg;
+};
+
 /**
  * struct wd_ctx - Define one ctx and related type.
  * @ctx:	The ctx itself.
@@ -144,6 +149,8 @@ struct wd_ctx_config_internal {
 	unsigned long *msg_cnt;
 };
 
+#define MAX_NB_DRV		(8)
+
 /**
  * struct wd_comp_sched - Define a scheduler.
  * @name:		Name of this scheduler.
@@ -167,6 +174,9 @@ struct wd_sched {
 				  const int sched_mode);
 	int (*poll_policy)(handle_t h_sched_ctx, __u32 expect, __u32 *count);
 	handle_t h_sched_ctx;
+	__u32 drv_nb;
+	struct wd_alg_driver *drv[MAX_NB_DRV];
+	pthread_mutex_t lock;
 };
 
 typedef int (*wd_alg_init)(struct wd_ctx_config *config, struct wd_sched *sched);

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -48,6 +48,7 @@ enum alg_task_type {
 	TASK_INSTR,
 	TASK_CE,
 	TASK_SVE,
+	TASK_ANY,
 	TASK_MAX_TYPE,
 };
 

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -46,6 +46,8 @@ enum alg_task_type {
 	TASK_MIX = 0x0,
 	TASK_HW,
 	TASK_INSTR,
+	TASK_CE,
+	TASK_SVE,
 	TASK_MAX_TYPE,
 };
 

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -73,6 +73,7 @@ struct wd_cipher_sess_setup {
 	enum wd_cipher_alg alg;
 	enum wd_cipher_mode mode;
 	void *sched_param;
+	struct wd_sess_para para;
 };
 
 struct wd_cipher_req;

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -149,6 +149,7 @@ struct wd_comp_sess_setup {
 	enum wd_comp_winsz_type win_sz; /* Denoted by enum wd_comp_winsz_type */
 	enum wd_comp_op_type op_type;   /* Denoted by enum wd_comp_op_type */
 	void *sched_param;
+	struct wd_sess_para para;
 };
 
 /**

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -100,6 +100,7 @@ struct wd_digest_sess_setup {
 	enum wd_digest_type alg;
 	enum wd_digest_mode mode;
 	void *sched_param;
+	struct wd_sess_para para;
 };
 
 typedef void *wd_digest_cb_t(void *cb_param);

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -116,6 +116,12 @@ struct wd_ctx_attr {
 	__u8 mode;
 };
 
+struct op_ctx {
+	handle_t ctx;
+	__u32 ctx_id;
+	__u8 mode;
+};
+
 struct wd_msg_handle {
 	int (*send)(struct wd_alg_driver *drv, handle_t ctx, void *drv_msg);
 	int (*recv)(struct wd_alg_driver *drv, handle_t ctx, void *drv_msg);

--- a/libwd.map
+++ b/libwd.map
@@ -45,6 +45,7 @@ global:
 	wd_alg_driver_unregister;
 	wd_request_drv;
 	wd_release_drv;
+	wd_find_drv;
 	wd_drv_alg_support;
 	wd_enable_drv;
 	wd_disable_drv;

--- a/uadk_tool/benchmark/sec_uadk_benchmark.c
+++ b/uadk_tool/benchmark/sec_uadk_benchmark.c
@@ -674,13 +674,13 @@ static int init_ctx_config2(struct acc_option *options)
 	/* init */
 	switch(subtype) {
 	case CIPHER_TYPE:
-		ret = wd_cipher_init2(alg_name, SCHED_POLICY_RR, TASK_HW);
+		ret = wd_cipher_init2(alg_name, SCHED_POLICY_RR, TASK_ANY);
 		break;
 	case AEAD_TYPE:
 		ret = wd_aead_init2(alg_name, SCHED_POLICY_RR, TASK_HW);
 		break;
 	case DIGEST_TYPE:
-		ret = wd_digest_init2(alg_name, SCHED_POLICY_RR, TASK_HW);
+		ret = wd_digest_init2(alg_name, SCHED_POLICY_RR, TASK_ANY);
 		break;
 	}
 	if (ret) {

--- a/uadk_tool/benchmark/zip_uadk_benchmark.c
+++ b/uadk_tool/benchmark/zip_uadk_benchmark.c
@@ -296,7 +296,7 @@ static int init_ctx_config2(struct acc_option *options)
 	}
 
 	/* init */
-	ret = wd_comp_init2(alg_name, SCHED_POLICY_RR, TASK_HW);
+	ret = wd_comp_init2(alg_name, SCHED_POLICY_RR, TASK_ANY);
 	if (ret) {
 		ZIP_TST_PRT("Fail to do comp init2!\n");
 		return ret;

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -88,7 +88,7 @@ static int wd_aead_open_driver(void)
 		return -WD_EINVAL;
 	}
 
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_request_drv(alg_name, TASK_HW);
 	if (!driver) {
 		wd_aead_close_driver();
 		WD_ERR("failed to get %s driver support\n", alg_name);

--- a/wd_alg.c
+++ b/wd_alg.c
@@ -332,3 +332,44 @@ void wd_release_drv(struct wd_alg_driver *drv)
 		select_node->refcnt--;
 	pthread_mutex_unlock(&mutex);
 }
+
+struct wd_alg_driver *wd_find_drv(char *drv_name, char *alg_name, int idx)
+{
+	struct wd_alg_list *head = &alg_list_head;
+	struct wd_alg_list *pnext = head->next;
+	struct wd_alg_driver *drv = NULL;
+
+	if (!pnext || !alg_name) {
+		WD_ERR("invalid: request alg param is error!\n");
+		return NULL;
+	}
+
+	pthread_mutex_lock(&mutex);
+
+	if (drv_name) {
+		while (pnext) {
+			if (!strcmp(alg_name, pnext->alg_name) &&
+			    !strcmp(drv_name, pnext->drv_name)) {
+				drv = pnext->drv;
+				break;
+			}
+			pnext = pnext->next;
+		}
+	} else {
+		int i = 0;
+
+		while (pnext) {
+			if (!strcmp(alg_name, pnext->alg_name)) {
+				if (i++ == idx) {
+					drv = pnext->drv;
+					break;
+				}
+			}
+			pnext = pnext->next;
+		}
+	}
+
+	pthread_mutex_unlock(&mutex);
+
+	return drv;
+}

--- a/wd_alg.c
+++ b/wd_alg.c
@@ -96,6 +96,7 @@ static bool wd_alg_check_available(int calc_type, const char *dev_name)
 
 	switch (calc_type) {
 	case UADK_ALG_SOFT:
+		ret = true;
 		break;
 	/* Should find the CPU if not support CE */
 	case UADK_ALG_CE_INSTR:

--- a/wd_alg.c
+++ b/wd_alg.c
@@ -293,7 +293,8 @@ struct wd_alg_driver *wd_request_drv(const char *alg_name, int task_type)
 		if (!strcmp(alg_name, pnext->alg_name) && pnext->available) {
 			calc_type = pnext->drv->calc_type;
 
-			if ((task_type == TASK_HW && calc_type == UADK_ALG_HW) ||
+			if ((task_type == TASK_ANY) ||
+			    (task_type == TASK_HW && calc_type == UADK_ALG_HW) ||
 			    (task_type == TASK_CE && calc_type == UADK_ALG_CE_INSTR) ||
 			    (task_type == TASK_SVE && calc_type == UADK_ALG_SVE_INSTR)) {
 				select_node = pnext;

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -101,7 +101,7 @@ static int wd_cipher_open_driver(void)
 		return -WD_EINVAL;
 	}
 
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_request_drv(alg_name, TASK_HW);
 	if (!driver) {
 		wd_cipher_close_driver();
 		WD_ERR("failed to get %s driver support\n", alg_name);

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -265,7 +265,7 @@ handle_t wd_cipher_alloc_sess(struct wd_cipher_sess_setup *setup)
 		}
 	}
 
-	if (WD_IS_ERR(sess->drv)) {
+	if (!sess->drv) {
 		WD_ERR("failed to init session drv!\n");
 		goto err_sess;
 	}

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -85,7 +85,7 @@ static int wd_comp_open_driver(void)
 		return -WD_EINVAL;
 	}
 
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_request_drv(alg_name, TASK_HW);
 	if (!driver) {
 		wd_comp_close_driver();
 		WD_ERR("failed to get %s driver support\n", alg_name);

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -505,7 +505,7 @@ handle_t wd_comp_alloc_sess(struct wd_comp_sess_setup *setup)
 		}
 	}
 
-	if (WD_IS_ERR(sess->drv)) {
+	if (!sess->drv) {
 		WD_ERR("failed to init session drv!\n");
 		goto sched_err;
 	}

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -68,7 +68,7 @@ static int wd_dh_open_driver(void)
 		return -WD_EINVAL;
 	}
 
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_request_drv(alg_name, TASK_HW);
 	if (!driver) {
 		wd_dh_close_driver();
 		WD_ERR("failed to get %s driver support\n", alg_name);

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -193,7 +193,7 @@ handle_t wd_digest_alloc_sess(struct wd_digest_sess_setup *setup)
 		}
 	}
 
-	if (WD_IS_ERR(sess->drv)) {
+	if (!sess->drv) {
 		WD_ERR("failed to init session drv!\n");
 		goto err_sess;
 	}

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -96,7 +96,7 @@ static int wd_digest_open_driver(void)
 		return -WD_EINVAL;
 	}
 
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_request_drv(alg_name, TASK_HW);
 	if (!driver) {
 		wd_digest_close_driver();
 		WD_ERR("failed to get %s driver support\n", alg_name);

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -122,7 +122,7 @@ static int wd_ecc_open_driver(void)
 		return -WD_EINVAL;
 	}
 
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_request_drv(alg_name, TASK_HW);
 	if (!driver) {
 		wd_ecc_close_driver();
 		WD_ERR("failed to get %s driver support\n", alg_name);

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -107,7 +107,7 @@ static int wd_rsa_open_driver(void)
 		return -WD_EINVAL;
 	}
 
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_request_drv(alg_name, TASK_HW);
 	if (!driver) {
 		wd_rsa_close_driver();
 		WD_ERR("failed to get %s driver support!\n", alg_name);

--- a/wd_util.c
+++ b/wd_util.c
@@ -2286,9 +2286,11 @@ struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name)
 
 	/* Get alg driver and dev name */
 	switch (task_type) {
+	case TASK_ANY:
 	case TASK_INSTR:
 	case TASK_CE:
 	case TASK_SVE:
+	case TASK_HW:
 		drv = wd_request_drv(alg_name, task_type);
 		if (!drv) {
 			WD_ERR("no soft %s driver support\n", alg_name);
@@ -2297,7 +2299,6 @@ struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name)
 		set_driver = drv;
 		set_driver->fallback = 0;
 		break;
-	case TASK_HW:
 	case TASK_MIX:
 		drv = wd_request_drv(alg_name, TASK_HW);
 		if (!drv) {
@@ -2305,16 +2306,13 @@ struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name)
 			return NULL;
 		}
 		set_driver = drv;
-		set_driver->fallback = 0;
-		if (task_type == TASK_MIX) {
-			drv = wd_request_drv(alg_name, TASK_INSTR);
-			if (!drv) {
-				set_driver->fallback = 0;
-				WD_ERR("no soft %s driver support\n", alg_name);
-			} else {
-				set_driver->fallback = (handle_t)drv;
-				WD_ERR("successful to get soft driver\n");
-			}
+		drv = wd_request_drv(alg_name, TASK_INSTR);
+		if (!drv) {
+			set_driver->fallback = 0;
+			WD_ERR("no soft %s driver support\n", alg_name);
+		} else {
+			set_driver->fallback = (handle_t)drv;
+			WD_ERR("successful to get soft driver\n");
 		}
 		break;
 	default:

--- a/wd_util.c
+++ b/wd_util.c
@@ -2287,7 +2287,9 @@ struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name)
 	/* Get alg driver and dev name */
 	switch (task_type) {
 	case TASK_INSTR:
-		drv = wd_request_drv(alg_name, true);
+	case TASK_CE:
+	case TASK_SVE:
+		drv = wd_request_drv(alg_name, task_type);
 		if (!drv) {
 			WD_ERR("no soft %s driver support\n", alg_name);
 			return NULL;
@@ -2297,7 +2299,7 @@ struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name)
 		break;
 	case TASK_HW:
 	case TASK_MIX:
-		drv = wd_request_drv(alg_name, false);
+		drv = wd_request_drv(alg_name, TASK_HW);
 		if (!drv) {
 			WD_ERR("no HW %s driver support\n", alg_name);
 			return NULL;
@@ -2305,7 +2307,7 @@ struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name)
 		set_driver = drv;
 		set_driver->fallback = 0;
 		if (task_type == TASK_MIX) {
-			drv = wd_request_drv(alg_name, true);
+			drv = wd_request_drv(alg_name, TASK_INSTR);
 			if (!drv) {
 				set_driver->fallback = 0;
 				WD_ERR("no soft %s driver support\n", alg_name);


### PR DESCRIPTION
RFC:

patch 1
cipher: support mutil-driver

    1. alloc_sess will pick driver according to setup.para.task_type & alg,
       will reuse task_type & alg from init2 if no setup.para to compatible with v2
       will reuse setting.driver to compatible with v1
    2. alloc_sess will add drivers to sched.drv[]
    3. poll_ctx will poll all drivers in sched.drv[]
    4. sw and hw will reuse common resources: sched, pool and ctxs.
    5. Only hw will request real ctxs.

patch 2
uadk: add op_ctx to make sw easier

    sw has no hw_ctx, but still need ctx_id to get pool msg
    for multi-threads. so use op_ctx taking info like ctx_id
    and mode: sync/async.
