### PR TITLE
uadk: add secure compilation option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4 -I./include
 AUTOMAKE_OPTIONS = foreign subdir-objects
 AM_CFLAGS=-Wall -Werror -fno-strict-aliasing -I$(top_srcdir)/include
+AM_CFLAGS+=-fPIC -fPIE -pie -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+	   -O2 -ftrapv -Wl,-z,relro,-z,now -Wl,-s
 CLEANFILES =
 
 if WITH_LOG_FILE

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ AM_PROG_AR
 AC_PROG_LIBTOOL
 AM_PROG_LIBTOOL
 LT_INIT
+AC_SUBST([hardcode_into_libs], [no])
 AM_PROG_CC_C_O
 
 AC_ARG_ENABLE([debug-log],


### PR DESCRIPTION
Add PIE、PIC、BIND_NOW、SP、NO Rpath/RunPath、FS、Ftrapv and Strip compilation option.