### PR TITLE
uadk: fix build errors with clang

### DIFF
--- a/test/wd_mempool_test.c
+++ b/test/wd_mempool_test.c
@@ -644,7 +644,7 @@ static void *sva_sec_cipher_async(void *arg)
         int cnt = g_times;
         handle_t h_sess;
         int ret;
-        int j, i;
+	int j;
 
 	setup->alg = WD_CIPHER_AES;
         setup->mode = WD_CIPHER_CBC;
@@ -658,7 +658,6 @@ static void *sva_sec_cipher_async(void *arg)
                 SEC_TST_PRT("test sec cipher set key is failed!\n");
                 goto out;;
         }
-	i = cnt;
         /* run task */
         do {
 try_do_again:
@@ -666,7 +665,6 @@ try_do_again:
                 req->src = pdata->bd_pool->bds[j].src;
                 req->dst = pdata->bd_pool->bds[j].dst;
                 ret = wd_do_cipher_async(h_sess, req);
-		i--;
                 if (ret == -EBUSY) { // busy
                         usleep(100);
                         goto try_do_again;

--- a/uadk_tool/benchmark/hpre_uadk_benchmark.c
+++ b/uadk_tool/benchmark/hpre_uadk_benchmark.c
@@ -2130,7 +2130,7 @@ static void *ecc_uadk_sync_run(void *arg)
 	memset(&req,     0, sizeof(req));
 
 	memset(&setup,     0, sizeof(setup));
-	if (subtype != X448_TYPE || subtype != X25519_TYPE) {
+	if (subtype != X448_TYPE && subtype != X25519_TYPE) {
 		ret = get_ecc_curve(&setup, cid);
 		if (ret)
 			return NULL;
@@ -2289,7 +2289,7 @@ static void *ecc_uadk_async_run(void *arg)
 	memset(&req,	 0, sizeof(req));
 
 	memset(&setup,	   0, sizeof(setup));
-	if (subtype != X448_TYPE || subtype != X25519_TYPE) {
+	if (subtype != X448_TYPE && subtype != X25519_TYPE) {
 		ret = get_ecc_curve(&setup, cid);
 		if (ret)
 			return NULL;

--- a/uadk_tool/benchmark/hpre_wd_benchmark.c
+++ b/uadk_tool/benchmark/hpre_wd_benchmark.c
@@ -2090,7 +2090,7 @@ static void *ecc_wd_sync_run(void *arg)
 	queue = g_thread_queue.bd_res[pdata->td_id].queue;
 
 	memset(&setup,	   0, sizeof(setup));
-	if (subtype != X448_TYPE || subtype != X25519_TYPE) {
+	if (subtype != X448_TYPE && subtype != X25519_TYPE) {
 		ret = get_ecc_curve(&setup, cid);
 		if (ret)
 			return NULL;
@@ -2248,7 +2248,7 @@ static void *ecc_wd_async_run(void *arg)
 	queue = g_thread_queue.bd_res[pdata->td_id].queue;
 
 	memset(&setup,	   0, sizeof(setup));
-	if (subtype != X448_TYPE || subtype != X25519_TYPE) {
+	if (subtype != X448_TYPE && subtype != X25519_TYPE) {
 		ret = get_ecc_curve(&setup, cid);
 		if (ret)
 			return NULL;

--- a/uadk_tool/benchmark/sec_uadk_benchmark.c
+++ b/uadk_tool/benchmark/sec_uadk_benchmark.c
@@ -148,10 +148,10 @@ static int sec_uadk_param_parse(thread_data *tddata, struct acc_option *options)
 	bool is_union = false;
 	u8 keysize = 0;
 	u8 ivsize = 0;
-	u8 dmode;
-	u8 dalg;
-	u8 mode;
-	u8 alg;
+	u8 dmode = 0;
+	u8 dalg = 0;
+	u8 mode = 0;
+	u8 alg = 0;
 
 	switch(algtype) {
 	case AES_128_ECB:

--- a/uadk_tool/benchmark/sec_wd_benchmark.c
+++ b/uadk_tool/benchmark/sec_wd_benchmark.c
@@ -214,10 +214,10 @@ static int sec_wd_param_parse(thread_data *tddata, struct acc_option *options)
 	bool is_union = false;
 	u8 keysize = 0;
 	u8 ivsize = 0;
-	u8 dmode;
-	u8 dalg;
-	u8 mode;
-	u8 alg;
+	u8 dmode = 0;
+	u8 dalg = 0;
+	u8 mode = 0;
+	u8 alg = 0;
 
 	switch(algtype) {
 	case AES_128_ECB:

--- a/uadk_tool/benchmark/uadk_benchmark.c
+++ b/uadk_tool/benchmark/uadk_benchmark.c
@@ -364,18 +364,6 @@ int get_pid_cpu_time(u32 *ptime)
 	return 0;
 }
 
-void mdelay(u32 ms)
-{
-	int clock_tcy = 2600000000; // 2.6Ghz CPU;
-	int i;
-
-	while(ms) {
-		i++;
-		if (i == clock_tcy)
-			ms--;
-	}
-}
-
 static void alarm_end(int sig)
 {
 	if (sig == SIGALRM) {

--- a/uadk_tool/benchmark/uadk_benchmark.h
+++ b/uadk_tool/benchmark/uadk_benchmark.h
@@ -198,7 +198,6 @@ enum test_alg {
 	ALG_MAX,
 };
 
-extern void mdelay(u32 ms);
 extern int get_pid_cpu_time(u32 *ptime);
 extern void cal_perfermance_data(struct acc_option *option, u32 sttime);
 extern void time_start(u32 seconds);

--- a/uadk_tool/test/test_sec.c
+++ b/uadk_tool/test/test_sec.c
@@ -60,7 +60,6 @@ static unsigned int g_ctxnum;
 static unsigned int g_data_fmt = WD_FLAT_BUF;
 static unsigned int g_sgl_num = 0;
 static unsigned int g_init;
-static pthread_spinlock_t lock = 0;
 
 static struct hash_testvec g_long_hash_tv;
 

--- a/v1/test/hisi_zip_test_sgl/zip_alg_sgl.h
+++ b/v1/test/hisi_zip_test_sgl/zip_alg_sgl.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef __WD_ZIP_ALG_SGL__H__
+#ifndef __WD_ZIP_ALG_SGL_H__
 #define __WD_ZIP_ALG_SGL_H__
 
 #include <stdio.h>

--- a/v1/test/test_mm/test_wd_mem.c
+++ b/v1/test/test_mm/test_wd_mem.c
@@ -75,11 +75,6 @@ static inline unsigned long long va_to_pa(struct wd_queue *q, void *va)
 	return (unsigned long long)wd_iova_map(q, va, 0);
 }
 
-static inline void *pa_to_va(struct wd_queue *q, unsigned long long pa)
-{
-	return wd_dma_to_va(q, (void *)pa);
-}
-
 struct mmt_queue_mempool *mmt_test_mempool_create(struct wd_queue *q,
 				unsigned int block_size, unsigned int block_num)
 {

--- a/v1/test/test_mm/test_wd_mem.h
+++ b/v1/test/test_mm/test_wd_mem.h
@@ -15,7 +15,7 @@
  */
 
 #ifndef __TEST_WD_MEM_H
-#define ___TEST_WD_MEM_H
+#define __TEST_WD_MEM_H
 
 #include <stdio.h>
 #include <string.h>

--- a/v1/wd_rsa.c
+++ b/v1/wd_rsa.c
@@ -105,8 +105,10 @@ struct wcrypto_rsa_prikey2 {
 };
 
 struct wcrypto_rsa_prikey {
-	struct wcrypto_rsa_prikey1 pkey1;
-	struct wcrypto_rsa_prikey2 pkey2;
+	union {
+		struct wcrypto_rsa_prikey1 pkey1;
+		struct wcrypto_rsa_prikey2 pkey2;
+	} pkey;
 };
 
 /* RSA CRT private key parameter types */
@@ -444,7 +446,7 @@ static int create_ctx_key(struct wcrypto_rsa_ctx_setup *setup,
 			WD_ERR("alloc prikey2 fail!\n");
 			return -WD_ENOMEM;
 		}
-		pkey2 = &ctx->prikey->pkey2;
+		pkey2 = &ctx->prikey->pkey.pkey2;
 		memset(ctx->prikey, 0, len);
 		init_pkey2(pkey2, ctx->key_size);
 	} else {
@@ -459,7 +461,7 @@ static int create_ctx_key(struct wcrypto_rsa_ctx_setup *setup,
 			WD_ERR("alloc prikey1 fail!\n");
 			return -WD_ENOMEM;
 		}
-		pkey1 = &ctx->prikey->pkey1;
+		pkey1 = &ctx->prikey->pkey.pkey1;
 		memset(ctx->prikey, 0, len);
 		init_pkey1(pkey1, ctx->key_size);
 	}
@@ -716,7 +718,7 @@ int wcrypto_set_rsa_prikey_params(void *ctx, struct wd_dtb *d, struct wd_dtb *n)
 		WD_ERR("ctx err in set rsa private key1!\n");
 		return -WD_EINVAL;
 	}
-	pkey1 = &c->prikey->pkey1;
+	pkey1 = &c->prikey->pkey.pkey1;
 	if (d) {
 		if (d->dsize > pkey1->key_size || !d->data) {
 			WD_ERR("d err in set rsa private key1!\n");
@@ -750,7 +752,7 @@ void wcrypto_get_rsa_prikey_params(struct wcrypto_rsa_prikey *pvk, struct wd_dtb
 		return;
 	}
 
-	pkey1 = &pvk->pkey1;
+	pkey1 = &pvk->pkey.pkey1;
 
 	if (d)
 		*d = &pkey1->d;
@@ -825,7 +827,7 @@ int wcrypto_set_rsa_crt_prikey_params(void *ctx, struct wd_dtb *dq,
 		return ret;
 	}
 
-	pkey2 = &c->prikey->pkey2;
+	pkey2 = &c->prikey->pkey.pkey2;
 	ret = rsa_prikey2_param_set(pkey2, dq, WD_CRT_PRIKEY_DQ);
 	if (ret) {
 		WD_ERR("dq err in set rsa private key2!\n");
@@ -871,7 +873,7 @@ void wcrypto_get_rsa_crt_prikey_params(struct wcrypto_rsa_prikey *pvk,
 		return;
 	}
 
-	pkey2 = &pvk->pkey2;
+	pkey2 = &pvk->pkey.pkey2;
 
 	if (dq)
 		*dq = &pkey2->dq;

--- a/wd_mempool.c
+++ b/wd_mempool.c
@@ -71,7 +71,7 @@ static inline int wd_atomic_test_add(struct wd_ref *ref, int a, int u)
 		c = __atomic_load_n(&ref->ref, __ATOMIC_RELAXED);
 		if (c == u)
 			break;
-	} while (! __atomic_compare_exchange_n(&ref->ref, &c, c + a, true,
+	} while (!__atomic_compare_exchange_n(&ref->ref, (__u32 *)&c, c + a, true,
 					       __ATOMIC_RELAXED, __ATOMIC_RELAXED));
 
 	return c;
@@ -297,11 +297,6 @@ static int test_bit(struct bitmap *bm, unsigned int nr)
 	unsigned long mask = BIT_MASK(nr);
 
 	return !(*p & mask);
-}
-
-inline static size_t wd_get_page_size(void)
-{
-	return sysconf(_SC_PAGESIZE);
 }
 
 void *wd_block_alloc(handle_t blkpool)


### PR DESCRIPTION
./cleanup.sh
./autogen.sh
./configure CC=clang
make

build error logs like:
wd_rsa.c:48:24: error: field 'pkey1' with variable sized type 'struct wd_rsa_prikey1' not at the end of a struct or class is a GNU extension [-Werror,-Wgnu-variable-sized-type-not-at-end] v1/wd_rsa.c:108:29: error: field 'pkey1' with variable sized type 'struct wcrypto_rsa_prikey1' not at the end of a struct or class is a GNU extension [-Werror,-Wgnu-variable-sized-type-not-at-end] clang-12: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument] clang-12: error: -Wl,-s: 'linker' input unused [-Werror,-Wunused-command-line-argument] clang-12: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument] clang-12: error: -Wl,-s: 'linker' input unused [-Werror,-Wunused-command-line-argument] clang-12clang-12: : errorerror: : -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]-Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument] clang-12: error: argument unused during compilation: '-pie' [-Werror,-Wunused-command-line-argument] wd_mempool.c:74:52: error: passing 'int *' to parameter of type '__u32 *' (aka 'unsigned int *') converts between pointers to integer types with different sign [-Werror,-Wpointer-sign] wd_mempool.c:302:22: error: unused function 'wd_get_page_size' [-Werror,-Wunused-function] ./test_wd_mem.h:17:9: warning: '__TEST_WD_MEM_H' is used as a header guard here, followed by #define of a different macro [-Wheader-guard] benchmark/hpre_uadk_benchmark.c:2133:27: error: overlapping comparisons always evaluate to true [-Werror,-Wtautological-overlap-compare] benchmark/sec_uadk_benchmark.c:494:7: error: variable 'dalg' is used uninitialized whenever switch case is taken [-Werror,-Wsometimes-uninitialized]