### PR TITLE
uadk: drv/hisi - fix failed to init drv after fork

### DIFF
--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -787,17 +787,12 @@ static void hisi_zip_sqe_ops_adapt(handle_t h_qp)
 
 static int hisi_zip_init(struct wd_alg_driver *drv, void *conf)
 {
-	struct hisi_zip_ctx *priv = (struct hisi_zip_ctx *)drv->priv;
 	struct wd_ctx_config_internal *config = conf;
 	struct hisi_qm_priv qm_priv;
+	struct hisi_zip_ctx *priv;
 	handle_t h_qp = 0;
 	handle_t h_ctx;
 	__u32 i, j;
-
-	if (priv) {
-		/* return if already inited */
-		return 0;
-	}
 
 	if (!config->ctx_num) {
 		WD_ERR("invalid: zip init config ctx num is 0!\n");

--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -527,30 +527,27 @@ out:
 static int hpre_rsa_dh_init(struct wd_alg_driver *drv, void *conf)
 {
 	struct wd_ctx_config_internal *config = (struct wd_ctx_config_internal *)conf;
-	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
 	struct hisi_qm_priv qm_priv;
+	struct hisi_hpre_ctx *priv;
 	int ret;
-
-	if (priv) {
-		/* return if already inited */
-		return WD_SUCCESS;
-	}
 
 	if (!config->ctx_num) {
 		WD_ERR("invalid: hpre rsa/dh init config ctx num is 0!\n");
 		return -WD_EINVAL;
 	}
 
-	drv->priv = malloc(sizeof(struct hisi_hpre_ctx));
-	if (!drv->priv)
+	priv = malloc(sizeof(struct hisi_hpre_ctx));
+	if (!priv)
 		return -WD_EINVAL;
 
 	qm_priv.op_type = HPRE_HW_V2_ALG_TYPE;
-	ret = hpre_init_qm_priv(config, drv->priv, &qm_priv);
+	ret = hpre_init_qm_priv(config, priv, &qm_priv);
 	if (ret) {
-		free(drv->priv);
+		free(priv);
 		return ret;
 	}
+
+	drv->priv = priv;
 
 	return WD_SUCCESS;
 }
@@ -558,30 +555,27 @@ static int hpre_rsa_dh_init(struct wd_alg_driver *drv, void *conf)
 static int hpre_ecc_init(struct wd_alg_driver *drv, void *conf)
 {
 	struct wd_ctx_config_internal *config = (struct wd_ctx_config_internal *)conf;
-	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
 	struct hisi_qm_priv qm_priv;
+	struct hisi_hpre_ctx *priv;
 	int ret;
-
-	if (priv) {
-		/* return if already inited */
-		return WD_SUCCESS;
-	}
 
 	if (!config->ctx_num) {
 		WD_ERR("invalid: hpre ecc init config ctx num is 0!\n");
 		return -WD_EINVAL;
 	}
 
-	drv->priv = malloc(sizeof(struct hisi_hpre_ctx));
-	if (!drv->priv)
+	priv = malloc(sizeof(struct hisi_hpre_ctx));
+	if (!priv)
 		return -WD_EINVAL;
 
 	qm_priv.op_type = HPRE_HW_V3_ECC_ALG_TYPE;
-	ret = hpre_init_qm_priv(config, drv->priv, &qm_priv);
+	ret = hpre_init_qm_priv(config, priv, &qm_priv);
 	if (ret) {
-		free(drv->priv);
+		free(priv);
 		return ret;
 	}
+
+	drv->priv = priv;
 
 	return WD_SUCCESS;
 }

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -3067,17 +3067,12 @@ static int hisi_sec_aead_recv_v3(struct wd_alg_driver *drv, handle_t ctx, void *
 
 static int hisi_sec_init(struct wd_alg_driver *drv, void *conf)
 {
-	struct hisi_sec_ctx *priv = (struct hisi_sec_ctx *)drv->priv;
 	struct wd_ctx_config_internal *config = conf;
 	struct hisi_qm_priv qm_priv;
+	struct hisi_sec_ctx *priv;
 	handle_t h_qp = 0;
 	handle_t h_ctx;
 	__u32 i, j;
-
-	if (priv) {
-		/* return if already inited */
-		return 0;
-	}
 
 	if (!config->ctx_num) {
 		WD_ERR("invalid: sec init config ctx num is 0!\n");


### PR DESCRIPTION
The drivers initialization function use 'drv.priv' to forbid reinit. But if the child process is forked after the parent process has initialized, it can't work due to the drivers go to wrong branch on initialization.

And the algorithms initialization function is already protected against re-entry. So it is unnecessary to check 'drv.priv' in driver.