### PR TITLE
bugfix for uadk

### DIFF
--- a/drv/hash_mb/hash_mb.c
+++ b/drv/hash_mb/hash_mb.c
@@ -192,6 +192,10 @@ static int hash_mb_init(struct wd_alg_driver *drv, void *conf)
 	struct hash_mb_ctx *priv;
 	int ret;
 
+	/* Fallback init is NULL */
+	if (!drv || !conf)
+		return 0;
+
 	priv = malloc(sizeof(struct hash_mb_ctx));
 	if (!priv)
 		return -WD_ENOMEM;

--- a/drv/isa_ce_sm3.c
+++ b/drv/isa_ce_sm3.c
@@ -375,7 +375,11 @@ static int sm3_ce_drv_init(struct wd_alg_driver *drv, void *conf)
 	struct wd_ctx_config_internal *config = (struct wd_ctx_config_internal *)conf;
 	struct sm3_ce_drv_ctx *sctx = (struct sm3_ce_drv_ctx *)drv->priv;
 
-	config->epoll_en = false;
+	/* Fallback init is NULL */
+	if (!drv || !conf)
+		return 0;
+
+	config->epoll_en = 0;
 
 	/* return if already inited */
 	if (sctx)

--- a/drv/isa_ce_sm4.c
+++ b/drv/isa_ce_sm4.c
@@ -36,6 +36,10 @@ static int isa_ce_init(struct wd_alg_driver *drv, void *conf)
 	struct wd_ctx_config_internal *config = conf;
 	struct sm4_ce_drv_ctx *sctx = drv->priv;
 
+	/* Fallback init is NULL */
+	if (!drv || !conf)
+		return 0;
+
 	config->epoll_en = 0;
 	memcpy(&sctx->config, config, sizeof(struct wd_ctx_config_internal));
 

--- a/uadk_tool/benchmark/hpre_uadk_benchmark.c
+++ b/uadk_tool/benchmark/hpre_uadk_benchmark.c
@@ -2706,6 +2706,7 @@ int hpre_uadk_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_thread_num = options->threads;
 	g_ctxnum = options->ctxnums;
 

--- a/uadk_tool/benchmark/hpre_wd_benchmark.c
+++ b/uadk_tool/benchmark/hpre_wd_benchmark.c
@@ -2564,6 +2564,7 @@ int hpre_wd_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_thread_num = options->threads;
 
 	if (options->optype >= (WCRYPTO_EC_OP_MAX - WCRYPTO_ECDSA_VERIFY)) {

--- a/uadk_tool/benchmark/sec_soft_benchmark.c
+++ b/uadk_tool/benchmark/sec_soft_benchmark.c
@@ -1277,6 +1277,7 @@ int sec_soft_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_thread_num = options->threads;
 	g_pktlen = options->pktlen;
 	g_jobsnum = options->ctxnums;

--- a/uadk_tool/benchmark/sec_uadk_benchmark.c
+++ b/uadk_tool/benchmark/sec_uadk_benchmark.c
@@ -1777,6 +1777,7 @@ int sec_uadk_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_thread_num = options->threads;
 	g_pktlen = options->pktlen;
 	g_ctxnum = options->ctxnums;

--- a/uadk_tool/benchmark/sec_wd_benchmark.c
+++ b/uadk_tool/benchmark/sec_wd_benchmark.c
@@ -1630,6 +1630,7 @@ int sec_wd_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_alg = options->subtype;
 	g_algtype = options->algtype;
 	g_optype = options->optype;

--- a/uadk_tool/benchmark/trng_wd_benchmark.c
+++ b/uadk_tool/benchmark/trng_wd_benchmark.c
@@ -312,6 +312,7 @@ int trng_wd_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_thread_num = options->threads;
 
 	ret = init_trng_wd_queue(options);

--- a/uadk_tool/benchmark/uadk_benchmark.c
+++ b/uadk_tool/benchmark/uadk_benchmark.c
@@ -331,6 +331,21 @@ void cal_avg_latency(u32 count)
 	ACC_TST_PRT("thread<%lu> avg latency: %.1fus\n", gettid(), latency);
 }
 
+void segmentfault_handler(int sig)
+{
+#define BUF_SZ 64
+	void *array[BUF_SZ];
+	size_t size;
+
+	/* Get void*'s for all entries on the stack */
+	size = backtrace(array, BUF_SZ);
+
+	/* Print out all the frames to stderr */
+	fprintf(stderr, "Error: signal %d:\n", sig);
+	backtrace_symbols_fd(array, size, STDERR_FILENO);
+	exit(1);
+}
+
 /*-------------------------------------main code------------------------------------------------------*/
 static void parse_alg_param(struct acc_option *option)
 {

--- a/uadk_tool/benchmark/uadk_benchmark.h
+++ b/uadk_tool/benchmark/uadk_benchmark.h
@@ -4,6 +4,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <execinfo.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <linux/random.h>
@@ -15,6 +16,7 @@
 #include <signal.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
+#include <signal.h>
 #include <unistd.h>
 
 #define ACC_TST_PRT		printf
@@ -217,6 +219,7 @@ extern void add_send_complete(void);
 extern u32 get_recv_time(void);
 extern void cal_avg_latency(u32 count);
 extern int get_alg_name(int alg, char *alg_name);
+extern void segmentfault_handler(int sig);
 
 int acc_cmd_parse(int argc, char *argv[], struct acc_option *option);
 int acc_default_case(struct acc_option *option);

--- a/uadk_tool/benchmark/zip_uadk_benchmark.c
+++ b/uadk_tool/benchmark/zip_uadk_benchmark.c
@@ -1331,6 +1331,7 @@ int zip_uadk_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_thread_num = options->threads;
 	g_pktlen = options->pktlen;
 	g_ctxnum = options->ctxnums;

--- a/uadk_tool/benchmark/zip_wd_benchmark.c
+++ b/uadk_tool/benchmark/zip_wd_benchmark.c
@@ -1162,6 +1162,7 @@ int zip_wd_benchmark(struct acc_option *options)
 	u32 ptime;
 	int ret;
 
+	signal(SIGSEGV, segmentfault_handler);
 	g_thread_num = options->threads;
 	g_pktlen = options->pktlen;
 

--- a/v1/drv/hisi_hpre_udrv.c
+++ b/v1/drv/hisi_hpre_udrv.c
@@ -490,12 +490,10 @@ int qm_fill_rsa_sqe(void *message, struct qm_queue_info *info, __u16 i)
 		return -WD_EINVAL;
 	hw_msg->task_len1 = msg->key_bytes / BYTE_BITS - 0x1;
 
-	/* prepare rsa key */
 	ret = qm_rsa_prepare_key(msg, q, hw_msg, &va, &size);
 	if (unlikely(ret))
 		return ret;
 
-	/* prepare in/out put */
 	ret = qm_rsa_prepare_iot(msg, q, hw_msg);
 	if (unlikely(ret)) {
 		rsa_key_unmap(msg, q, hw_msg, va, size);
@@ -576,13 +574,11 @@ static int fill_dh_g_param(struct wd_queue *q, struct wcrypto_dh_msg *msg,
 	int ret;
 
 	ret = qm_crypto_bin_to_hpre_bin((char *)msg->g,
-		(const char *)msg->g, msg->key_bytes,
-		msg->gbytes, "dh g");
+		(const char *)msg->g, msg->key_bytes, msg->gbytes, "dh g");
 	if (unlikely(ret))
 		return ret;
 
-	phy = (uintptr_t)drv_iova_map(q, (void *)msg->g,
-				msg->key_bytes);
+	phy = (uintptr_t)drv_iova_map(q, (void *)msg->g, msg->key_bytes);
 	if (unlikely(!phy)) {
 		WD_ERR("Get dh g parameter dma address fail!\n");
 		return -WD_ENOMEM;
@@ -1338,8 +1334,7 @@ static int qm_ecc_prepare_in(struct wcrypto_ecc_msg *msg,
 		hw_msg->bd_rsv2 = 1; /* fall through */
 	case WCRYPTO_ECXDH_GEN_KEY: /* fall through */
 	case WCRYPTO_SM2_KG:
-		ret = ecc_prepare_dh_gen_in((void *)in,
-					    data);
+		ret = ecc_prepare_dh_gen_in((void *)in, data);
 		break;
 	case WCRYPTO_ECXDH_COMPUTE_KEY:
 		/*
@@ -1667,17 +1662,14 @@ static int qm_fill_ecc_sqe_general(void *message, struct qm_queue_info *info,
 	memset(hw_msg, 0, sizeof(struct hisi_hpre_sqe));
 	hw_msg->task_len1 = ((msg->key_bytes) >> BYTE_BITS_SHIFT) - 0x1;
 
-	/* prepare algorithm */
 	ret = qm_ecc_prepare_alg(hw_msg, msg);
 	if (unlikely(ret))
 		return ret;
 
-	/* prepare key */
 	ret = qm_ecc_prepare_key(msg, q, hw_msg, &va, &size);
 	if (unlikely(ret))
 		return ret;
 
-	/* prepare in/out put */
 	ret = qm_ecc_prepare_iot(msg, q, hw_msg);
 	if (unlikely(ret))
 		goto map_key_fail;

--- a/v1/drv/hisi_qm_udrv.c
+++ b/v1/drv/hisi_qm_udrv.c
@@ -20,6 +20,7 @@
 #include <sys/mman.h>
 #include <string.h>
 #include <stdint.h>
+#include <pthread.h>
 #include <sys/ioctl.h>
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
@@ -458,6 +459,11 @@ static int qm_init_queue_info(struct wd_queue *q)
 	struct hisi_qp_ctx qp_ctx = {0};
 	int ret;
 
+	if (!info->sqe_size) {
+		WD_ERR("invalid: sqe size is 0!\n");
+		return -WD_EINVAL;
+	}
+
 	info->sq_tail_index = 0;
 	info->cq_head_index = 0;
 	info->cqc_phase = 1;
@@ -502,11 +508,6 @@ static int qm_set_queue_info(struct wd_queue *q)
 	ret = qm_set_queue_regions(q);
 	if (ret)
 		return -WD_EINVAL;
-	if (!info->sqe_size) {
-		WD_ERR("sqe size =%d err!\n", info->sqe_size);
-		ret = -WD_EINVAL;
-		goto err_with_regions;
-	}
 	info->cq_base = (void *)((uintptr_t)info->sq_base +
 			info->sqe_size * info->sq_depth);
 
@@ -534,8 +535,24 @@ static int qm_set_queue_info(struct wd_queue *q)
 		goto err_with_regions;
 	}
 
+	ret = pthread_spin_init(&info->sd_lock, PTHREAD_PROCESS_PRIVATE);
+	if (ret) {
+		WD_ERR("failed to init qinfo sd_lock!\n");
+		goto free_cache;
+	}
+
+	ret = pthread_spin_init(&info->rc_lock, PTHREAD_PROCESS_PRIVATE);
+	if (ret) {
+		WD_ERR("failed to init qinfo rc_lock!\n");
+		goto uninit_lock;
+	}
+
 	return 0;
 
+uninit_lock:
+	pthread_spin_destroy(&info->sd_lock);
+free_cache:
+	free(info->req_cache);
 err_with_regions:
 	qm_unset_queue_regions(q);
 	return ret;
@@ -576,8 +593,10 @@ void qm_uninit_queue(struct wd_queue *q)
 	struct q_info *qinfo = q->qinfo;
 	struct qm_queue_info *info = qinfo->priv;
 
-	qm_unset_queue_regions(q);
+	pthread_spin_destroy(&info->rc_lock);
+	pthread_spin_destroy(&info->sd_lock);
 	free(info->req_cache);
+	qm_unset_queue_regions(q);
 	free(qinfo->priv);
 	qinfo->priv = NULL;
 }
@@ -605,10 +624,10 @@ int qm_send(struct wd_queue *q, void **req, __u32 num)
 	int ret;
 	__u32 i;
 
-	wd_spinlock(&info->sd_lock);
+	pthread_spin_lock(&info->sd_lock);
 	if (unlikely((__u32)__atomic_load_n(&info->used, __ATOMIC_RELAXED) >
 		     info->sq_depth - num - 1)) {
-		wd_unspinlock(&info->sd_lock);
+		pthread_spin_unlock(&info->sd_lock);
 		WD_ERR("queue is full!\n");
 		return -WD_EBUSY;
 	}
@@ -617,7 +636,7 @@ int qm_send(struct wd_queue *q, void **req, __u32 num)
 		ret = info->sqe_fill[qinfo->atype](req[i], qinfo->priv,
 				info->sq_tail_index);
 		if (unlikely(ret != WD_SUCCESS)) {
-			wd_unspinlock(&info->sd_lock);
+			pthread_spin_unlock(&info->sd_lock);
 			WD_ERR("sqe fill error, ret %d!\n", ret);
 			return -WD_EINVAL;
 		}
@@ -629,7 +648,7 @@ int qm_send(struct wd_queue *q, void **req, __u32 num)
 	}
 
 	ret = qm_tx_update(info, num);
-	wd_unspinlock(&info->sd_lock);
+	pthread_spin_unlock(&info->sd_lock);
 
 	return ret;
 }
@@ -662,9 +681,9 @@ static int check_ds_rx_base(struct qm_queue_info *info,
 		return 0;
 
 	if (before) {
-		wd_spinlock(&info->rc_lock);
+		pthread_spin_lock(&info->rc_lock);
 		qm_rx_from_cache(info, resp, num);
-		wd_unspinlock(&info->rc_lock);
+		pthread_spin_unlock(&info->rc_lock);
 		WD_ERR("wd queue hw error happened before qm receive!\n");
 	} else {
 		WD_ERR("wd queue hw error happened after qm receive!\n");
@@ -705,7 +724,7 @@ int qm_recv(struct wd_queue *q, void **resp, __u32 num)
 	if (unlikely(ret))
 		return ret;
 
-	wd_spinlock(&info->rc_lock);
+	pthread_spin_lock(&info->rc_lock);
 	for (i = 0; i < num; i++) {
 		cqe = info->cq_base + info->cq_head_index * sizeof(struct cqe);
 		if (info->cqc_phase != CQE_PHASE(cqe))
@@ -714,7 +733,7 @@ int qm_recv(struct wd_queue *q, void **resp, __u32 num)
 		mb(); /* make sure the data is all in memory before read */
 		sq_head = CQE_SQ_HEAD_INDEX(cqe);
 		if (unlikely(sq_head >= info->sq_depth)) {
-			wd_unspinlock(&info->rc_lock);
+			pthread_spin_unlock(&info->rc_lock);
 			WD_ERR("CQE_SQ_HEAD_INDEX(%u) error\n", sq_head);
 			return -WD_EIO;
 		}
@@ -726,7 +745,7 @@ int qm_recv(struct wd_queue *q, void **resp, __u32 num)
 		if (!ret) {
 			break;
 		} else if (ret < 0) {
-			wd_unspinlock(&info->rc_lock);
+			pthread_spin_unlock(&info->rc_lock);
 			WD_ERR("recv sqe error %u\n", sq_head);
 			return ret;
 		}
@@ -747,7 +766,7 @@ int qm_recv(struct wd_queue *q, void **resp, __u32 num)
 			ret = i;
 	}
 
-	wd_unspinlock(&info->rc_lock);
+	pthread_spin_unlock(&info->rc_lock);
 
 	return ret;
 }

--- a/v1/drv/hisi_qm_udrv.h
+++ b/v1/drv/hisi_qm_udrv.h
@@ -166,8 +166,8 @@ struct qm_queue_info {
 	qm_sqe_parse sqe_parse[WCRYPTO_MAX_ALG];
 	hisi_qm_sqe_fill_priv sqe_fill_priv;
 	hisi_qm_sqe_parse_priv sqe_parse_priv;
-	struct wd_lock sd_lock;
-	struct wd_lock rc_lock;
+	pthread_spinlock_t sd_lock;
+	pthread_spinlock_t rc_lock;
 	struct wd_queue *q;
 	int (*sgl_info)(struct hw_sgl_info *info);
 	int (*sgl_init)(void *pool, struct wd_sgl *sgl);

--- a/v1/drv/hisi_rng_udrv.h
+++ b/v1/drv/hisi_rng_udrv.h
@@ -29,7 +29,7 @@ struct rng_queue_info {
 	void *req_cache[TRNG_Q_DEPTH];
 	__u8  send_idx;
 	__u8 recv_idx;
-	struct wd_lock lock;
+	pthread_spinlock_t lock;
 };
 
 int rng_init_queue(struct wd_queue *q);

--- a/v1/drv/hisi_zip_udrv.c
+++ b/v1/drv/hisi_zip_udrv.c
@@ -177,13 +177,11 @@ int qm_fill_zip_sqe(void *smsg, struct qm_queue_info *info, __u16 i)
 		return -WD_EINVAL;
 	}
 
-	if (unlikely(msg->data_fmt != WD_SGL_BUF &&
-		     msg->in_size > MAX_BUFFER_SIZE)) {
+	if (unlikely(msg->data_fmt != WD_SGL_BUF && msg->in_size > MAX_BUFFER_SIZE)) {
 		WD_ERR("The in_len is out of range in_len(%u)!\n", msg->in_size);
 		return -WD_EINVAL;
 	}
-	if (unlikely(msg->data_fmt != WD_SGL_BUF &&
-		     msg->avail_out > MAX_BUFFER_SIZE)) {
+	if (unlikely(msg->data_fmt != WD_SGL_BUF && msg->avail_out > MAX_BUFFER_SIZE)) {
 		WD_ERR("warning: avail_out is out of range (%u), will set 8MB size max!\n",
 		       msg->avail_out);
 		msg->avail_out = MAX_BUFFER_SIZE;
@@ -500,8 +498,10 @@ static int fill_zip_addr_lz77_zstd(void *ssqe,
 	} else {
 		sqe->cipher_key_addr_l = lower_32_bits((__u64)addr.dest_addr);
 		sqe->cipher_key_addr_h = upper_32_bits((__u64)addr.dest_addr);
-		sqe->dest_addr_l = lower_32_bits((__u64)addr.dest_addr + msg->in_size);
-		sqe->dest_addr_h = upper_32_bits((__u64)addr.dest_addr + msg->in_size);
+		sqe->dest_addr_l = lower_32_bits((__u64)addr.dest_addr +
+						 msg->in_size + ZSTD_LIT_RSV_SIZE);
+		sqe->dest_addr_h = upper_32_bits((__u64)addr.dest_addr +
+						 msg->in_size + ZSTD_LIT_RSV_SIZE);
 	}
 
 	sqe->stream_ctx_addr_l = lower_32_bits((__u64)addr.ctxbuf_addr);
@@ -671,7 +671,7 @@ static void fill_priv_lz77_zstd(void *ssqe, struct wcrypto_comp_msg *recv_msg)
 		format->sequences_start = zstd_out->sequence;
 	} else {
 		format->literals_start = recv_msg->dst;
-		format->sequences_start = recv_msg->dst + recv_msg->in_size;
+		format->sequences_start = recv_msg->dst + recv_msg->in_size + ZSTD_LIT_RSV_SIZE;
 		format->freq = (void *)(&format->lit_length_overflow_pos + 1);
 	}
 

--- a/v1/wd_util.c
+++ b/v1/wd_util.c
@@ -25,7 +25,7 @@
 void wd_spinlock(struct wd_lock *lock)
 {
 	while (__atomic_test_and_set(&lock->lock, __ATOMIC_ACQUIRE))
-		while (__atomic_load_n(&lock->lock, __ATOMIC_RELAXED))
+		while (__atomic_load_n(&lock->lock, __ATOMIC_ACQUIRE))
 			;
 }
 

--- a/wd_util.c
+++ b/wd_util.c
@@ -1212,6 +1212,7 @@ err_free_ctxs:
 	free(ctx_config->ctxs);
 err_free_ctx_config:
 	free(ctx_config);
+	config->ctx_config = NULL;
 	return ret;
 }
 


### PR DESCRIPTION
Longfang Liu (2):
  uadk_tools: add segfault locating function
  uadk: bugfix CE driver initialization problem

Wenkai Lin (5):
  uadk/v1: fix for atomic memory order
  uadk: replace wd_lock to pthread_spinlock
  uadk/v1: fix for wd_lock implementation
  uadk: fix for env uninit segment fault
  uadk/v1: replace wd_spinlock to pthread_spin_lock

Yang Shen (1):
  uadk/v1/drv: hisi_zip_udrv - fix the wrong literal buffer size

Zhiqi Song (1):
  uadk/v1/hpre: remove redundant comments

 drv/hash_mb/hash_mb.c                     |  4 ++
 drv/isa_ce_sm3.c                          |  6 +-
 drv/isa_ce_sm4.c                          |  4 ++
 uadk_tool/benchmark/hpre_uadk_benchmark.c |  1 +
 uadk_tool/benchmark/hpre_wd_benchmark.c   |  1 +
 uadk_tool/benchmark/sec_soft_benchmark.c  |  1 +
 uadk_tool/benchmark/sec_uadk_benchmark.c  |  1 +
 uadk_tool/benchmark/sec_wd_benchmark.c    |  1 +
 uadk_tool/benchmark/trng_wd_benchmark.c   |  1 +
 uadk_tool/benchmark/uadk_benchmark.c      | 15 +++++
 uadk_tool/benchmark/uadk_benchmark.h      |  3 +
 uadk_tool/benchmark/zip_uadk_benchmark.c  |  1 +
 uadk_tool/benchmark/zip_wd_benchmark.c    |  1 +
 v1/drv/hisi_hpre_udrv.c                   | 14 +----
 v1/drv/hisi_qm_udrv.c                     | 51 +++++++++++-----
 v1/drv/hisi_qm_udrv.h                     |  4 +-
 v1/drv/hisi_rng_udrv.c                    | 25 +++++---
 v1/drv/hisi_rng_udrv.h                    |  2 +-
 v1/drv/hisi_zip_udrv.c                    | 14 ++---
 v1/wd_util.c                              | 17 ++++--
 wd_mempool.c                              | 74 +++++++++++------------
 wd_util.c                                 |  1 +
 22 files changed, 154 insertions(+), 88 deletions(-)