### PR TITLE
uadk bugfix and cleancode

### DIFF
--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -254,7 +254,7 @@ int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes);
  *
  * Return 0 if the datalist is not less than expected size.
  */
-int wd_check_datalist(struct wd_datalist *head, __u32 size);
+int wd_check_datalist(struct wd_datalist *head, __u64 size);
 
 
 /*

--- a/v1/drv/hisi_sec_udrv.c
+++ b/v1/drv/hisi_sec_udrv.c
@@ -1738,7 +1738,7 @@ int qm_fill_digest_bd3_sqe(void *message, struct qm_queue_info *info, __u16 i)
 	info->req_cache[i] = msg;
 
 #ifdef DEBUG_LOG
-	sec_dump_bd((unsigned int *)sqe, SQE_BYTES_NUMS);
+	sec_dump_bd((unsigned char *)temp, SQE_BYTES_NUMS);
 #endif
 
 	return WD_SUCCESS;
@@ -1961,10 +1961,7 @@ int qm_parse_cipher_bd3_sqe(void *msg, const struct qm_queue_info *info,
 	}
 
 #ifdef DEBUG_LOG
-	if (sqe3->type == BD_TYPE3)
-		sec_dump_bd((unsigned char *)sqe3, SQE_BYTES_NUMS);
-	else
-		sec_dump_bd((unsigned char *)sqe, SQE_BYTES_NUMS);
+	sec_dump_bd((unsigned char *)msg, SQE_BYTES_NUMS);
 #endif
 
 	return 1;
@@ -2515,7 +2512,7 @@ int qm_fill_aead_bd3_sqe(void *message, struct qm_queue_info *info, __u16 i)
 	info->req_cache[i] = msg;
 
 #ifdef DEBUG_LOG
-	sec_dump_bd((unsigned char *)sqe, SQE_BYTES_NUMS);
+	sec_dump_bd((unsigned char *)temp, SQE_BYTES_NUMS);
 #endif
 
 	return ret;
@@ -2602,7 +2599,7 @@ int qm_parse_aead_bd3_sqe(void *msg, const struct qm_queue_info *info,
 	}
 
 #ifdef DEBUG_LOG
-	sec_dump_bd((unsigned char *)sqe, SQE_BYTES_NUMS);
+	sec_dump_bd((unsigned char *)msg, SQE_BYTES_NUMS);
 #endif
 
 	return 1;
@@ -2669,7 +2666,7 @@ int qm_parse_digest_bd3_sqe(void *msg, const struct qm_queue_info *info,
 	}
 
 #ifdef DEBUG_LOG
-	sec_dump_bd((unsigned int *)sqe, SQE_BYTES_NUMS);
+	sec_dump_bd((unsigned char *)msg, SQE_BYTES_NUMS);
 #endif
 
 	return 1;

--- a/v1/libwd.map
+++ b/v1/libwd.map
@@ -160,6 +160,7 @@ global:
 	wd_get_sgl_datalen;
 	wd_get_sge_datalen;
 	wd_get_sgl_bufsize;
+	hisi_qm_inject_op_register;
 
 local: *;
 };

--- a/v1/wd.c
+++ b/v1/wd.c
@@ -688,8 +688,10 @@ int wd_wait(struct wd_queue *q, __u16 ms)
 	fds[0].events = POLLIN;
 
 	ret = poll(fds, 1, ms);
-	if (unlikely(ret < 0))
+	if (unlikely(ret < 0)) {
+		WD_ERR("failed to poll a queue!\n");
 		return -WD_ENODEV;
+	}
 
 	/* return 0 for no data, 1 for new message */
 	return ret;
@@ -700,8 +702,11 @@ int wd_recv_sync(struct wd_queue *q, void **resp, __u16 ms)
 	int ret;
 
 	ret = wd_wait(q, ms);
-	if (likely(ret > 0))
-		return wd_recv(q, resp);
+	if (likely(ret > 0)) {
+		ret = wd_recv(q, resp);
+		if (unlikely(!ret))
+			WD_ERR("failed to recv data after poll!\n");
+	}
 
 	return ret;
 }

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -374,7 +374,7 @@ void wd_aead_free_sess(handle_t h_sess)
 static int wd_aead_param_check(struct wd_aead_sess *sess,
 			       struct wd_aead_req *req)
 {
-	__u32 len;
+	__u64 len;
 	int ret;
 
 	if (unlikely(!sess || !req)) {
@@ -410,18 +410,11 @@ static int wd_aead_param_check(struct wd_aead_sess *sess,
 		return -WD_EINVAL;
 	}
 
-	ret = wd_check_src_dst(req->src, req->in_bytes, req->dst, req->out_bytes);
-	if (unlikely(ret)) {
-		WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
-		return -WD_EINVAL;
-	}
-
 	if (req->data_fmt == WD_SGL_BUF) {
-		len = req->in_bytes + req->assoc_bytes;
+		len = (__u64)req->in_bytes + req->assoc_bytes;
 		ret = wd_check_datalist(req->list_src, len);
 		if (unlikely(ret)) {
-			WD_ERR("failed to check the src datalist, size = %u\n",
-				len);
+			WD_ERR("failed to check the src datalist, size = %llu\n", len);
 			return -WD_EINVAL;
 		}
 
@@ -429,6 +422,12 @@ static int wd_aead_param_check(struct wd_aead_sess *sess,
 		if (unlikely(ret)) {
 			WD_ERR("failed to check the dst datalist, size = %u\n",
 				req->out_bytes);
+			return -WD_EINVAL;
+		}
+	} else {
+		ret = wd_check_src_dst(req->src, req->in_bytes, req->dst, req->out_bytes);
+		if (unlikely(ret)) {
+			WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 			return -WD_EINVAL;
 		}
 	}

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -560,7 +560,7 @@ static int cipher_iv_len_check(struct wd_cipher_req *req,
 
 	if (!req->iv) {
 		WD_ERR("invalid: cipher input iv is NULL!\n");
-		ret = -WD_EINVAL;
+		return -WD_EINVAL;
 	}
 
 	switch (sess->alg) {
@@ -636,12 +636,6 @@ static int wd_cipher_check_params(handle_t h_sess,
 	if (unlikely(ret))
 		return ret;
 
-	ret = wd_check_src_dst(req->src, req->in_bytes, req->dst, req->out_bytes);
-	if (unlikely(ret)) {
-		WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
-		return -WD_EINVAL;
-	}
-
 	if (req->data_fmt == WD_SGL_BUF) {
 		ret = wd_check_datalist(req->list_src, req->in_bytes);
 		if (unlikely(ret)) {
@@ -655,6 +649,12 @@ static int wd_cipher_check_params(handle_t h_sess,
 		if (unlikely(ret)) {
 			WD_ERR("failed to check the dst datalist, len = %u\n",
 				req->in_bytes);
+			return -WD_EINVAL;
+		}
+	} else {
+		ret = wd_check_src_dst(req->src, req->in_bytes, req->dst, req->out_bytes);
+		if (unlikely(ret)) {
+			WD_ERR("invalid: src/dst addr is NULL when src/dst size is non-zero!\n");
 			return -WD_EINVAL;
 		}
 	}

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -548,17 +548,23 @@ static int wd_digest_param_check(struct wd_digest_sess *sess,
 		return -WD_EINVAL;
 	}
 
-	ret = wd_check_src_dst(req->in, req->in_bytes, req->out, req->out_bytes);
-	if (unlikely(ret)) {
-		WD_ERR("invalid: in/out addr is NULL when in/out size is non-zero!\n");
-		return -WD_EINVAL;
-	}
-
 	if (req->data_fmt == WD_SGL_BUF) {
 		ret = wd_check_datalist(req->list_in, req->in_bytes);
 		if (unlikely(ret)) {
 			WD_ERR("failed to check the src datalist, size = %u\n",
 				req->in_bytes);
+			return -WD_EINVAL;
+		}
+
+		ret = wd_check_src_dst(NULL, 0, req->out, req->out_bytes);
+		if (unlikely(ret)) {
+			WD_ERR("invalid: out addr is NULL when out size is non-zero!\n");
+			return -WD_EINVAL;
+		}
+	} else {
+		ret = wd_check_src_dst(req->in, req->in_bytes, req->out, req->out_bytes);
+		if (unlikely(ret)) {
+			WD_ERR("invalid: in/out addr is NULL when in/out size is non-zero!\n");
 			return -WD_EINVAL;
 		}
 	}

--- a/wd_util.c
+++ b/wd_util.c
@@ -475,10 +475,10 @@ int wd_check_src_dst(void *src, __u32 in_bytes, void *dst, __u32 out_bytes)
 	return 0;
 }
 
-int wd_check_datalist(struct wd_datalist *head, __u32 size)
+int wd_check_datalist(struct wd_datalist *head, __u64 size)
 {
 	struct wd_datalist *tmp = head;
-	__u32 list_size = 0;
+	__u64 list_size = 0;
 
 	while (tmp) {
 		if (tmp->data)

--- a/wd_util.c
+++ b/wd_util.c
@@ -2632,10 +2632,15 @@ static int wd_alg_ce_ctx_init(struct wd_init_attrs *attrs)
 	ctx_config->ctx_num = 1;
 	ctx_config->ctxs = calloc(ctx_config->ctx_num, sizeof(struct wd_ctx));
 	if (!ctx_config->ctxs) {
-		return -WD_ENOMEM;
 		WD_ERR("failed to alloc ctxs!\n");
+		return -WD_ENOMEM;
 	}
+
 	ctx_config->ctxs[0].ctx = (handle_t)calloc(1, sizeof(struct wd_ce_ctx));
+	if (!ctx_config->ctxs[0].ctx) {
+		free(ctx_config->ctxs);
+		return -WD_ENOMEM;
+	}
 
 	return WD_SUCCESS;
 }
@@ -2719,7 +2724,7 @@ int wd_alg_attrs_init(struct wd_init_attrs *attrs)
 	char alg_type[CRYPTO_MAX_ALG_NAME];
 	int driver_type = UADK_ALG_HW;
 	char *alg = attrs->alg;
-	int ret = 0;
+	int ret = -WD_EINVAL;
 
 	if (!attrs->ctx_params)
 		return -WD_EINVAL;
@@ -2801,7 +2806,6 @@ int wd_alg_attrs_init(struct wd_init_attrs *attrs)
 						  numa_max_node() + 1, alg_poll_func);
 		if (!alg_sched) {
 			WD_ERR("fail to instance scheduler\n");
-			ret = -WD_EINVAL;
 			goto out_ctx_config;
 		}
 		attrs->sched = alg_sched;


### PR DESCRIPTION
Weili Qian (3):
  uadk: modify address check
  uadk: check calloc return value
  drv/hisi_sec: modify minor errors in hisi_sec.c

Wenkai Lin (3):
  uadk/v1: fix for sec_dump_bd
  uadk/v1: fix for wd_recv_sync print
  uadk/v1: update the symbol table for libraries

 drv/hisi_sec.c         | 59 ++++++++++++++++++++++++++----------------
 include/wd_util.h      |  2 +-
 v1/drv/hisi_sec_udrv.c | 13 ++++------
 v1/libwd.map           |  1 +
 v1/wd.c                | 11 +++++---
 wd_aead.c              | 19 +++++++-------
 wd_cipher.c            | 14 +++++-----
 wd_digest.c            | 18 ++++++++-----
 wd_util.c              | 14 ++++++----
 9 files changed, 88 insertions(+), 63 deletions(-)