### PR TITLE
demo with hack

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,6 +47,10 @@ uadk_driversdir=$(libdir)/uadk
 uadk_drivers_LTLIBRARIES=libhisi_sec.la libhisi_hpre.la libhisi_zip.la \
 			 libisa_ce.la libisa_sve.la libhisi_dae.la
 
+if HAVE_ZLIB
+uadk_drivers_LTLIBRARIES+=libhisi_zlib.la
+endif
+
 libwd_la_SOURCES=wd.c wd_mempool.c wd.h	wd_alg.c wd_alg.h	\
 		 v1/wd.c v1/wd.h v1/wd_adapter.c v1/wd_adapter.h \
 		 v1/wd_rng.c v1/wd_rng.h	\
@@ -75,6 +79,8 @@ libwd_comp_la_SOURCES=wd_comp.c wd_comp.h wd_comp_drv.h wd_util.c wd_util.h \
 
 libhisi_zip_la_SOURCES=drv/hisi_comp.c hisi_comp.h drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h wd_comp_drv.h
+
+libhisi_zlib_la_SOURCES=drv/hisi_zlib.c
 
 libwd_crypto_la_SOURCES=wd_cipher.c wd_cipher.h wd_cipher_drv.h \
 			wd_aead.c wd_aead.h wd_aead_drv.h \
@@ -115,6 +121,8 @@ libwd_comp_la_LIBADD = $(libwd_la_OBJECTS) -ldl -lnuma
 libwd_comp_la_DEPENDENCIES = libwd.la
 
 libhisi_zip_la_LIBADD = -ldl
+
+libhisi_zlib_la_LIBADD = -ldl -lz
 
 libwd_crypto_la_LIBADD = $(libwd_la_OBJECTS) -ldl -lnuma
 libwd_crypto_la_DEPENDENCIES = libwd.la
@@ -162,6 +170,9 @@ libwd_dae_la_DEPENDENCIES= libwd.la
 libhisi_zip_la_LIBADD= -lwd -ldl -lwd_comp
 libhisi_zip_la_LDFLAGS=$(UADK_VERSION)
 libhisi_zip_la_DEPENDENCIES= libwd.la libwd_comp.la
+
+libhisi_zlib_la_LIBADD= -ldl -lz
+libhisi_zlib_la_LDFLAGS=$(UADK_VERSION)
 
 libhisi_sec_la_LIBADD= -lwd -lwd_crypto
 libhisi_sec_la_LDFLAGS=$(UADK_VERSION)

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,8 @@ libwd_la_SOURCES=wd.c wd_mempool.c wd.h	wd_alg.c wd_alg.h	\
 		 v1/drv/hisi_zip_udrv.c v1/drv/hisi_zip_udrv.h \
 		 v1/drv/hisi_hpre_udrv.c v1/drv/hisi_hpre_udrv.h \
 		 v1/drv/hisi_sec_udrv.c v1/drv/hisi_sec_udrv.h \
-		 v1/drv/hisi_rng_udrv.c v1/drv/hisi_rng_udrv.h
+		 v1/drv/hisi_rng_udrv.c v1/drv/hisi_rng_udrv.h \
+		 adapter.c
 
 libwd_dae_la_SOURCES=wd_dae.h wd_agg.h wd_agg_drv.h wd_agg.c \
 		     wd_util.c wd_util.h wd_sched.c wd_sched.h wd.c wd.h

--- a/adapter.c
+++ b/adapter.c
@@ -7,26 +7,100 @@
 
 #include "adapter.h"
 
-int uadk_adapter_add_workers(struct uadk_adapter *adapter, char *alg)
+#define CONFIG_FILE_ENV "UADK_CONF"
+#define DRIVER_NAME_KEY "driver_name"
+#define MODE_KEY "mode"
+
+static int read_value_int(FILE *fp, const char *key)
+{
+	char line[1024];
+
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		char *key_value = strtok(line, "=");
+			if (key_value && strcmp(key_value, key) == 0) {
+				char *value = strtok(NULL, "\n");
+
+				if (value) {
+					int mode = atoi(value);
+					return mode;
+				}
+			}
+	}
+	return 0;
+}
+
+static void read_config_entries(FILE *fp, struct uadk_adapter *adapter, char *alg_name)
 {
 	struct uadk_adapter_worker *worker;
 	struct wd_alg_driver *drv;
-	int idx = 0;
-	
-	do {
-		drv = wd_find_drv(NULL, alg, idx);
-		if (!drv)
-			break;
+	char *drv_name = NULL;
+	char line[1024];
+	int i = 0;
 
-		worker = &adapter->workers[idx];
-		worker->driver = drv;
-		worker->lifetime = 0;
-		worker->idx = idx;
-		adapter->workers_nb++;
-		
-		if (++idx >= UADK_MAX_NB_WORKERS)
-			break;
-	} while (drv);
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		char *key_value = strtok(line, "=");
+
+		if (key_value && strcmp(key_value, DRIVER_NAME_KEY) == 0)
+			drv_name = strdup(strtok(NULL, "\n"));
+
+		if ((drv_name != NULL) && (alg_name != NULL)) {
+			drv = wd_find_drv(drv_name, alg_name, 0);
+			if (!drv)
+				continue;
+
+			worker = &adapter->workers[i];
+			worker->driver = drv;
+			worker->lifetime = 0;
+			worker->idx = i;
+			adapter->workers_nb++;
+
+			if (drv_name) {
+				free(drv_name);
+				drv_name = NULL;
+			}
+
+			if (++i >= UADK_MAX_NB_WORKERS)
+				break;
+		}
+	}
+
+	if (drv_name)
+		free(drv_name);
+}
+
+int uadk_adapter_add_workers(struct uadk_adapter *adapter, char *alg)
+{
+	char *uadk_conf = getenv(CONFIG_FILE_ENV);
+	struct uadk_adapter_worker *worker;
+	struct wd_alg_driver *drv;
+	FILE *fp = NULL;
+	int idx = 0;
+
+	if (uadk_conf != NULL)
+		fp = fopen(uadk_conf, "r");
+
+	if (fp) {
+		/* if env UADK_CONF exist, only parse config */
+		adapter->mode = read_value_int(fp, MODE_KEY);
+		read_config_entries(fp, adapter, alg);
+		fclose(fp);
+	} else {
+		/* if no UADK_CONF, parse all drv to the workers*/
+		do {
+			drv = wd_find_drv(NULL, alg, idx);
+			if (!drv)
+				break;
+
+			worker = &adapter->workers[idx];
+			worker->driver = drv;
+			worker->lifetime = 0;
+			worker->idx = idx;
+			adapter->workers_nb++;
+
+			if (++idx >= UADK_MAX_NB_WORKERS)
+				break;
+		} while (drv);
+	}
 
 	return (adapter->workers_nb == 0);
 }

--- a/adapter.c
+++ b/adapter.c
@@ -61,7 +61,6 @@ static void read_config_entries(char *conf, struct uadk_adapter *adapter, char *
 
 			worker = &adapter->workers[i];
 			worker->driver = drv;
-			worker->lifetime = 0;
 			worker->idx = i;
 			adapter->workers_nb++;
 			if (drv_name) {
@@ -103,7 +102,6 @@ int uadk_adapter_add_workers(struct uadk_adapter *adapter, char *alg)
 
 		worker = &adapter->workers[idx];
 		worker->driver = drv;
-		worker->lifetime = 0;
 		worker->idx = idx;
 		adapter->workers_nb++;
 
@@ -123,7 +121,6 @@ struct uadk_adapter_worker *uadk_adapter_choose_worker(
 	/* use worker[0] for simplicity now */
 	worker = &adapter->workers[0];
 	worker->valid = true;
-	worker->lifetime = 0;
 
 	return worker;
 }
@@ -150,7 +147,6 @@ struct uadk_adapter_worker *uadk_adapter_switch_worker(
 
 	new_worker = &adapter->workers[idx];
 	new_worker->valid = true;
-	new_worker->lifetime = 0;
 
 	return new_worker;
 }

--- a/adapter.c
+++ b/adapter.c
@@ -1,0 +1,73 @@
+
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright 2024-2025 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2024-2025 Linaro ltd.
+ */
+
+#include "adapter.h"
+
+int uadk_adapter_add_workers(struct uadk_adapter *adapter, char *alg)
+{
+	struct uadk_adapter_worker *worker;
+	struct wd_alg_driver *drv;
+	int idx = 0;
+	
+	do {
+		drv = wd_find_drv(NULL, alg, idx);
+		if (!drv)
+			break;
+
+		worker = &adapter->workers[idx];
+		worker->driver = drv;
+		worker->lifetime = 0;
+		worker->idx = idx;
+		adapter->workers_nb++;
+		
+		if (++idx >= UADK_MAX_NB_WORKERS)
+			break;
+	} while (drv);
+
+	return (adapter->workers_nb == 0);
+}
+
+struct uadk_adapter_worker *uadk_adapter_choose_worker(
+	struct uadk_adapter *adapter,
+	enum alg_task_type type)
+{
+	struct uadk_adapter_worker *worker;
+
+	/* use worker[0] for simplicity now */
+	worker = &adapter->workers[0];
+	worker->valid = true;
+	worker->lifetime = 0;
+
+	return worker;
+}
+
+struct uadk_adapter_worker *uadk_adapter_switch_worker(
+	struct uadk_adapter *adapter,
+	struct uadk_adapter_worker *worker,
+	int para)
+{
+	struct uadk_adapter_worker *new_worker;
+	int idx = worker->idx;
+
+	if (adapter->workers_nb == 1)
+		return worker;
+
+	if (para) {
+		idx += 1;
+	} else {
+		if (idx == 0)
+			idx = adapter->workers_nb - 1;
+		else
+			idx -= 1;
+	}
+
+	new_worker = &adapter->workers[idx];
+	new_worker->valid = true;
+	new_worker->lifetime = 0;
+
+	return new_worker;
+}

--- a/adapter.c
+++ b/adapter.c
@@ -109,6 +109,22 @@ int uadk_adapter_add_workers(struct uadk_adapter *adapter, char *alg)
 			break;
 	} while (drv);
 
+	/* sorted as priority */
+	for (int i = 0; i < adapter->workers_nb; i++) {
+		for (int j = i; j < adapter->workers_nb; j++) {
+			if (adapter->workers[i].driver->priority <
+			    adapter->workers[j].driver->priority) {
+				struct uadk_adapter_worker tmp_worker;
+
+				tmp_worker.driver = adapter->workers[i].driver;
+				adapter->workers[i].driver = adapter->workers[j].driver;
+				adapter->workers[i].idx = i;
+				adapter->workers[j].driver = tmp_worker.driver;
+				adapter->workers[j].idx = j;
+			}
+		}
+	}
+
 	return (adapter->workers_nb == 0);
 }
 

--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -1000,9 +1000,10 @@ static void get_ctx_buf(struct hisi_zip_sqe *sqe,
 	}
 }
 
-static int parse_zip_sqe(struct hisi_qp *qp, struct hisi_zip_sqe *sqe,
-			 struct wd_comp_msg *msg)
+static int parse_zip_sqe(struct wd_alg_driver *drv, struct hisi_qp *qp,
+			 struct hisi_zip_sqe *sqe, struct wd_comp_msg *msg)
 {
+	struct hisi_zip_ctx *priv = (struct hisi_zip_ctx *)drv->priv;
 	__u32 buf_type = (sqe->dw9 & HZ_BUF_TYPE_MASK) >> BUF_TYPE_SHIFT;
 	__u16 ctx_st = sqe->ctx_dw0 & HZ_CTX_ST_MASK;
 	__u16 lstblk = sqe->dw3 & HZ_LSTBLK_MASK;
@@ -1027,7 +1028,7 @@ static int parse_zip_sqe(struct hisi_qp *qp, struct hisi_zip_sqe *sqe,
 	recv_msg->tag = tag;
 
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		recv_msg = wd_comp_get_msg(qp->q_info.idx, tag);
+		recv_msg = wd_find_msg_in_pool(priv->config.pool, qp->q_info.idx, tag);
 		if (unlikely(!recv_msg)) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u!\n",
 			       qp->q_info.idx, tag);
@@ -1084,7 +1085,7 @@ static int hisi_zip_comp_recv(struct wd_alg_driver *drv, handle_t ctx, void *com
 	if (unlikely(ret < 0))
 		return ret;
 
-	return parse_zip_sqe(qp, &sqe, recv_msg);
+	return parse_zip_sqe(drv, qp, &sqe, recv_msg);
 }
 
 #define GEN_ZIP_ALG_DRIVER(zip_alg_name) \

--- a/drv/hisi_dae.c
+++ b/drv/hisi_dae.c
@@ -653,6 +653,7 @@ static void fill_hashagg_msg_task_err(struct dae_sqe *sqe, struct wd_agg_msg *ms
 
 static int hashagg_recv(struct wd_alg_driver *drv, handle_t ctx, void *hashagg_msg)
 {
+	struct hisi_dae_ctx *priv = (struct hisi_dae_ctx *)drv->priv;
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
 	struct dae_extend_addr *ext_addr = qp->priv;
@@ -673,7 +674,7 @@ static int hashagg_recv(struct wd_alg_driver *drv, handle_t ctx, void *hashagg_m
 
 	msg->tag = sqe.low_tag;
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		temp_msg = wd_agg_get_msg(qp->q_info.idx, msg->tag);
+		temp_msg = wd_find_msg_in_pool(priv->config.pool, qp->q_info.idx, msg->tag);
 		if (!temp_msg) {
 			msg->result = WD_AGG_IN_EPARA;
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",

--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -661,6 +661,7 @@ static void hpre_result_check(struct hisi_hpre_sqe *hw_msg,
 
 static int rsa_recv(struct wd_alg_driver *drv, handle_t ctx, void *rsa_msg)
 {
+	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
 	struct hisi_hpre_sqe hw_msg = {0};
@@ -679,7 +680,7 @@ static int rsa_recv(struct wd_alg_driver *drv, handle_t ctx, void *rsa_msg)
 
 	msg->tag = LW_U16(hw_msg.low_tag);
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		temp_msg = wd_rsa_get_msg(qp->q_info.idx, msg->tag);
+		temp_msg = wd_find_msg_in_pool(priv->config.pool, qp->q_info.idx, msg->tag);
 		if (!temp_msg) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
 				qp->q_info.idx, msg->tag);
@@ -804,6 +805,7 @@ static int dh_send(struct wd_alg_driver *drv, handle_t ctx, void *dh_msg)
 
 static int dh_recv(struct wd_alg_driver *drv, handle_t ctx, void *dh_msg)
 {
+	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
 	handle_t h_qp = (handle_t)wd_ctx_get_priv(ctx);
 	struct hisi_qp *qp = (struct hisi_qp *)h_qp;
 	struct wd_dh_msg *msg = dh_msg;
@@ -822,7 +824,7 @@ static int dh_recv(struct wd_alg_driver *drv, handle_t ctx, void *dh_msg)
 
 	msg->tag = LW_U16(hw_msg.low_tag);
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		temp_msg = wd_dh_get_msg(qp->q_info.idx, msg->tag);
+		temp_msg = wd_find_msg_in_pool(priv->config.pool, qp->q_info.idx, msg->tag);
 		if (!temp_msg) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
 				qp->q_info.idx, msg->tag);
@@ -2039,7 +2041,6 @@ static int ecc_out_transfer(struct wd_ecc_msg *msg,
 	return ret;
 }
 
-
 static __u32 get_hash_bytes(__u8 type)
 {
 	__u32 val = 0;
@@ -2305,15 +2306,16 @@ static int sm2_convert_dec_out(struct wd_ecc_msg *src,
 	return ret;
 }
 
-static int ecc_sqe_parse(struct hisi_qp *qp, struct wd_ecc_msg *msg,
-			 struct hisi_hpre_sqe *hw_msg)
+static int ecc_sqe_parse(struct wd_alg_driver *drv, struct hisi_qp *qp,
+			 struct wd_ecc_msg *msg, struct hisi_hpre_sqe *hw_msg)
 {
+	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
 	struct wd_ecc_msg *temp_msg;
 	int ret;
 
 	msg->tag = LW_U16(hw_msg->low_tag);
 	if (qp->q_info.qp_mode == CTX_MODE_ASYNC) {
-		temp_msg = wd_ecc_get_msg(qp->q_info.idx, msg->tag);
+		temp_msg = wd_find_msg_in_pool(priv->config.pool, qp->q_info.idx, msg->tag);
 		if (!temp_msg) {
 			WD_ERR("failed to get send msg! idx = %u, tag = %u.\n",
 				qp->q_info.idx, msg->tag);
@@ -2344,7 +2346,7 @@ dump_err_msg:
 	return ret;
 }
 
-static int parse_second_sqe(handle_t h_qp,
+static int parse_second_sqe(struct wd_alg_driver *drv, handle_t h_qp,
 			    struct wd_ecc_msg *msg,
 			    struct wd_ecc_msg **second)
 {
@@ -2373,15 +2375,15 @@ static int parse_second_sqe(handle_t h_qp,
 	hsz = (hw_msg.task_len1 + 1) * BYTE_BITS;
 	dst = *(struct wd_ecc_msg **)((uintptr_t)data +
 		hsz * ECDH_OUT_PARAM_NUM);
-	ret = ecc_sqe_parse((struct hisi_qp *)h_qp, dst, &hw_msg);
+	ret = ecc_sqe_parse(drv, (struct hisi_qp *)h_qp, dst, &hw_msg);
 	msg->result = dst->result;
 	*second = dst;
 
 	return ret;
 }
 
-static int sm2_enc_parse(handle_t h_qp, struct wd_ecc_msg *msg,
-			 struct hisi_hpre_sqe *hw_msg)
+static int sm2_enc_parse(struct wd_alg_driver *drv, handle_t h_qp,
+			 struct wd_ecc_msg *msg, struct hisi_hpre_sqe *hw_msg)
 {
 	__u16 tag = LW_U16(hw_msg->low_tag);
 	struct wd_ecc_msg *second = NULL;
@@ -2399,14 +2401,14 @@ static int sm2_enc_parse(handle_t h_qp, struct wd_ecc_msg *msg,
 	memcpy(&src, first + 1, sizeof(src));
 
 	/* parse first sqe */
-	ret = ecc_sqe_parse((struct hisi_qp *)h_qp, first, hw_msg);
+	ret = ecc_sqe_parse(drv, (struct hisi_qp *)h_qp, first, hw_msg);
 	if (ret) {
 		WD_ERR("failed to parse first BD, ret = %d!\n", ret);
 		goto free_first;
 	}
 
 	/* parse second sqe */
-	ret = parse_second_sqe(h_qp, msg, &second);
+	ret = parse_second_sqe(drv, h_qp, msg, &second);
 	if (unlikely(ret)) {
 		WD_ERR("failed to parse second BD, ret = %d!\n", ret);
 		goto free_first;
@@ -2426,8 +2428,8 @@ free_first:
 	return ret;
 }
 
-static int sm2_dec_parse(handle_t ctx, struct wd_ecc_msg *msg,
-			 struct hisi_hpre_sqe *hw_msg)
+static int sm2_dec_parse(struct wd_alg_driver *drv, handle_t ctx,
+			 struct wd_ecc_msg *msg, struct hisi_hpre_sqe *hw_msg)
 {
 	__u16 tag = LW_U16(hw_msg->low_tag);
 	struct wd_ecc_msg *dst;
@@ -2443,7 +2445,7 @@ static int sm2_dec_parse(handle_t ctx, struct wd_ecc_msg *msg,
 	memcpy(&src, dst + 1, sizeof(src));
 
 	/* parse first sqe */
-	ret = ecc_sqe_parse((struct hisi_qp *)ctx, dst, hw_msg);
+	ret = ecc_sqe_parse(drv, (struct hisi_qp *)ctx, dst, hw_msg);
 	if (ret) {
 		WD_ERR("failed to parse decode BD, ret = %d!\n", ret);
 		goto fail;
@@ -2482,12 +2484,12 @@ static int ecc_recv(struct wd_alg_driver *drv, handle_t ctx, void *ecc_msg)
 
 	if (hw_msg.alg == HPRE_ALG_ECDH_MULTIPLY &&
 		hw_msg.sm2_mlen == HPRE_SM2_ENC)
-		return sm2_enc_parse(h_qp, msg, &hw_msg);
+		return sm2_enc_parse(drv, h_qp, msg, &hw_msg);
 	else if (hw_msg.alg == HPRE_ALG_ECDH_MULTIPLY &&
 		hw_msg.sm2_mlen == HPRE_SM2_DEC)
-		return sm2_dec_parse(h_qp, msg, &hw_msg);
+		return sm2_dec_parse(drv, h_qp, msg, &hw_msg);
 
-	return ecc_sqe_parse((struct hisi_qp *)h_qp, msg, &hw_msg);
+	return ecc_sqe_parse(drv, (struct hisi_qp *)h_qp, msg, &hw_msg);
 }
 
 static int hpre_get_usage(void *param)

--- a/drv/hisi_zlib.c
+++ b/drv/hisi_zlib.c
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright 2023-2024 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2023-2024 Linaro ltd.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <zlib.h>
+
+#include "drv/wd_comp_drv.h"
+
+struct hisi_zlib_priv {
+	int windowbits;
+};
+
+static int hisi_zlib_init(struct wd_alg_driver *drv, void *conf)
+{
+	struct hisi_zlib_priv *priv;
+
+	priv = malloc(sizeof(struct hisi_zlib_priv));
+	if (!priv)
+		return -ENOMEM;
+
+	if (strcmp(drv->alg_name, "zlib") == 0)
+		priv->windowbits = 15;
+	else if (strcmp(drv->alg_name, "deflate") == 0)
+		priv->windowbits = -15;
+	else if (strcmp(drv->alg_name, "gzip") == 0)
+		priv->windowbits = 15 + 16;
+
+	drv->priv = priv;
+
+	return 0;
+}
+static void hisi_zlib_exit(struct wd_alg_driver *drv)
+{
+	struct hisi_zlib_priv *priv = (struct hisi_zlib_priv *)drv->priv;
+
+	free(priv);
+}
+
+static int hisi_zlib_send(struct wd_alg_driver *drv, handle_t ctx, void *comp_msg)
+{
+	struct hisi_zlib_priv *priv = (struct hisi_zlib_priv *)drv->priv;
+	struct wd_comp_msg *msg = comp_msg;
+	z_stream strm;
+	int ret;
+
+	memset(&strm, 0, sizeof(z_stream));
+
+	strm.next_in = msg->req.src;
+	strm.avail_in = msg->req.src_len;
+	strm.next_out = msg->req.dst;
+	strm.avail_out = msg->req.dst_len;
+
+	if (msg->req.op_type == WD_DIR_COMPRESS) {
+		/* deflate */
+
+		ret = deflateInit2(&strm, Z_BEST_SPEED, Z_DEFLATED, priv->windowbits,
+				8, Z_DEFAULT_STRATEGY);
+		if (ret != Z_OK) {
+			printf("deflateInit2: %d\n", ret);
+			return -EINVAL;
+		}
+
+		do {
+			ret = deflate(&strm, Z_FINISH);
+			if ((ret == Z_STREAM_ERROR) || (ret == Z_BUF_ERROR)) {
+				printf("defalte error %d - %s\n", ret, strm.msg);
+				ret = -ENOSR;
+				break;
+			} else if (!strm.avail_in) {
+				if (ret != Z_STREAM_END)
+					printf("deflate unexpected return: %d\n", ret);
+				ret = 0;
+				break;
+			} else if (!strm.avail_out) {
+				printf("deflate out of memory\n");
+				ret = -ENOSPC;
+				break;
+			}
+		} while (ret == Z_OK);
+
+		deflateEnd(&strm);
+
+	} else {
+		/* inflate */
+
+		/* Window size of 15, +32 for auto-decoding gzip/zlib */
+		ret = inflateInit2(&strm, 15 + 32);
+		if (ret != Z_OK) {
+			printf("zlib inflateInit: %d\n", ret);
+			return -EINVAL;
+		}
+
+		do {
+			ret = inflate(&strm, Z_NO_FLUSH);
+			if ((ret < 0) || (ret == Z_NEED_DICT)) {
+				printf("zlib error %d - %s\n", ret, strm.msg);
+				ret = -EINVAL;
+				break;
+			}
+			if (!strm.avail_out) {
+				if (!strm.avail_in || (ret == Z_STREAM_END)) {
+					ret = 0;
+					break;
+				}
+				printf("%s: avail_out is empty!\n", __func__);
+				ret = -EINVAL;
+				break;
+			}
+		} while (strm.avail_in && (ret != Z_STREAM_END));
+		inflateEnd(&strm);
+	}
+
+	msg->produced = msg->req.dst_len - strm.avail_out;
+	msg->in_cons = msg->req.src_len;
+
+	return ret;
+}
+static int hisi_zlib_recv(struct wd_alg_driver *drv, handle_t ctx, void *msg)
+{
+	/*
+	 * recv just return since cpu does not support async,
+	 * once send func return, the operation is done
+	 */
+	return 0;
+}
+
+#define GEN_ZLIB_ALG_DRIVER(zlib_alg_name) \
+{\
+	.drv_name = "hisi_zlib",\
+	.alg_name = zlib_alg_name,\
+	.calc_type = UADK_ALG_SOFT,\
+	.priority = 0,\
+	.init = hisi_zlib_init,\
+	.exit = hisi_zlib_exit,\
+	.send = hisi_zlib_send,\
+	.recv = hisi_zlib_recv,\
+}
+
+static struct wd_alg_driver zlib_alg_driver[] = {
+	GEN_ZLIB_ALG_DRIVER("zlib"),
+	GEN_ZLIB_ALG_DRIVER("gzip"),
+	GEN_ZLIB_ALG_DRIVER("deflate"),
+};
+
+static void __attribute__((constructor)) hisi_zlib_probe(void)
+{
+	int alg_num = ARRAY_SIZE(zlib_alg_driver);
+	int i, ret;
+
+	for (i = 0; i < alg_num; i++) {
+		ret = wd_alg_driver_register(&zlib_alg_driver[i]);
+		if (ret)
+			fprintf(stderr, "Error: register zlib %s failed!\n",
+				zlib_alg_driver[i].alg_name);
+	}
+}
+
+static void __attribute__((destructor)) hisi_zlib_remove(void)
+{
+	int alg_num = ARRAY_SIZE(zlib_alg_driver);
+	int i;
+
+	for (i = 0; i < alg_num; i++)
+		wd_alg_driver_unregister(&zlib_alg_driver[i]);
+}

--- a/include/adapter.h
+++ b/include/adapter.h
@@ -25,7 +25,6 @@ struct uadk_adapter_worker {
 	struct wd_ctx_config_internal config;
 	struct wd_async_msg_pool pool;
 	bool valid;
-	int lifetime;
 	int idx;
 };
 

--- a/include/adapter.h
+++ b/include/adapter.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright 2024-2025 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2024-2025 Linaro ltd.
+ */
+
+#ifndef __ADAPTER_H
+#define __ADAPTER_H
+
+#include "wd_alg.h"
+#include "wd_util.h"
+
+#define UADK_MAX_NB_WORKERS  (2)
+#define UADK_WORKER_LIFETIME (10)
+
+enum uadk_adapter_mode {
+	UADK_ADAPT_MODE_PRIMARY,
+	UADK_ADAPT_MODE_ROUNDROBIN,
+};
+
+struct uadk_adapter_worker {
+	struct wd_alg_driver *driver;
+	struct wd_ctx_config *ctx_config;
+	struct wd_sched *sched;
+	struct wd_ctx_config_internal config;
+	struct wd_async_msg_pool pool;
+	bool valid;
+	int lifetime;
+	int idx;
+};
+
+struct uadk_adapter {
+	unsigned int workers_nb;
+	enum uadk_adapter_mode mode;
+	struct uadk_adapter_worker workers[UADK_MAX_NB_WORKERS];
+};
+
+int uadk_adapter_add_workers(struct uadk_adapter *adapter, char *alg);
+
+struct uadk_adapter_worker *uadk_adapter_choose_worker(
+	struct uadk_adapter *adapter,
+	enum alg_task_type type
+);
+
+struct uadk_adapter_worker *uadk_adapter_switch_worker(
+	struct uadk_adapter *adapter,
+	struct uadk_adapter_worker *worker,
+	int para
+);
+#endif

--- a/include/drv/wd_aead_drv.h
+++ b/include/drv/wd_aead_drv.h
@@ -70,8 +70,6 @@ struct wd_aead_msg {
 	enum wd_aead_msg_state msg_state;
 };
 
-struct wd_aead_msg *wd_aead_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/drv/wd_agg_drv.h
+++ b/include/drv/wd_agg_drv.h
@@ -47,8 +47,6 @@ struct wd_agg_ops {
 	int (*hash_table_init)(struct wd_dae_hash_table *hash_table, void *priv);
 };
 
-struct wd_agg_msg *wd_agg_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/drv/wd_cipher_drv.h
+++ b/include/drv/wd_cipher_drv.h
@@ -50,8 +50,6 @@ struct wd_cipher_msg {
 	__u8 *out;
 };
 
-struct wd_cipher_msg *wd_cipher_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/drv/wd_comp_drv.h
+++ b/include/drv/wd_comp_drv.h
@@ -55,8 +55,6 @@ struct wd_comp_msg {
 	__u32 tag;
 };
 
-struct wd_comp_msg *wd_comp_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/drv/wd_dh_drv.h
+++ b/include/drv/wd_dh_drv.h
@@ -24,8 +24,6 @@ struct wd_dh_msg {
 	__u8 result; /* Data format, denoted by WD error code */
 };
 
-struct wd_dh_msg *wd_dh_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/drv/wd_digest_drv.h
+++ b/include/drv/wd_digest_drv.h
@@ -80,8 +80,6 @@ static inline enum hash_block_type get_hash_block_type(struct wd_digest_msg *msg
 		return HASH_SINGLE_BLOCK;
 }
 
-struct wd_digest_msg *wd_digest_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/drv/wd_ecc_drv.h
+++ b/include/drv/wd_ecc_drv.h
@@ -175,8 +175,6 @@ struct wd_ecc_out {
 	char data[];
 };
 
-struct wd_ecc_msg *wd_ecc_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/drv/wd_rsa_drv.h
+++ b/include/drv/wd_rsa_drv.h
@@ -49,8 +49,6 @@ struct wd_rsa_msg {
 	__u8 *key; /* Input key VA pointer, should be DMA buffer */
 };
 
-struct wd_rsa_msg *wd_rsa_get_msg(__u32 idx, __u32 tag);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/wd_aead.h
+++ b/include/wd_aead.h
@@ -207,6 +207,7 @@ int wd_aead_get_maxauthsize(handle_t h_sess);
  * @count: how many respondences this poll has to get.
  */
 int wd_aead_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
+int wd_aead_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 
 /**
  * wd_aead_poll() Poll finished request.

--- a/include/wd_alg.h
+++ b/include/wd_alg.h
@@ -195,6 +195,7 @@ void wd_enable_drv(struct wd_alg_driver *drv);
 void wd_disable_drv(struct wd_alg_driver *drv);
 
 struct wd_alg_list *wd_get_alg_head(void);
+struct wd_alg_driver *wd_find_drv(char *drv_name, char *alg_name, int idx);
 
 #ifdef WD_STATIC_DRV
 /*

--- a/include/wd_alg_common.h
+++ b/include/wd_alg_common.h
@@ -151,6 +151,7 @@ struct wd_ctx_config_internal {
 	void *priv;
 	bool epoll_en;
 	unsigned long *msg_cnt;
+	struct wd_async_msg_pool *pool;
 };
 
 /*
@@ -170,16 +171,17 @@ struct wd_ctx_config_internal {
 struct wd_sched {
 	const char *name;
 	int sched_policy;
+	struct uadk_adapter_worker *worker;
 	handle_t (*sched_init)(handle_t h_sched_ctx, void *sched_param);
 	__u32 (*pick_next_ctx)(handle_t h_sched_ctx,
 				  void *sched_key,
 				  const int sched_mode);
-	int (*poll_policy)(handle_t h_sched_ctx, __u32 expect, __u32 *count);
+	int (*poll_policy)(struct wd_sched *sched, __u32 expect, __u32 *count);
 	handle_t h_sched_ctx;
 };
 
-typedef int (*wd_alg_init)(struct wd_ctx_config *config, struct wd_sched *sched);
-typedef int (*wd_alg_poll_ctx)(__u32 idx, __u32 expt, __u32 *count);
+typedef int (*wd_alg_init)(struct uadk_adapter_worker *worker, struct wd_sched *sched);
+typedef int (*wd_alg_poll_ctx)(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 
 struct wd_datalist {
 	void *data;

--- a/include/wd_cipher.h
+++ b/include/wd_cipher.h
@@ -171,6 +171,7 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req);
  * @count: how many respondences this poll has to get.
  */
 int wd_cipher_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
+int wd_cipher_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 /**
  * wd_cipher_poll() Poll finished request.
  * this function will call poll_policy function which is registered to wd cipher

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -199,6 +199,7 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req);
  * specific ctx, this function should be used.
  */
 int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
+int wd_comp_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 
 int wd_comp_poll(__u32 expt, __u32 *count);
 

--- a/include/wd_dh.h
+++ b/include/wd_dh.h
@@ -58,6 +58,7 @@ void wd_dh_free_sess(handle_t sess);
 int wd_do_dh_async(handle_t sess, struct wd_dh_req *req);
 int wd_do_dh_sync(handle_t sess, struct wd_dh_req *req);
 int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
+int wd_dh_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 int wd_dh_poll(__u32 expt, __u32 *count);
 int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched);
 void wd_dh_uninit(void);

--- a/include/wd_digest.h
+++ b/include/wd_digest.h
@@ -230,6 +230,7 @@ int wd_digest_set_key(handle_t h_sess, const __u8 *key, __u32 key_len);
  * @count: recv poll nums.
  */
 int wd_digest_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
+int wd_digest_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 
 /**
  * wd_digest_poll() - Poll operation for asynchronous operation.

--- a/include/wd_ecc.h
+++ b/include/wd_ecc.h
@@ -509,6 +509,7 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req);
  * specific ctx, this function should be used.
  */
 int wd_ecc_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
+int wd_ecc_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 
 /**
  * wd_ecc_env_init() - Init ctx and schedule resources according to wd ecc

--- a/include/wd_rsa.h
+++ b/include/wd_rsa.h
@@ -202,6 +202,7 @@ __u32 wd_rsa_poll(void);
  * specific ctx, this function should be used.
  */
 int wd_rsa_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
+int wd_rsa_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count);
 
 /**
  * wd_rsa_env_init() - Init ctx and schedule resources according to wd rsa

--- a/include/wd_sched.h
+++ b/include/wd_sched.h
@@ -34,7 +34,8 @@ struct sched_params {
 	__u32 end;
 };
 
-typedef int (*user_poll_func)(__u32 pos, __u32 expect, __u32 *count);
+typedef int (*user_poll_func)(struct wd_sched *sched, __u32 pos,
+			      __u32 expect, __u32 *count);
 
 /*
  * wd_sched_rr_instance - Instante the schedule min region.

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -56,6 +56,8 @@ struct wd_ctx_range {
 	__u32 size;
 };
 
+struct uadk_adapter_worker;
+
 struct wd_env_config_per_numa {
 	/* Config begin */
 	int node;
@@ -465,8 +467,9 @@ void wd_ctx_param_uninit(struct wd_ctx_params *ctx_params);
  *
  * Return device if succeed and other error number if fail.
  */
-int wd_alg_attrs_init(struct wd_init_attrs *attrs);
-void wd_alg_attrs_uninit(struct wd_init_attrs *attrs);
+int wd_alg_attrs_init(struct uadk_adapter_worker *worker,
+		      struct wd_init_attrs *attrs);
+void wd_alg_attrs_uninit(struct uadk_adapter_worker *worker);
 
 /**
  * wd_alg_drv_bind() - Request the ctxs and initialize the sched_domain

--- a/libwd.map
+++ b/libwd.map
@@ -50,5 +50,9 @@ global:
 	wd_enable_drv;
 	wd_disable_drv;
 	wd_get_alg_head;
+
+	uadk_adapter_add_workers;
+	uadk_adapter_choose_worker;
+	uadk_adapter_switch_worker;
 local: *;
 };

--- a/libwd.map
+++ b/libwd.map
@@ -45,6 +45,7 @@ global:
 	wd_alg_driver_unregister;
 	wd_request_drv;
 	wd_release_drv;
+	wd_find_drv;
 	wd_drv_alg_support;
 	wd_enable_drv;
 	wd_disable_drv;

--- a/libwd_comp.map
+++ b/libwd_comp.map
@@ -11,6 +11,7 @@ global:
 	wd_do_comp_strm;
 	wd_do_comp_async;
 	wd_comp_poll_ctx;
+	wd_comp_poll_ctx_;
 	wd_comp_poll;
 	wd_do_comp_sync2;
 	wd_comp_env_init;
@@ -20,7 +21,6 @@ global:
 	wd_comp_get_env_param;
 	wd_comp_set_driver;
 	wd_comp_get_driver;
-	wd_comp_get_msg;
 	wd_comp_reset_sess;
 
 	wd_sched_rr_instance;
@@ -37,5 +37,6 @@ global:
 	wd_inflate_reset;
 	wd_inflate_end;
 
+	wd_find_msg_in_pool;
 local: *;
 };

--- a/libwd_crypto.map
+++ b/libwd_crypto.map
@@ -11,6 +11,7 @@ global:
 	wd_do_cipher_sync;
 	wd_do_cipher_async;
 	wd_cipher_poll_ctx;
+	wd_cipher_poll_ctx_;
 	wd_cipher_poll;
 	wd_cipher_env_init;
 	wd_cipher_env_uninit;
@@ -19,7 +20,6 @@ global:
 	wd_cipher_get_env_param;
 	wd_cipher_set_driver;
 	wd_cipher_get_driver;
-	wd_cipher_get_msg;
 
 	wd_aead_init;
 	wd_aead_uninit;
@@ -36,6 +36,7 @@ global:
 	wd_aead_get_authsize;
 	wd_aead_get_maxauthsize;
 	wd_aead_poll_ctx;
+	wd_aead_poll_ctx_;
 	wd_aead_poll;
 	wd_aead_env_init;
 	wd_aead_env_uninit;
@@ -44,7 +45,6 @@ global:
 	wd_aead_get_env_param;
 	wd_aead_set_driver;
 	wd_aead_get_driver;
-	wd_aead_get_msg;
 
 	wd_digest_init;
 	wd_digest_uninit;
@@ -57,6 +57,7 @@ global:
 	wd_do_digest_async;
 	wd_digest_set_key;
 	wd_digest_poll_ctx;
+	wd_digest_poll_ctx_;
 	wd_digest_poll;
 	wd_digest_env_init;
 	wd_digest_env_uninit;
@@ -65,7 +66,6 @@ global:
 	wd_digest_get_env_param;
 	wd_digest_set_driver;
 	wd_digest_get_driver;
-	wd_digest_get_msg;
 
 	wd_rsa_is_crt;
 	wd_rsa_get_key_bits;
@@ -100,6 +100,7 @@ global:
 	wd_do_rsa_sync;
 	wd_do_rsa_async;
 	wd_rsa_poll_ctx;
+	wd_rsa_poll_ctx_;
 	wd_rsa_env_init;
 	wd_rsa_env_uninit;
 	wd_rsa_ctx_num_init;
@@ -107,7 +108,6 @@ global:
 	wd_rsa_get_env_param;
 	wd_rsa_set_driver;
 	wd_rsa_get_driver;
-	wd_rsa_get_msg;
 
 	wd_dh_get_mode;
 	wd_dh_key_bits;
@@ -118,6 +118,7 @@ global:
 	wd_do_dh_async;
 	wd_do_dh_sync;
 	wd_dh_poll_ctx;
+	wd_dh_poll_ctx_;
 	wd_dh_poll;
 	wd_dh_init;
 	wd_dh_uninit;
@@ -131,7 +132,6 @@ global:
 	wd_dh_get_env_param;
 	wd_dh_set_driver;
 	wd_dh_get_driver;
-	wd_dh_get_msg;
 
 	wd_ecc_get_key_bits;
 	wd_ecc_get_key;
@@ -148,7 +148,6 @@ global:
 	wd_ecxdh_get_out_params;
 	wd_ecc_set_driver;
 	wd_ecc_get_driver;
-	wd_ecc_get_msg;
 
 	wd_sm2_new_sign_in;
 	wd_sm2_new_verf_in;
@@ -178,6 +177,7 @@ global:
 	wd_do_ecc_sync;
 	wd_do_ecc_async;
 	wd_ecc_poll_ctx;
+	wd_ecc_poll_ctx_;
 	wd_ecc_env_init;
 	wd_ecc_env_uninit;
 	wd_ecc_ctx_num_init;
@@ -187,5 +187,6 @@ global:
 	wd_sched_rr_instance;
 	wd_sched_rr_alloc;
 	wd_sched_rr_release;
+	wd_find_msg_in_pool;
 local: *;
 };

--- a/libwd_dae.map
+++ b/libwd_dae.map
@@ -11,7 +11,6 @@ global:
 	wd_agg_get_output_sync;
 	wd_agg_get_output_async;
 	wd_agg_rehash_sync;
-	wd_agg_get_msg;
 	wd_agg_poll;
 
 	wd_sched_rr_instance;

--- a/sample/uadk_comp.c
+++ b/sample/uadk_comp.c
@@ -127,7 +127,7 @@ out:
 	return NULL;
 }
 
-static int lib_poll_func(__u32 pos, __u32 expect, __u32 *count)
+static int lib_poll_func(struct wd_sched *sched, __u32 pos, __u32 expect, __u32 *count)
 {
 	int ret;
 

--- a/test/hisi_hpre_test/test_hisi_hpre.c
+++ b/test/hisi_hpre_test/test_hisi_hpre.c
@@ -1789,7 +1789,7 @@ static __u32 hpre_pick_next_ctx(handle_t sched_ctx,
 	return last_ctx;
 }
 
-int rsa_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
+int rsa_poll_policy(struct wd_sched *sched, __u32 expect, __u32 *count)
 {
 	int ret;
 	struct wd_ctx *ctxs;
@@ -1813,7 +1813,7 @@ int rsa_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
 	return 0;
 }
 
-static int dh_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
+static int dh_poll_policy(struct wd_sched *sched, __u32 expect, __u32 *count)
 {
 	int ret;
 	struct wd_ctx *ctxs;
@@ -1836,7 +1836,7 @@ static int dh_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
 	return 0;
 }
 
-static int ecc_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
+static int ecc_poll_policy(struct wd_sched *sched, __u32 expect, __u32 *count)
 {
 	int ret;
 	struct wd_ctx *ctxs;

--- a/test/hisi_zip_test/test_lib.c
+++ b/test/hisi_zip_test/test_lib.c
@@ -590,7 +590,7 @@ void *send_thread_func(void *arg)
 	return NULL;
 }
 
-int lib_poll_func(__u32 pos, __u32 expect, __u32 *count)
+int lib_poll_func(struct wd_sched *sched, __u32 pos, __u32 expect, __u32 *count)
 {
 	int ret;
 

--- a/test/hisi_zip_test/test_lib.h
+++ b/test/hisi_zip_test/test_lib.h
@@ -267,7 +267,7 @@ int hizip_verify_random_output(struct test_options *opts,
 void *mmap_alloc(size_t len);
 int mmap_free(void *addr, size_t len);
 
-int lib_poll_func(__u32 pos, __u32 expect, __u32 *count);
+int lib_poll_func(struct wd_sched *sched, __u32 pos, __u32 expect, __u32 *count);
 typedef int (*check_output_fn)(unsigned char *buf, unsigned int size, void *opaque);
 
 /* for block interface */

--- a/test/wd_mempool_test.c
+++ b/test/wd_mempool_test.c
@@ -436,7 +436,7 @@ static __u32 sva_sched_pick_next_ctx(handle_t h_sched_ctx,
         return index;
 }
 
-static int sva_sched_poll_policy(handle_t h_sched_ctx, __u32 expect,
+static int sva_sched_poll_policy(struct wd_sched *sched, __u32 expect,
                                  __u32 *count)
 {
         int recv = 0;

--- a/uadk_tool/benchmark/hpre_uadk_benchmark.c
+++ b/uadk_tool/benchmark/hpre_uadk_benchmark.c
@@ -486,17 +486,17 @@ static int init_hpre_ctx_config(struct acc_option *options)
 
 	switch(subtype) {
 	case RSA_TYPE:
-		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_rsa_poll_ctx);
+		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_rsa_poll_ctx_);
 		break;
 	case DH_TYPE:
-		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_dh_poll_ctx);
+		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_dh_poll_ctx_);
 		break;
 	case ECDH_TYPE:
 	case ECDSA_TYPE:
 	case SM2_TYPE:
 	case X25519_TYPE:
 	case X448_TYPE:
-		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_ecc_poll_ctx);
+		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_ecc_poll_ctx_);
 		break;
 	default:
 		HPRE_TST_PRT("failed to parse alg subtype!\n");

--- a/uadk_tool/benchmark/sec_uadk_benchmark.c
+++ b/uadk_tool/benchmark/sec_uadk_benchmark.c
@@ -686,13 +686,13 @@ static int init_ctx_config(struct acc_option *options)
 
 	switch(subtype) {
 	case CIPHER_TYPE:
-		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_cipher_poll_ctx);
+		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_cipher_poll_ctx_);
 		break;
 	case AEAD_TYPE:
-		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_aead_poll_ctx);
+		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_aead_poll_ctx_);
 		break;
 	case DIGEST_TYPE:
-		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_digest_poll_ctx);
+		g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1, max_node, wd_digest_poll_ctx_);
 		break;
 	default:
 		SEC_TST_PRT("failed to parse alg subtype!\n");
@@ -1205,7 +1205,6 @@ recv_error:
 
 	return NULL;
 }
-
 
 static void *sec_uadk_cipher_async(void *arg)
 {

--- a/uadk_tool/benchmark/zip_uadk_benchmark.c
+++ b/uadk_tool/benchmark/zip_uadk_benchmark.c
@@ -490,7 +490,7 @@ static int init_ctx_config(struct acc_option *options)
 		goto free_ctxs;
 	}
 
-	g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 2, max_node, wd_comp_poll_ctx);
+	g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 2, max_node, wd_comp_poll_ctx_);
 	if (!g_sched) {
 		ZIP_TST_PRT("failed to alloc sched!\n");
 		ret = -ENOMEM;

--- a/uadk_tool/test/test_sec.c
+++ b/uadk_tool/test/test_sec.c
@@ -42,6 +42,7 @@
 
 static struct wd_ctx_config g_ctx_cfg;
 static struct wd_sched *g_sched;
+static struct wd_sched g_sched_test;
 
 static long long int g_times;
 static unsigned int g_thread_num;
@@ -593,7 +594,7 @@ int get_cipher_resource(struct cipher_testvec **alg_tv, int* alg, int* mode)
 	return 0;
 }
 
-static int sched_single_poll_policy(handle_t h_sched_ctx,
+static int sched_single_poll_policy(struct wd_sched *sched,
 				    __u32 expect, __u32 *count)
 {
 	return 0;
@@ -618,7 +619,7 @@ static int init_ctx_config(int type, int mode)
 
 	g_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, 1,
 				    numa_max_node() + 1,
-				    wd_cipher_poll_ctx);
+				    wd_cipher_poll_ctx_);
 	if (!g_sched) {
 		printf("Fail to alloc sched!\n");
 		goto out;
@@ -1226,7 +1227,7 @@ static void *poll_func(void *arg)
 	int expt = g_times * g_thread_num;
 
 	while (1) {
-		ret = g_sched->poll_policy(g_sched->h_sched_ctx, 1, &count);
+		ret = g_sched->poll_policy(g_sched, 1, &count);
 		if (ret != -EAGAIN && ret < 0) {
 			SEC_TST_PRT("poll ctx is error----------->\n");
 			break;
@@ -1416,7 +1417,6 @@ static __u32 sched_digest_pick_next_ctx(handle_t h_sched_ctx,
 static int digest_init1(int type, int mode)
 {
 	struct uacce_dev_list *list;
-	struct wd_sched sched;
 	int ret;
 
 	if (g_use_env)
@@ -1443,12 +1443,12 @@ static int digest_init1(int type, int mode)
 	g_ctx_cfg.ctxs[0].op_type = type;
 	g_ctx_cfg.ctxs[0].ctx_mode = mode;
 
-	sched.name = SCHED_SINGLE;
-	sched.pick_next_ctx = sched_digest_pick_next_ctx;
-	sched.poll_policy = sched_single_poll_policy;
-	sched.sched_init = sched_digest_init;
+	g_sched_test.name = SCHED_SINGLE;
+	g_sched_test.pick_next_ctx = sched_digest_pick_next_ctx;
+	g_sched_test.poll_policy = sched_single_poll_policy;
+	g_sched_test.sched_init = sched_digest_init;
 	/* digest init */
-	ret = wd_digest_init(&g_ctx_cfg, &sched);
+	ret = wd_digest_init(&g_ctx_cfg, &g_sched_test);
 	if (ret) {
 		SEC_TST_PRT("Fail to digest ctx!\n");
 		goto out;
@@ -2685,7 +2685,6 @@ static __u32 sched_aead_pick_next_ctx(handle_t h_sched_ctx,
 static int aead_init1(int type, int mode)
 {
 	struct uacce_dev_list *list;
-	struct wd_sched sched;
 	int ret;
 
 	if (g_use_env)
@@ -2712,12 +2711,12 @@ static int aead_init1(int type, int mode)
 	g_ctx_cfg.ctxs[0].op_type = type;
 	g_ctx_cfg.ctxs[0].ctx_mode = mode;
 
-	sched.name = SCHED_SINGLE;
-	sched.pick_next_ctx = sched_aead_pick_next_ctx;
-	sched.poll_policy = sched_single_poll_policy;
-	sched.sched_init = sched_aead_init;
+	g_sched_test.name = SCHED_SINGLE;
+	g_sched_test.pick_next_ctx = sched_aead_pick_next_ctx;
+	g_sched_test.poll_policy = sched_single_poll_policy;
+	g_sched_test.sched_init = sched_aead_init;
 	/* aead init*/
-	ret = wd_aead_init(&g_ctx_cfg, &sched);
+	ret = wd_aead_init(&g_ctx_cfg, &g_sched_test);
 	if (ret) {
 		SEC_TST_PRT("Fail to aead ctx!\n");
 		goto out;

--- a/wd_alg.c
+++ b/wd_alg.c
@@ -128,6 +128,7 @@ static bool wd_alg_check_available(int calc_type, const char *dev_name)
 
 	switch (calc_type) {
 	case UADK_ALG_SOFT:
+		ret = true;
 		break;
 	/* Should find the CPU if not support CE */
 	case UADK_ALG_CE_INSTR:

--- a/wd_alg.c
+++ b/wd_alg.c
@@ -395,3 +395,44 @@ void wd_release_drv(struct wd_alg_driver *drv)
 		select_node->refcnt--;
 	pthread_mutex_unlock(&mutex);
 }
+
+struct wd_alg_driver *wd_find_drv(char *drv_name, char *alg_name, int idx)
+{
+	struct wd_alg_list *head = &alg_list_head;
+	struct wd_alg_list *pnext = head->next;
+	struct wd_alg_driver *drv = NULL;
+
+	if (!pnext || !alg_name) {
+		WD_ERR("invalid: request alg param is error!\n");
+		return NULL;
+	}
+
+	pthread_mutex_lock(&mutex);
+
+	if (drv_name) {
+		while (pnext) {
+			if (!strcmp(alg_name, pnext->alg_name) &&
+			    !strcmp(drv_name, pnext->drv_name)) {
+				drv = pnext->drv;
+				break;
+			}
+			pnext = pnext->next;
+		}
+	} else {
+		int i = 0;
+
+		while (pnext) {
+			if (!strcmp(alg_name, pnext->alg_name)) {
+				if (i++ == idx) {
+					drv = pnext->drv;
+					break;
+				}
+			}
+			pnext = pnext->next;
+		}
+	}
+
+	pthread_mutex_unlock(&mutex);
+
+	return drv;
+}

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -292,6 +292,9 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 		goto out_uninit;
 	wd_comp_setting.adapter = adapter;
 
+	//test round robin
+	adapter->mode = UADK_ADAPT_MODE_ROUNDROBIN;
+
 	state = wd_comp_open_driver(WD_TYPE_V2);
 	if (state)
 		goto out_uninit;

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -54,6 +54,18 @@ struct wd_comp_setting {
 struct wd_env_config wd_comp_env_config;
 static struct wd_init_attrs wd_comp_init_attrs;
 
+void wd_comp_switch_worker(struct wd_comp_sess *sess, int para)
+{
+	struct uadk_adapter_worker *worker;
+
+	pthread_spin_lock(&sess->worker_lock);
+	worker = uadk_adapter_switch_worker(wd_comp_setting.adapter,
+					    sess->worker, para);
+	if (worker)
+		sess->worker = worker;
+	pthread_spin_unlock(&sess->worker_lock);
+}
+
 static void wd_comp_close_driver(int init_type)
 {
 #ifndef WD_STATIC_DRV
@@ -73,8 +85,6 @@ static void wd_comp_close_driver(int init_type)
 
 static int wd_comp_open_driver(int init_type)
 {
-	struct wd_alg_driver *driver = NULL;
-	char *alg_name = "zlib";
 #ifndef WD_STATIC_DRV
 	char lib_path[PATH_MAX];
 	int ret;
@@ -108,15 +118,6 @@ static int wd_comp_open_driver(int init_type)
 	if (init_type == WD_TYPE_V2)
 		return WD_SUCCESS;
 #endif
-	driver = wd_find_drv(NULL, alg_name, false);
-	if (!driver) {
-		wd_comp_close_driver(WD_TYPE_V1);
-		WD_ERR("failed to get %s driver support\n", alg_name);
-		return -WD_EINVAL;
-	}
-
-	wd_comp_setting.adapter->workers[0].driver = driver;
-
 	return WD_SUCCESS;
 }
 
@@ -200,6 +201,7 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
 	struct uadk_adapter_worker *worker;
 	struct uadk_adapter *adapter = NULL;
+	char *alg = "zlib";
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_comp_clear_status);
@@ -217,13 +219,17 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 		goto out_clear_init;
 
 	wd_comp_setting.adapter = adapter;
-	worker = &adapter->workers[0];
-	worker->ctx_config = config;
-	adapter->workers_nb++;
 
 	ret = wd_comp_open_driver(WD_TYPE_V1);
 	if (ret)
 		goto out_clear_init;
+
+	ret = uadk_adapter_add_workers(adapter, alg);
+	if (ret)
+		goto out_clear_driver;
+
+	worker = &adapter->workers[0];
+	worker->ctx_config = config;
 
 	ret = wd_comp_init_nolock(worker, sched);
 	if (ret)
@@ -259,10 +265,9 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 	struct wd_ctx_params comp_ctx_params = {0};
 	struct uadk_adapter_worker *worker;
 	struct uadk_adapter *adapter = NULL;
-	struct wd_alg_driver *drv;
 	int state, ret = -WD_EINVAL;
-	int idx = 0;
 	bool flag;
+	int i;
 
 	pthread_atfork(NULL, NULL, wd_comp_clear_status);
 
@@ -291,15 +296,16 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 	if (state)
 		goto out_uninit;
 
-	do {
-		worker = &adapter->workers[idx];
-		drv = wd_find_drv(NULL, alg, idx);
-		if (!drv)
-			break;
-		worker->driver = drv;
+	ret = uadk_adapter_add_workers(adapter, alg);
+	if (ret)
+		goto out_dlclose;
+
+	for (i = 0; i < adapter->workers_nb; i++) {
+		worker = &adapter->workers[i];
 
 		comp_ctx_params.ctx_set_num = comp_ctx_num;
-		ret = wd_ctx_param_init(&comp_ctx_params, ctx_params, drv,
+		ret = wd_ctx_param_init(&comp_ctx_params, ctx_params,
+					worker->driver,
 					WD_COMP_TYPE, WD_DIR_MAX);
 		if (ret) {
 			WD_ERR("fail to init ctx param\n");
@@ -317,10 +323,7 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 			WD_ERR("fail to init alg attrs.\n");
 			goto out_dlclose;
 		}
-		wd_comp_setting.adapter->workers_nb++;
-		if (++idx >= UADK_MAX_NB_WORKERS)
-			break;
-	} while (drv);
+	}
 
 	wd_alg_set_init(&wd_comp_setting.status);
 
@@ -633,6 +636,19 @@ static int wd_comp_sync_job(struct wd_comp_sess *sess,
 				 msg, NULL, worker->config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 
+	if (ret) {
+		wd_comp_switch_worker(sess, 1);
+		worker->lifetime++;
+		return ret;
+	}
+
+	if ((worker->lifetime != 0) ||
+	    (wd_comp_setting.adapter->mode = UADK_ADAPT_MODE_ROUNDROBIN))
+		worker->lifetime++;
+
+	if (worker->lifetime == UADK_WORKER_LIFETIME)
+		wd_comp_switch_worker(sess, 0);
+
 	return ret;
 }
 
@@ -898,11 +914,19 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 	if (unlikely(ret))
 		goto fail_with_msg;
 
+	if ((worker->lifetime != 0) ||
+	    (wd_comp_setting.adapter->mode = UADK_ADAPT_MODE_ROUNDROBIN))
+		worker->lifetime++;
+
+	if (worker->lifetime == UADK_WORKER_LIFETIME)
+		wd_comp_switch_worker(sess, 0);
+
 	return 0;
 
 fail_with_msg:
 	wd_put_msg_to_pool(&worker->pool, idx, msg->tag);
-
+	wd_comp_switch_worker(sess, 1);
+	worker->lifetime++;
 	return ret;
 }
 

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -294,9 +294,6 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 		goto out_uninit;
 	wd_comp_setting.adapter = adapter;
 
-	//test round robin
-	adapter->mode = UADK_ADAPT_MODE_ROUNDROBIN;
-
 	state = wd_comp_open_driver(WD_TYPE_V2);
 	if (state)
 		goto out_uninit;

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -479,7 +479,7 @@ handle_t wd_comp_alloc_sess(struct wd_comp_sess_setup *setup)
 	sess->win_sz = setup->win_sz;
 	sess->stream_pos = WD_COMP_STREAM_NEW;
 
-	sess->sched_key = calloc(sizeof(void *), nb);
+	sess->sched_key = (void **)calloc(nb, sizeof(void *));
 	for (i = 0; i < nb; i++) {
 		worker = &wd_comp_setting.adapter->workers[i];
 

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -14,6 +14,7 @@
 
 #include "drv/wd_comp_drv.h"
 #include "wd_comp.h"
+#include "adapter.h"
 
 #define HW_CTX_SIZE			(64 * 1024)
 #define STREAM_CHUNK			(128 * 1024)
@@ -39,16 +40,15 @@ struct wd_comp_sess {
 	__u32 checksum;
 	__u8 *ctx_buf;
 	void *sched_key;
+	struct uadk_adapter_worker *worker;
+	pthread_spinlock_t worker_lock;
 };
 
 struct wd_comp_setting {
 	enum wd_status status;
-	struct wd_ctx_config_internal config;
-	struct wd_sched sched;
-	struct wd_async_msg_pool pool;
-	struct wd_alg_driver *driver;
 	void *dlhandle;
 	void *dlh_list;
+	struct uadk_adapter *adapter;
 } wd_comp_setting;
 
 struct wd_env_config wd_comp_env_config;
@@ -63,12 +63,10 @@ static void wd_comp_close_driver(int init_type)
 	}
 
 	if (wd_comp_setting.dlhandle) {
-		wd_release_drv(wd_comp_setting.driver);
 		dlclose(wd_comp_setting.dlhandle);
 		wd_comp_setting.dlhandle = NULL;
 	}
 #else
-	wd_release_drv(wd_comp_setting.driver);
 	hisi_zip_remove();
 #endif
 }
@@ -76,7 +74,7 @@ static void wd_comp_close_driver(int init_type)
 static int wd_comp_open_driver(int init_type)
 {
 	struct wd_alg_driver *driver = NULL;
-	const char *alg_name = "zlib";
+	char *alg_name = "zlib";
 #ifndef WD_STATIC_DRV
 	char lib_path[PATH_MAX];
 	int ret;
@@ -110,14 +108,14 @@ static int wd_comp_open_driver(int init_type)
 	if (init_type == WD_TYPE_V2)
 		return WD_SUCCESS;
 #endif
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_find_drv(NULL, alg_name, false);
 	if (!driver) {
 		wd_comp_close_driver(WD_TYPE_V1);
 		WD_ERR("failed to get %s driver support\n", alg_name);
 		return -WD_EINVAL;
 	}
 
-	wd_comp_setting.driver = driver;
+	wd_comp_setting.adapter->workers[0].driver = driver;
 
 	return WD_SUCCESS;
 }
@@ -142,67 +140,66 @@ static bool wd_comp_alg_check(const char *alg_name)
 	return false;
 }
 
-static int wd_comp_init_nolock(struct wd_ctx_config *config, struct wd_sched *sched)
+static int wd_comp_init_nolock(struct uadk_adapter_worker *worker, struct wd_sched *sched)
 {
 	int ret;
 
 	ret = wd_set_epoll_en("WD_COMP_EPOLL_EN",
-			      &wd_comp_setting.config.epoll_en);
+			      &worker->config.epoll_en);
 	if (ret < 0)
 		return ret;
 
-	ret = wd_init_ctx_config(&wd_comp_setting.config, config);
+	ret = wd_init_ctx_config(&worker->config, worker->ctx_config);
 	if (ret < 0)
 		return ret;
 
-	ret = wd_init_sched(&wd_comp_setting.sched, sched);
+	worker->config.pool = &worker->pool;
+	sched->worker = worker;
+	worker->sched = sched;
+
+	ret = wd_init_async_request_pool(&worker->pool,
+					 worker->ctx_config, WD_POOL_MAX_ENTRIES,
+					 sizeof(struct wd_comp_msg));
 	if (ret < 0)
 		goto out_clear_ctx_config;
 
-	ret = wd_init_async_request_pool(&wd_comp_setting.pool,
-					 config, WD_POOL_MAX_ENTRIES,
-					 sizeof(struct wd_comp_msg));
-	if (ret < 0)
-		goto out_clear_sched;
-
-	ret = wd_alg_init_driver(&wd_comp_setting.config,
-					wd_comp_setting.driver);
+	ret = wd_alg_init_driver(&worker->config, worker->driver);
 	if (ret)
 		goto out_clear_pool;
 
 	return 0;
 
 out_clear_pool:
-	wd_uninit_async_request_pool(&wd_comp_setting.pool);
-out_clear_sched:
-	wd_clear_sched(&wd_comp_setting.sched);
+	wd_uninit_async_request_pool(&worker->pool);
 out_clear_ctx_config:
-	wd_clear_ctx_config(&wd_comp_setting.config);
+	wd_clear_ctx_config(&worker->config);
 	return ret;
 }
 
 static int wd_comp_uninit_nolock(void)
 {
+	struct uadk_adapter_worker *worker;
 	enum wd_status status;
 
 	wd_alg_get_init(&wd_comp_setting.status, &status);
 	if (status == WD_UNINIT)
 		return -WD_EINVAL;
 
-	/* Uninit async request pool */
-	wd_uninit_async_request_pool(&wd_comp_setting.pool);
+	for (int i = 0; i < wd_comp_setting.adapter->workers_nb; i++) {
+		worker = &wd_comp_setting.adapter->workers[i];
 
-	/* Unset config, sched, driver */
-	wd_clear_sched(&wd_comp_setting.sched);
+		wd_uninit_async_request_pool(&worker->pool);
+		wd_alg_uninit_driver(&worker->config, worker->driver);
+	}
 
-	wd_alg_uninit_driver(&wd_comp_setting.config,
-			     wd_comp_setting.driver);
-
+	free(wd_comp_setting.adapter);
 	return 0;
 }
 
 int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
+	struct uadk_adapter_worker *worker;
+	struct uadk_adapter *adapter = NULL;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_comp_clear_status);
@@ -215,11 +212,20 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	if (ret)
 		goto out_clear_init;
 
+	adapter = calloc(1, sizeof(*adapter));
+	if (adapter == NULL)
+		goto out_clear_init;
+
+	wd_comp_setting.adapter = adapter;
+	worker = &adapter->workers[0];
+	worker->ctx_config = config;
+	adapter->workers_nb++;
+
 	ret = wd_comp_open_driver(WD_TYPE_V1);
 	if (ret)
 		goto out_clear_init;
 
-	ret = wd_comp_init_nolock(config, sched);
+	ret = wd_comp_init_nolock(worker, sched);
 	if (ret)
 		goto out_clear_driver;
 
@@ -230,6 +236,7 @@ int wd_comp_init(struct wd_ctx_config *config, struct wd_sched *sched)
 out_clear_driver:
 	wd_comp_close_driver(WD_TYPE_V1);
 out_clear_init:
+	free(adapter);
 	wd_alg_clear_init(&wd_comp_setting.status);
 	return ret;
 }
@@ -250,7 +257,11 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 {
 	struct wd_ctx_nums comp_ctx_num[WD_DIR_MAX] = {0};
 	struct wd_ctx_params comp_ctx_params = {0};
+	struct uadk_adapter_worker *worker;
+	struct uadk_adapter *adapter = NULL;
+	struct wd_alg_driver *drv;
 	int state, ret = -WD_EINVAL;
+	int idx = 0;
 	bool flag;
 
 	pthread_atfork(NULL, NULL, wd_comp_clear_status);
@@ -271,90 +282,79 @@ int wd_comp_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_par
 		goto out_uninit;
 	}
 
+	adapter = calloc(1, sizeof(*adapter));
+	if (adapter == NULL)
+		goto out_uninit;
+	wd_comp_setting.adapter = adapter;
+
 	state = wd_comp_open_driver(WD_TYPE_V2);
 	if (state)
 		goto out_uninit;
 
-	while (ret != 0) {
-		memset(&wd_comp_setting.config, 0, sizeof(struct wd_ctx_config_internal));
-
-		/* Get alg driver and dev name */
-		wd_comp_setting.driver = wd_alg_drv_bind(task_type, alg);
-		if (!wd_comp_setting.driver) {
-			WD_ERR("failed to bind %s driver.\n", alg);
-			goto out_dlclose;
-		}
+	do {
+		worker = &adapter->workers[idx];
+		drv = wd_find_drv(NULL, alg, idx);
+		if (!drv)
+			break;
+		worker->driver = drv;
 
 		comp_ctx_params.ctx_set_num = comp_ctx_num;
-		ret = wd_ctx_param_init(&comp_ctx_params, ctx_params,
-					wd_comp_setting.driver, WD_COMP_TYPE, WD_DIR_MAX);
+		ret = wd_ctx_param_init(&comp_ctx_params, ctx_params, drv,
+					WD_COMP_TYPE, WD_DIR_MAX);
 		if (ret) {
-			if (ret == -WD_EAGAIN) {
-				wd_disable_drv(wd_comp_setting.driver);
-				wd_alg_drv_unbind(wd_comp_setting.driver);
-				continue;
-			}
-			goto out_unbind_drv;
+			WD_ERR("fail to init ctx param\n");
+			goto out_dlclose;
 		}
 
 		wd_comp_init_attrs.alg = alg;
 		wd_comp_init_attrs.sched_type = sched_type;
-		wd_comp_init_attrs.driver = wd_comp_setting.driver;
 		wd_comp_init_attrs.ctx_params = &comp_ctx_params;
 		wd_comp_init_attrs.alg_init = wd_comp_init_nolock;
-		wd_comp_init_attrs.alg_poll_ctx = wd_comp_poll_ctx;
-		ret = wd_alg_attrs_init(&wd_comp_init_attrs);
+		wd_comp_init_attrs.alg_poll_ctx = wd_comp_poll_ctx_;
+		ret = wd_alg_attrs_init(worker, &wd_comp_init_attrs);
+		wd_ctx_param_uninit(&comp_ctx_params);
 		if (ret) {
-			if (ret == -WD_ENODEV) {
-				wd_disable_drv(wd_comp_setting.driver);
-				wd_alg_drv_unbind(wd_comp_setting.driver);
-				wd_ctx_param_uninit(&comp_ctx_params);
-				continue;
-			}
 			WD_ERR("fail to init alg attrs.\n");
-			goto out_params_uninit;
+			goto out_dlclose;
 		}
-	}
+		wd_comp_setting.adapter->workers_nb++;
+		if (++idx >= UADK_MAX_NB_WORKERS)
+			break;
+	} while (drv);
 
 	wd_alg_set_init(&wd_comp_setting.status);
-	wd_ctx_param_uninit(&comp_ctx_params);
 
 	return 0;
 
-out_params_uninit:
-	wd_ctx_param_uninit(&comp_ctx_params);
-out_unbind_drv:
-	wd_alg_drv_unbind(wd_comp_setting.driver);
 out_dlclose:
 	wd_comp_close_driver(WD_TYPE_V2);
 out_uninit:
+	free(adapter);
 	wd_alg_clear_init(&wd_comp_setting.status);
 	return ret;
 }
 
 void wd_comp_uninit2(void)
 {
+	struct uadk_adapter_worker *worker;
 	int ret;
 
 	ret = wd_comp_uninit_nolock();
 	if (ret)
 		return;
 
-	wd_alg_attrs_uninit(&wd_comp_init_attrs);
-	wd_alg_drv_unbind(wd_comp_setting.driver);
+	for (int i = 0; i < wd_comp_setting.adapter->workers_nb; i++) {
+		worker = &wd_comp_setting.adapter->workers[i];
+		wd_alg_attrs_uninit(worker);
+	}
 	wd_comp_close_driver(WD_TYPE_V2);
 	wd_comp_setting.dlh_list = NULL;
 	wd_alg_clear_init(&wd_comp_setting.status);
 }
 
-struct wd_comp_msg *wd_comp_get_msg(__u32 idx, __u32 tag)
+int wd_comp_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count)
 {
-	return wd_find_msg_in_pool(&wd_comp_setting.pool, idx, tag);
-}
-
-int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
-{
-	struct wd_ctx_config_internal *config = &wd_comp_setting.config;
+	struct uadk_adapter_worker *worker;
 	struct wd_ctx_internal *ctx;
 	struct wd_comp_msg resp_msg;
 	struct wd_comp_msg *msg;
@@ -368,16 +368,22 @@ int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 		return -WD_EINVAL;
 	}
 
+	/* back-compatible with init1 api */
+	if (sched == NULL)
+		worker = &wd_comp_setting.adapter->workers[0];
+	else
+		worker = sched->worker; 
+
 	*count = 0;
 
-	ret = wd_check_ctx(config, CTX_MODE_ASYNC, idx);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_ASYNC, idx);
 	if (unlikely(ret))
 		return ret;
 
-	ctx = config->ctxs + idx;
+	ctx = worker->config.ctxs + idx;
 
 	do {
-		ret = wd_alg_driver_recv(wd_comp_setting.driver, ctx->ctx, &resp_msg);
+		ret = wd_alg_driver_recv(worker->driver, ctx->ctx, &resp_msg);
 		if (unlikely(ret < 0)) {
 			if (ret == -WD_HW_EACCESS)
 				WD_ERR("wd comp recv hw error!\n");
@@ -386,7 +392,7 @@ int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 
 		recv_count++;
 
-		msg = wd_find_msg_in_pool(&wd_comp_setting.pool, idx,
+		msg = wd_find_msg_in_pool(&worker->pool, idx,
 					  resp_msg.tag);
 		if (unlikely(!msg)) {
 			WD_ERR("failed to find msg from pool!\n");
@@ -399,13 +405,17 @@ int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 		req->cb(req, req->cb_param);
 
 		/* free msg cache to msg_pool */
-		wd_put_msg_to_pool(&wd_comp_setting.pool, idx, resp_msg.tag);
+		wd_put_msg_to_pool(&worker->pool, idx, resp_msg.tag);
 		*count = recv_count;
 	} while (--tmp);
 
 	return ret;
 }
 
+int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
+{
+	return wd_comp_poll_ctx_(NULL, idx, expt, count);
+}
 static int wd_comp_check_sess_params(struct wd_comp_sess_setup *setup)
 {
 	if (setup->alg_type >= WD_COMP_ALG_MAX)  {
@@ -436,6 +446,7 @@ static int wd_comp_check_sess_params(struct wd_comp_sess_setup *setup)
 
 handle_t wd_comp_alloc_sess(struct wd_comp_sess_setup *setup)
 {
+	struct uadk_adapter_worker *worker;
 	struct wd_comp_sess *sess;
 	int ret;
 
@@ -454,14 +465,18 @@ handle_t wd_comp_alloc_sess(struct wd_comp_sess_setup *setup)
 	if (!sess->ctx_buf)
 		goto sess_err;
 
+	/* todo, use workers[0] now, will adapter.choose_worker later */
+	worker = sess->worker = &wd_comp_setting.adapter->workers[0];
+	worker->valid = true;
+
 	sess->alg_type = setup->alg_type;
 	sess->comp_lv = setup->comp_lv;
 	sess->win_sz = setup->win_sz;
 	sess->stream_pos = WD_COMP_STREAM_NEW;
 
 	/* Some simple scheduler don't need scheduling parameters */
-	sess->sched_key = (void *)wd_comp_setting.sched.sched_init(
-		     wd_comp_setting.sched.h_sched_ctx, setup->sched_param);
+	sess->sched_key = (void *)worker->sched->sched_init(
+		worker->sched->h_sched_ctx, setup->sched_param);
 	if (WD_IS_ERR(sess->sched_key)) {
 		WD_ERR("failed to init session schedule key!\n");
 		goto sched_err;
@@ -590,29 +605,32 @@ static int wd_comp_sync_job(struct wd_comp_sess *sess,
 			    struct wd_comp_req *req,
 			    struct wd_comp_msg *msg)
 {
-	struct wd_ctx_config_internal *config = &wd_comp_setting.config;
-	handle_t h_sched_ctx = wd_comp_setting.sched.h_sched_ctx;
+	struct uadk_adapter_worker *worker;
 	struct wd_msg_handle msg_handle;
 	struct wd_ctx_internal *ctx;
 	__u32 idx;
 	int ret;
 
-	idx = wd_comp_setting.sched.pick_next_ctx(h_sched_ctx,
-						  sess->sched_key,
-						  CTX_MODE_SYNC);
-	ret = wd_check_ctx(config, CTX_MODE_SYNC, idx);
+	pthread_spin_lock(&sess->worker_lock);
+	worker = sess->worker;
+	pthread_spin_unlock(&sess->worker_lock);
+	
+	idx = worker->sched->pick_next_ctx(
+		     worker->sched->h_sched_ctx,
+		     sess->sched_key, CTX_MODE_SYNC);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_SYNC, idx);
 	if (unlikely(ret))
 		return ret;
 
-	wd_dfx_msg_cnt(config, WD_CTX_CNT_NUM, idx);
-	ctx = config->ctxs + idx;
+	wd_dfx_msg_cnt(&worker->config, WD_CTX_CNT_NUM, idx);
+	ctx = worker->config.ctxs + idx;
 
-	msg_handle.send = wd_comp_setting.driver->send;
-	msg_handle.recv = wd_comp_setting.driver->recv;
+	msg_handle.send = worker->driver->send;
+	msg_handle.recv = worker->driver->recv;
 
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_handle_msg_sync(wd_comp_setting.driver, &msg_handle, ctx->ctx,
-				 msg, NULL, config->epoll_en);
+	ret = wd_handle_msg_sync(worker->driver, &msg_handle, ctx->ctx,
+				 msg, NULL, worker->config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 
 	return ret;
@@ -831,9 +849,8 @@ int wd_do_comp_strm(handle_t h_sess, struct wd_comp_req *req)
 
 int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 {
-	struct wd_ctx_config_internal *config = &wd_comp_setting.config;
 	struct wd_comp_sess *sess = (struct wd_comp_sess *)h_sess;
-	handle_t h_sched_ctx = wd_comp_setting.sched.h_sched_ctx;
+	struct uadk_adapter_worker *worker;
 	struct wd_ctx_internal *ctx;
 	struct wd_comp_msg *msg;
 	int tag, ret;
@@ -848,16 +865,20 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 		return -WD_EINVAL;
 	}
 
-	idx = wd_comp_setting.sched.pick_next_ctx(h_sched_ctx,
-						  sess->sched_key,
-						  CTX_MODE_ASYNC);
-	ret = wd_check_ctx(config, CTX_MODE_ASYNC, idx);
+	pthread_spin_lock(&sess->worker_lock);
+	worker = sess->worker;
+	pthread_spin_unlock(&sess->worker_lock);
+
+	idx = worker->sched->pick_next_ctx(
+		     worker->sched->h_sched_ctx,
+		     sess->sched_key, CTX_MODE_ASYNC);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_ASYNC, idx);
 	if (unlikely(ret))
 		return ret;
 
-	ctx = config->ctxs + idx;
+	ctx = worker->config.ctxs + idx;
 
-	tag = wd_get_msg_from_pool(&wd_comp_setting.pool, idx, (void **)&msg);
+	tag = wd_get_msg_from_pool(&worker->pool, idx, (void **)&msg);
 	if (unlikely(tag < 0)) {
 		WD_ERR("failed to get msg from pool!\n");
 		return tag;
@@ -866,13 +887,13 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 	msg->tag = tag;
 	msg->stream_mode = WD_COMP_STATELESS;
 
-	ret = wd_alg_driver_send(wd_comp_setting.driver, ctx->ctx, msg);
+	ret = wd_alg_driver_send(worker->driver, ctx->ctx, msg);
 	if (unlikely(ret < 0)) {
 		WD_ERR("wd comp send error, ret = %d!\n", ret);
 		goto fail_with_msg;
 	}
 
-	wd_dfx_msg_cnt(config, WD_CTX_CNT_NUM, idx);
+	wd_dfx_msg_cnt(&worker->config, WD_CTX_CNT_NUM, idx);
 	ret = wd_add_task_to_async_queue(&wd_comp_env_config, idx);
 	if (unlikely(ret))
 		goto fail_with_msg;
@@ -880,25 +901,40 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 	return 0;
 
 fail_with_msg:
-	wd_put_msg_to_pool(&wd_comp_setting.pool, idx, msg->tag);
+	wd_put_msg_to_pool(&worker->pool, idx, msg->tag);
 
 	return ret;
 }
 
 int wd_comp_poll(__u32 expt, __u32 *count)
 {
-	handle_t h_sched_ctx;
-	struct wd_sched *sched;
+	struct uadk_adapter_worker *worker;
+	__u32 recv = 0;
+	int ret = WD_SUCCESS;
 
 	if (unlikely(!count)) {
 		WD_ERR("invalid: comp poll count is NULL!\n");
 		return -WD_EINVAL;
 	}
 
-	h_sched_ctx = wd_comp_setting.sched.h_sched_ctx;
-	sched = &wd_comp_setting.sched;
+	for (int i = 0; i < wd_comp_setting.adapter->workers_nb; i++) {
+		worker = &wd_comp_setting.adapter->workers[i];
 
-	return sched->poll_policy(h_sched_ctx, expt, count);
+		if (worker->valid) {
+			struct wd_sched *sched = worker->sched;
+
+			ret = worker->sched->poll_policy(sched, expt, &recv);
+			if (ret)
+				return ret;
+
+			*count += recv;
+			expt -= recv;
+
+			if (expt == 0)
+				break;
+		}
+	}
+	return ret;
 }
 
 static const struct wd_config_variable table[] = {

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -14,6 +14,7 @@
 
 #include "include/drv/wd_dh_drv.h"
 #include "wd_util.h"
+#include "adapter.h"
 
 #define DH_MAX_KEY_SIZE			512
 #define WD_DH_G2			2
@@ -26,16 +27,15 @@ struct wd_dh_sess {
 	struct wd_dtb g;
 	struct wd_dh_sess_setup setup;
 	void  *sched_key;
+	struct uadk_adapter_worker *worker;
+	pthread_spinlock_t worker_lock;
 };
 
 static struct wd_dh_setting {
 	enum wd_status status;
-	struct wd_ctx_config_internal config;
-	struct wd_sched sched;
-	struct wd_async_msg_pool pool;
-	struct wd_alg_driver *driver;
 	void *dlhandle;
 	void *dlh_list;
+	struct uadk_adapter *adapter;
 } wd_dh_setting;
 
 struct wd_env_config wd_dh_env_config;
@@ -52,11 +52,9 @@ static void wd_dh_close_driver(int init_type)
 	if (!wd_dh_setting.dlhandle)
 		return;
 
-	wd_release_drv(wd_dh_setting.driver);
 	dlclose(wd_dh_setting.dlhandle);
 	wd_dh_setting.dlhandle = NULL;
 #else
-	wd_release_drv(wd_dh_setting.driver);
 	hisi_hpre_remove();
 #endif
 }
@@ -64,7 +62,7 @@ static void wd_dh_close_driver(int init_type)
 static int wd_dh_open_driver(int init_type)
 {
 	struct wd_alg_driver *driver = NULL;
-	const char *alg_name = "dh";
+	char *alg_name = "dh";
 #ifndef WD_STATIC_DRV
 	char lib_path[PATH_MAX];
 	int ret;
@@ -98,14 +96,14 @@ static int wd_dh_open_driver(int init_type)
 	if (init_type == WD_TYPE_V2)
 		return WD_SUCCESS;
 #endif
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_find_drv(NULL, alg_name, 0);
 	if (!driver) {
 		wd_dh_close_driver(WD_TYPE_V1);
 		WD_ERR("failed to get %s driver support\n", alg_name);
 		return -WD_EINVAL;
 	}
 
-	wd_dh_setting.driver = driver;
+	wd_dh_setting.adapter->workers[0].driver = driver;
 
 	return WD_SUCCESS;
 }
@@ -115,67 +113,68 @@ static void wd_dh_clear_status(void)
 	wd_alg_clear_init(&wd_dh_setting.status);
 }
 
-static int wd_dh_common_init(struct wd_ctx_config *config, struct wd_sched *sched)
+static int wd_dh_common_init(struct uadk_adapter_worker *worker,
+			     struct wd_sched *sched)
 {
 	int ret;
 
-	ret = wd_set_epoll_en("WD_DH_EPOLL_EN",
-			      &wd_dh_setting.config.epoll_en);
+	ret = wd_set_epoll_en("WD_DH_EPOLL_EN",	&worker->config.epoll_en);
 	if (ret < 0)
 		return ret;
 
-	ret = wd_init_ctx_config(&wd_dh_setting.config, config);
+	ret = wd_init_ctx_config(&worker->config, worker->ctx_config);
 	if (ret)
 		return ret;
 
-	ret = wd_init_sched(&wd_dh_setting.sched, sched);
+	worker->config.pool = &worker->pool;
+	sched->worker = worker;
+	worker->sched = sched;
+
+	/* initialize async request pool */
+	ret = wd_init_async_request_pool(&worker->pool,
+					 worker->ctx_config, WD_POOL_MAX_ENTRIES,
+					 sizeof(struct wd_dh_msg));
 	if (ret)
 		goto out_clear_ctx_config;
 
-	/* initialize async request pool */
-	ret = wd_init_async_request_pool(&wd_dh_setting.pool,
-					 config, WD_POOL_MAX_ENTRIES,
-					 sizeof(struct wd_dh_msg));
-	if (ret)
-		goto out_clear_sched;
-
-	ret = wd_alg_init_driver(&wd_dh_setting.config,
-				 wd_dh_setting.driver);
+	ret = wd_alg_init_driver(&worker->config, worker->driver);
 	if (ret)
 		goto out_clear_pool;
 
 	return WD_SUCCESS;
 
 out_clear_pool:
-	wd_uninit_async_request_pool(&wd_dh_setting.pool);
-out_clear_sched:
-	wd_clear_sched(&wd_dh_setting.sched);
+	wd_uninit_async_request_pool(&worker->pool);
 out_clear_ctx_config:
-	wd_clear_ctx_config(&wd_dh_setting.config);
+	wd_clear_ctx_config(&worker->config);
 	return ret;
 }
 
 static int wd_dh_common_uninit(void)
 {
+	struct uadk_adapter_worker *worker;
 	enum wd_status status;
 
 	wd_alg_get_init(&wd_dh_setting.status, &status);
 	if (status == WD_UNINIT)
 		return -WD_EINVAL;
 
-	/* uninit async request pool */
-	wd_uninit_async_request_pool(&wd_dh_setting.pool);
+	for (int i = 0; i < wd_dh_setting.adapter->workers_nb; i++) {
+		worker = &wd_dh_setting.adapter->workers[i];
 
-	/* unset config, sched, driver */
-	wd_clear_sched(&wd_dh_setting.sched);
-	wd_alg_uninit_driver(&wd_dh_setting.config,
-			     wd_dh_setting.driver);
+		wd_uninit_async_request_pool(&worker->pool);
+		wd_alg_uninit_driver(&worker->config, worker->driver);
+	}
+
+	free(wd_dh_setting.adapter);
 
 	return WD_SUCCESS;
 }
 
 int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
+	struct uadk_adapter_worker *worker;
+	struct uadk_adapter *adapter = NULL;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_dh_clear_status);
@@ -188,11 +187,20 @@ int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	if (ret)
 		goto out_clear_init;
 
+	adapter = calloc(1, sizeof(*adapter));
+	if (adapter == NULL)
+		goto out_clear_init;
+
+	wd_dh_setting.adapter = adapter;
+	worker = &adapter->workers[0];
+	worker->ctx_config = config;
+	adapter->workers_nb++;
+
 	ret = wd_dh_open_driver(WD_TYPE_V1);
 	if (ret)
 		goto out_clear_init;
 
-	ret = wd_dh_common_init(config, sched);
+	ret = wd_dh_common_init(worker, sched);
 	if (ret)
 		goto out_close_driver;
 
@@ -203,6 +211,7 @@ int wd_dh_init(struct wd_ctx_config *config, struct wd_sched *sched)
 out_close_driver:
 	wd_dh_close_driver(WD_TYPE_V1);
 out_clear_init:
+	free(adapter);
 	wd_alg_clear_init(&wd_dh_setting.status);
 	return ret;
 }
@@ -222,8 +231,12 @@ void wd_dh_uninit(void)
 int wd_dh_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_params *ctx_params)
 {
 	struct wd_ctx_nums dh_ctx_num[WD_DH_PHASE2] = {0};
+	struct uadk_adapter_worker *worker;
+	struct uadk_adapter *adapter = NULL;
+	struct wd_alg_driver *drv;
 	struct wd_ctx_params dh_ctx_params = {0};
 	int state, ret = -WD_EINVAL;
+	int idx = 0;
 
 	pthread_atfork(NULL, NULL, wd_dh_clear_status);
 
@@ -242,78 +255,72 @@ int wd_dh_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_param
 		goto out_clear_init;
 	}
 
+	adapter = calloc(1, sizeof(*adapter));
+	if (adapter == NULL)
+		goto out_clear_init;
+	wd_dh_setting.adapter = adapter;
+
 	state = wd_dh_open_driver(WD_TYPE_V2);
 	if (state)
 		goto out_clear_init;
 
-	while (ret) {
-		memset(&wd_dh_setting.config, 0, sizeof(struct wd_ctx_config_internal));
-
-		/* Get alg driver and dev name */
-		wd_dh_setting.driver = wd_alg_drv_bind(task_type, alg);
-		if (!wd_dh_setting.driver) {
-			WD_ERR("fail to bind a valid driver.\n");
-			ret = -WD_EINVAL;
-			goto out_dlopen;
-		}
+	do {
+		worker = &adapter->workers[idx];
+		drv = wd_find_drv(NULL, alg, idx);
+		if (!drv)
+			break;
+		worker->driver = drv;
 
 		dh_ctx_params.ctx_set_num = dh_ctx_num;
 		ret = wd_ctx_param_init(&dh_ctx_params, ctx_params,
-					wd_dh_setting.driver, WD_DH_TYPE, WD_DH_PHASE2);
+					drv, WD_DH_TYPE, WD_DH_PHASE2);
 		if (ret) {
-			if (ret == -WD_EAGAIN) {
-				wd_disable_drv(wd_dh_setting.driver);
-				wd_alg_drv_unbind(wd_dh_setting.driver);
-				continue;
-			}
-			goto out_driver;
+			WD_ERR("fail to init ctx param\n");
+			goto out_dlopen;
 		}
 
 		wd_dh_init_attrs.alg = alg;
 		wd_dh_init_attrs.sched_type = sched_type;
-		wd_dh_init_attrs.driver = wd_dh_setting.driver;
 		wd_dh_init_attrs.ctx_params = &dh_ctx_params;
 		wd_dh_init_attrs.alg_init = wd_dh_common_init;
-		wd_dh_init_attrs.alg_poll_ctx = wd_dh_poll_ctx;
-		ret = wd_alg_attrs_init(&wd_dh_init_attrs);
+		wd_dh_init_attrs.alg_poll_ctx = wd_dh_poll_ctx_;
+		ret = wd_alg_attrs_init(worker, &wd_dh_init_attrs);
+		wd_ctx_param_uninit(&dh_ctx_params);
 		if (ret) {
-			if (ret == -WD_ENODEV) {
-				wd_disable_drv(wd_dh_setting.driver);
-				wd_alg_drv_unbind(wd_dh_setting.driver);
-				wd_ctx_param_uninit(&dh_ctx_params);
-				continue;
-			}
 			WD_ERR("failed to init alg attrs!\n");
-			goto out_params_uninit;
+			goto out_dlopen;
 		}
-	}
+		adapter->workers_nb++;
+		if (++idx >= UADK_MAX_NB_WORKERS)
+			break;
+	} while (drv);
 
 	wd_alg_set_init(&wd_dh_setting.status);
-	wd_ctx_param_uninit(&dh_ctx_params);
 
 	return WD_SUCCESS;
 
-out_params_uninit:
-	wd_ctx_param_uninit(&dh_ctx_params);
-out_driver:
-	wd_alg_drv_unbind(wd_dh_setting.driver);
 out_dlopen:
 	wd_dh_close_driver(WD_TYPE_V2);
 out_clear_init:
+	free(adapter);
 	wd_alg_clear_init(&wd_dh_setting.status);
 	return ret;
 }
 
 void wd_dh_uninit2(void)
 {
+	struct uadk_adapter_worker *worker;
 	int ret;
 
 	ret = wd_dh_common_uninit();
 	if (ret)
 		return;
 
-	wd_alg_attrs_uninit(&wd_dh_init_attrs);
-	wd_alg_drv_unbind(wd_dh_setting.driver);
+	for (int i = 0; i < wd_dh_setting.adapter->workers_nb; i++) {
+		worker = &wd_dh_setting.adapter->workers[i];
+		wd_alg_attrs_uninit(worker);
+	}
+
 	wd_dh_close_driver(WD_TYPE_V2);
 	wd_dh_setting.dlh_list = NULL;
 	wd_alg_clear_init(&wd_dh_setting.status);
@@ -350,11 +357,10 @@ static int fill_dh_msg(struct wd_dh_msg *msg, struct wd_dh_req *req,
 	return WD_SUCCESS;
 }
 
-int wd_do_dh_sync(handle_t sess, struct wd_dh_req *req)
+int wd_do_dh_sync(handle_t h_sess, struct wd_dh_req *req)
 {
-	struct wd_ctx_config_internal *config = &wd_dh_setting.config;
-	handle_t h_sched_ctx = wd_dh_setting.sched.h_sched_ctx;
-	struct wd_dh_sess *sess_t = (struct wd_dh_sess *)sess;
+	struct wd_dh_sess *sess = (struct wd_dh_sess *)h_sess;
+	struct uadk_adapter_worker *worker;
 	struct wd_msg_handle msg_handle;
 	struct wd_ctx_internal *ctx;
 	struct wd_dh_msg msg;
@@ -366,27 +372,31 @@ int wd_do_dh_sync(handle_t sess, struct wd_dh_req *req)
 		return -WD_EINVAL;
 	}
 
-	idx = wd_dh_setting.sched.pick_next_ctx(h_sched_ctx,
-							   sess_t->sched_key,
-							   CTX_MODE_SYNC);
-	ret = wd_check_ctx(config, CTX_MODE_SYNC, idx);
+	pthread_spin_lock(&sess->worker_lock);
+	worker = sess->worker;
+	pthread_spin_unlock(&sess->worker_lock);
+	
+	idx = worker->sched->pick_next_ctx(
+		     worker->sched->h_sched_ctx,
+ 		     sess->sched_key, CTX_MODE_SYNC);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_SYNC, idx);
 	if (ret)
 		return ret;
 
-	wd_dfx_msg_cnt(config, WD_CTX_CNT_NUM, idx);
-	ctx = config->ctxs + idx;
+	wd_dfx_msg_cnt(&worker->config, WD_CTX_CNT_NUM, idx);
+	ctx = worker->config.ctxs + idx;
 
 	memset(&msg, 0, sizeof(struct wd_dh_msg));
-	ret = fill_dh_msg(&msg, req, sess_t);
+	ret = fill_dh_msg(&msg, req, sess);
 	if (unlikely(ret))
 		return ret;
 
-	msg_handle.send = wd_dh_setting.driver->send;
-	msg_handle.recv = wd_dh_setting.driver->recv;
+	msg_handle.send = worker->driver->send;
+	msg_handle.recv = worker->driver->recv;
 
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_handle_msg_sync(wd_dh_setting.driver, &msg_handle, ctx->ctx,
-				 &msg, &balance, wd_dh_setting.config.epoll_en);
+	ret = wd_handle_msg_sync(worker->driver, &msg_handle, ctx->ctx,
+				 &msg, &balance, worker->config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 	if (unlikely(ret))
 		return ret;
@@ -397,11 +407,10 @@ int wd_do_dh_sync(handle_t sess, struct wd_dh_req *req)
 	return GET_NEGATIVE(msg.result);
 }
 
-int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
+int wd_do_dh_async(handle_t h_sess, struct wd_dh_req *req)
 {
-	struct wd_ctx_config_internal *config = &wd_dh_setting.config;
-	handle_t h_sched_ctx = wd_dh_setting.sched.h_sched_ctx;
-	struct wd_dh_sess *sess_t = (struct wd_dh_sess *)sess;
+	struct wd_dh_sess *sess = (struct wd_dh_sess *)h_sess;
+	struct uadk_adapter_worker *worker;
 	struct wd_dh_msg *msg = NULL;
 	struct wd_ctx_internal *ctx;
 	int ret, mid;
@@ -412,16 +421,20 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 		return -WD_EINVAL;
 	}
 
-	idx = wd_dh_setting.sched.pick_next_ctx(h_sched_ctx,
-							   sess_t->sched_key,
-							   CTX_MODE_ASYNC);
-	ret = wd_check_ctx(config, CTX_MODE_ASYNC, idx);
+	pthread_spin_lock(&sess->worker_lock);
+	worker = sess->worker;
+	pthread_spin_unlock(&sess->worker_lock);
+	
+	idx = worker->sched->pick_next_ctx(
+		     worker->sched->h_sched_ctx,
+ 		     sess->sched_key, CTX_MODE_ASYNC);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_ASYNC, idx);
 	if (ret)
 		return ret;
 
-	ctx = config->ctxs + idx;
+	ctx = worker->config.ctxs + idx;
 
-	mid = wd_get_msg_from_pool(&wd_dh_setting.pool, idx, (void **)&msg);
+	mid = wd_get_msg_from_pool(&worker->pool, idx, (void **)&msg);
 	if (unlikely(mid < 0)) {
 		WD_ERR("failed to get msg from pool!\n");
 		return mid;
@@ -432,7 +445,7 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 		goto fail_with_msg;
 	msg->tag = mid;
 
-	ret = wd_alg_driver_send(wd_dh_setting.driver, ctx->ctx, msg);
+	ret = wd_alg_driver_send(worker->driver, ctx->ctx, msg);
 	if (unlikely(ret)) {
 		if (ret != -WD_EBUSY)
 			WD_ERR("failed to send dh BD, hw is err!\n");
@@ -440,7 +453,7 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 		goto fail_with_msg;
 	}
 
-	wd_dfx_msg_cnt(config, WD_CTX_CNT_NUM, idx);
+	wd_dfx_msg_cnt(&worker->config, WD_CTX_CNT_NUM, idx);
 	ret = wd_add_task_to_async_queue(&wd_dh_env_config, idx);
 	if (ret)
 		goto fail_with_msg;
@@ -448,19 +461,14 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 	return WD_SUCCESS;
 
 fail_with_msg:
-	wd_put_msg_to_pool(&wd_dh_setting.pool, idx, mid);
+	wd_put_msg_to_pool(&worker->pool, idx, msg->tag);
 
 	return ret;
 }
 
-struct wd_dh_msg *wd_dh_get_msg(__u32 idx, __u32 tag)
+int wd_dh_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count)
 {
-	return wd_find_msg_in_pool(&wd_dh_setting.pool, idx, tag);
-}
-
-int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
-{
-	struct wd_ctx_config_internal *config = &wd_dh_setting.config;
+	struct uadk_adapter_worker *worker;
 	struct wd_ctx_internal *ctx;
 	struct wd_dh_msg rcv_msg;
 	struct wd_dh_req *req;
@@ -474,27 +482,33 @@ int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 		return -WD_EINVAL;
 	}
 
+	/* back-compatible with init1 api */
+	if (sched == NULL)
+		worker = &wd_dh_setting.adapter->workers[0];
+	else
+		worker = sched->worker; 
+
 	*count = 0;
 
-	ret = wd_check_ctx(config, CTX_MODE_ASYNC, idx);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_ASYNC, idx);
 	if (ret)
 		return ret;
 
-	ctx = config->ctxs + idx;
+	ctx = worker->config.ctxs + idx;
 
 	do {
-		ret = wd_alg_driver_recv(wd_dh_setting.driver, ctx->ctx, &rcv_msg);
+		ret = wd_alg_driver_recv(worker->driver, ctx->ctx, &rcv_msg);
 		if (ret == -WD_EAGAIN) {
 			return ret;
 		} else if (unlikely(ret)) {
 			WD_ERR("failed to async recv, ret = %d!\n", ret);
 			*count = rcv_cnt;
-			wd_put_msg_to_pool(&wd_dh_setting.pool, idx,
+			wd_put_msg_to_pool(&worker->pool, idx,
 					   rcv_msg.tag);
 			return ret;
 		}
 		rcv_cnt++;
-		msg = wd_find_msg_in_pool(&wd_dh_setting.pool,
+		msg = wd_find_msg_in_pool(&worker->pool,
 			idx, rcv_msg.tag);
 		if (!msg) {
 			WD_ERR("failed to find msg!\n");
@@ -505,23 +519,47 @@ int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 		msg->req.status = rcv_msg.result;
 		req = &msg->req;
 		req->cb(req);
-		wd_put_msg_to_pool(&wd_dh_setting.pool, idx, rcv_msg.tag);
+		wd_put_msg_to_pool(&worker->pool, idx, rcv_msg.tag);
 		*count = rcv_cnt;
 	} while (--tmp);
 
 	return ret;
 }
 
+int wd_dh_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
+{
+	return wd_dh_poll_ctx_(NULL, idx, expt, count);
+}
+
 int wd_dh_poll(__u32 expt, __u32 *count)
 {
-	handle_t h_sched_ctx = wd_dh_setting.sched.h_sched_ctx;
+	struct uadk_adapter_worker *worker;
+	__u32 recv = 0;
+	int ret = WD_SUCCESS;
 
 	if (unlikely(!count)) {
 		WD_ERR("invalid: dh poll count is NULL!\n");
 		return -WD_EINVAL;
 	}
 
-	return wd_dh_setting.sched.poll_policy(h_sched_ctx, expt, count);
+	for (int i = 0; i < wd_dh_setting.adapter->workers_nb; i++) {
+		worker = &wd_dh_setting.adapter->workers[i];
+
+		if (worker->valid) {
+			struct wd_sched *sched = worker->sched;
+
+			ret = worker->sched->poll_policy(sched, expt, &recv);
+			if (ret)
+				return ret;
+
+			*count += recv;
+			expt -= recv;
+
+			if (expt == 0)
+				break;
+		}
+	}
+	return ret;
 }
 
 int wd_dh_get_mode(handle_t sess, __u8 *alg_mode)
@@ -581,6 +619,7 @@ void wd_dh_get_g(handle_t sess, struct wd_dtb **g)
 
 handle_t wd_dh_alloc_sess(struct wd_dh_sess_setup *setup)
 {
+	struct uadk_adapter_worker *worker;
 	struct wd_dh_sess *sess;
 
 	if (!setup) {
@@ -602,8 +641,12 @@ handle_t wd_dh_alloc_sess(struct wd_dh_sess_setup *setup)
 	sess = malloc(sizeof(struct wd_dh_sess));
 	if (!sess)
 		return (handle_t)0;
-
 	memset(sess, 0, sizeof(struct wd_dh_sess));
+
+	/* todo, use workers[0] now, will adapter.choose_worker later */
+	worker = sess->worker = &wd_dh_setting.adapter->workers[0];
+	worker->valid = true;
+
 	memcpy(&sess->setup, setup, sizeof(*setup));
 	sess->key_size = setup->key_bits >> BYTE_BITS_SHIFT;
 
@@ -613,8 +656,8 @@ handle_t wd_dh_alloc_sess(struct wd_dh_sess_setup *setup)
 
 	sess->g.bsize = sess->key_size;
 	/* Some simple scheduler don't need scheduling parameters */
-	sess->sched_key = (void *)wd_dh_setting.sched.sched_init(
-		     wd_dh_setting.sched.h_sched_ctx, setup->sched_param);
+	sess->sched_key = (void *)worker->sched->sched_init(
+		worker->sched->h_sched_ctx, setup->sched_param);
 	if (WD_IS_ERR(sess->sched_key)) {
 		WD_ERR("failed to init session schedule key!\n");
 		goto sched_err;

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -80,6 +80,7 @@ void wd_digest_switch_worker(struct wd_digest_sess *sess, int para)
 					    sess->worker, para);
 	if (worker)
 		sess->worker = worker;
+	sess->worker_lifetime = 0;
 	pthread_spin_unlock(&sess->worker_lock);
 
 }

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -436,7 +436,6 @@ int wd_digest_init2_(char *alg, __u32 sched_type, int task_type,
 			goto out_dlclose;
 		}
 		wd_digest_init_attrs.alg = alg;
-		wd_digest_init_attrs.sched_type = sched_type;
 		wd_digest_init_attrs.ctx_params = &digest_ctx_params;
 		wd_digest_init_attrs.alg_init = wd_digest_init_nolock;
 		wd_digest_init_attrs.alg_poll_ctx = wd_digest_poll_ctx_;

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -224,7 +224,7 @@ handle_t wd_digest_alloc_sess(struct wd_digest_sess_setup *setup)
 		goto err_sess;
 	}
 
-	sess->sched_key = calloc(sizeof(void *), nb);
+	sess->sched_key = (void **)calloc(nb, sizeof(void *));
 	for (i = 0; i < nb; i++) {
 		worker = &wd_digest_setting.adapter->workers[i];
 

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -15,6 +15,7 @@
 
 #include "include/drv/wd_ecc_drv.h"
 #include "include/wd_ecc_curve.h"
+#include "adapter.h"
 #include "wd_ecc.h"
 
 #define ECC_MAX_HW_BITS			521
@@ -50,6 +51,8 @@ struct wd_ecc_sess {
 	struct wd_ecc_key key;
 	struct wd_ecc_sess_setup setup;
 	void *sched_key;
+	struct uadk_adapter_worker *worker;
+	pthread_spinlock_t worker_lock;
 };
 
 struct wd_ecc_curve_list {
@@ -61,12 +64,9 @@ struct wd_ecc_curve_list {
 
 static struct wd_ecc_setting {
 	enum wd_status status;
-	struct wd_ctx_config_internal config;
-	struct wd_sched sched;
-	struct wd_async_msg_pool pool;
-	struct wd_alg_driver *driver;
 	void *dlhandle;
 	void *dlh_list;
+	struct uadk_adapter *adapter;
 } wd_ecc_setting;
 
 struct wd_env_config wd_ecc_env_config;
@@ -106,11 +106,9 @@ static void wd_ecc_close_driver(int init_type)
 	if (!wd_ecc_setting.dlhandle)
 		return;
 
-	wd_release_drv(wd_ecc_setting.driver);
 	dlclose(wd_ecc_setting.dlhandle);
 	wd_ecc_setting.dlhandle = NULL;
 #else
-	wd_release_drv(wd_ecc_setting.driver);
 	hisi_hpre_remove();
 #endif
 }
@@ -118,7 +116,7 @@ static void wd_ecc_close_driver(int init_type)
 static int wd_ecc_open_driver(int init_type)
 {
 	struct wd_alg_driver *driver = NULL;
-	const char *alg_name = "sm2";
+	char *alg_name = "sm2";
 #ifndef WD_STATIC_DRV
 	char lib_path[PATH_MAX];
 	int ret;
@@ -152,14 +150,14 @@ static int wd_ecc_open_driver(int init_type)
 	if (init_type == WD_TYPE_V2)
 		return WD_SUCCESS;
 #endif
-	driver = wd_request_drv(alg_name, false);
+	driver = wd_find_drv(NULL, alg_name, 0);
 	if (!driver) {
 		wd_ecc_close_driver(WD_TYPE_V1);
 		WD_ERR("failed to get %s driver support\n", alg_name);
 		return -WD_EINVAL;
 	}
 
-	wd_ecc_setting.driver = driver;
+	wd_ecc_setting.adapter->workers[0].driver = driver;
 
 	return WD_SUCCESS;
 }
@@ -179,66 +177,67 @@ static void wd_ecc_clear_status(void)
 	wd_alg_clear_init(&wd_ecc_setting.status);
 }
 
-static int wd_ecc_common_init(struct wd_ctx_config *config, struct wd_sched *sched)
+static int wd_ecc_common_init(struct uadk_adapter_worker *worker, struct wd_sched *sched)
 {
 	int ret;
 
 	ret = wd_set_epoll_en("WD_ECC_EPOLL_EN",
-			      &wd_ecc_setting.config.epoll_en);
+			      &worker->config.epoll_en);
 	if (ret < 0)
 		return ret;
 
-	ret = wd_init_ctx_config(&wd_ecc_setting.config, config);
+	ret = wd_init_ctx_config(&worker->config, worker->ctx_config);
 	if (ret < 0)
 		return ret;
 
-	ret = wd_init_sched(&wd_ecc_setting.sched, sched);
+	worker->config.pool = &worker->pool;
+	sched->worker = worker;
+	worker->sched = sched;
+
+	ret = wd_init_async_request_pool(&worker->pool,
+					 worker->ctx_config, WD_POOL_MAX_ENTRIES,
+					 sizeof(struct wd_ecc_msg));
 	if (ret < 0)
 		goto out_clear_ctx_config;
 
-	ret = wd_init_async_request_pool(&wd_ecc_setting.pool,
-					 config, WD_POOL_MAX_ENTRIES,
-					 sizeof(struct wd_ecc_msg));
-	if (ret < 0)
-		goto out_clear_sched;
-
-	ret = wd_alg_init_driver(&wd_ecc_setting.config,
-				 wd_ecc_setting.driver);
+	ret = wd_alg_init_driver(&worker->config, worker->driver);
 	if (ret)
 		goto out_clear_pool;
 
 	return WD_SUCCESS;
 
 out_clear_pool:
-	wd_uninit_async_request_pool(&wd_ecc_setting.pool);
-out_clear_sched:
-	wd_clear_sched(&wd_ecc_setting.sched);
+	wd_uninit_async_request_pool(&worker->pool);
 out_clear_ctx_config:
-	wd_clear_ctx_config(&wd_ecc_setting.config);
+	wd_clear_ctx_config(&worker->config);
 	return ret;
 }
 
 static int wd_ecc_common_uninit(void)
 {
+	struct uadk_adapter_worker *worker;
 	enum wd_status status;
 
 	wd_alg_get_init(&wd_ecc_setting.status, &status);
 	if (status == WD_UNINIT)
 		return -WD_EINVAL;
 
-	/* uninit async request pool */
-	wd_uninit_async_request_pool(&wd_ecc_setting.pool);
+	for (int i = 0; i < wd_ecc_setting.adapter->workers_nb; i++) {
+		worker = &wd_ecc_setting.adapter->workers[i];
 
-	/* unset config, sched, driver */
-	wd_clear_sched(&wd_ecc_setting.sched);
-	wd_alg_uninit_driver(&wd_ecc_setting.config,
-			     wd_ecc_setting.driver);
+		wd_uninit_async_request_pool(&worker->pool);
+		wd_alg_uninit_driver(&worker->config, worker->driver);
+	}
+
+	free(wd_ecc_setting.adapter);
 
 	return WD_SUCCESS;
 }
 
 int wd_ecc_init(struct wd_ctx_config *config, struct wd_sched *sched)
 {
+	struct uadk_adapter_worker *worker;
+	struct uadk_adapter *adapter = NULL;
 	int ret;
 
 	pthread_atfork(NULL, NULL, wd_ecc_clear_status);
@@ -251,11 +250,20 @@ int wd_ecc_init(struct wd_ctx_config *config, struct wd_sched *sched)
 	if (ret)
 		goto out_clear_init;
 
+	adapter = calloc(1, sizeof(*adapter));
+	if (adapter == NULL)
+		goto out_clear_init;
+
+	wd_ecc_setting.adapter = adapter;
+	worker = &adapter->workers[0];
+	worker->ctx_config = config;
+	adapter->workers_nb++;
+
 	ret = wd_ecc_open_driver(WD_TYPE_V1);
 	if (ret)
 		goto out_clear_init;
 
-	ret = wd_ecc_common_init(config, sched);
+	ret = wd_ecc_common_init(worker, sched);
 	if (ret)
 		goto out_close_driver;
 
@@ -266,6 +274,7 @@ int wd_ecc_init(struct wd_ctx_config *config, struct wd_sched *sched)
 out_close_driver:
 	wd_ecc_close_driver(WD_TYPE_V1);
 out_clear_init:
+	free(adapter);
 	wd_alg_clear_init(&wd_ecc_setting.status);
 	return ret;
 }
@@ -286,7 +295,11 @@ int wd_ecc_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_para
 {
 	struct wd_ctx_nums ecc_ctx_num[WD_EC_OP_MAX] = {0};
 	struct wd_ctx_params ecc_ctx_params = {0};
+	struct uadk_adapter_worker *worker;
+	struct uadk_adapter *adapter = NULL;
+	struct wd_alg_driver *drv;
 	int state, ret = -WD_EINVAL;
+	int idx = 0;
 	bool flag;
 
 	pthread_atfork(NULL, NULL, wd_ecc_clear_status);
@@ -307,61 +320,50 @@ int wd_ecc_init2_(char *alg, __u32 sched_type, int task_type, struct wd_ctx_para
 		goto out_clear_init;
 	}
 
+	adapter = calloc(1, sizeof(*adapter));
+	if (adapter == NULL)
+		goto out_clear_init;
+	wd_ecc_setting.adapter = adapter;
+
 	state = wd_ecc_open_driver(WD_TYPE_V2);
 	if (state)
 		goto out_clear_init;
 
-	while (ret) {
-		memset(&wd_ecc_setting.config, 0, sizeof(struct wd_ctx_config_internal));
-
-		/* Get alg driver and dev name */
-		wd_ecc_setting.driver = wd_alg_drv_bind(task_type, alg);
-		if (!wd_ecc_setting.driver) {
-			WD_ERR("failed to bind a valid driver!\n");
-			ret = -WD_EINVAL;
-			goto out_dlopen;
-		}
-
+	do {
+		worker = &adapter->workers[idx];
+		drv = wd_find_drv(NULL, alg, idx);
+		if (!drv)
+			break;
+		worker->driver = drv;
+		
 		ecc_ctx_params.ctx_set_num = ecc_ctx_num;
-		ret = wd_ctx_param_init(&ecc_ctx_params, ctx_params,
-					wd_ecc_setting.driver, WD_ECC_TYPE, WD_EC_OP_MAX);
+		ret = wd_ctx_param_init(&ecc_ctx_params, ctx_params, drv,
+					WD_ECC_TYPE, WD_EC_OP_MAX);
 		if (ret) {
-			if (ret == -WD_EAGAIN) {
-				wd_disable_drv(wd_ecc_setting.driver);
-				wd_alg_drv_unbind(wd_ecc_setting.driver);
-				continue;
-			}
-			goto out_driver;
+			WD_ERR("fail to init ctx param\n");
+			goto out_dlopen;
 		}
 
 		wd_ecc_init_attrs.alg = alg;
 		wd_ecc_init_attrs.sched_type = sched_type;
-		wd_ecc_init_attrs.driver = wd_ecc_setting.driver;
 		wd_ecc_init_attrs.ctx_params = &ecc_ctx_params;
 		wd_ecc_init_attrs.alg_init = wd_ecc_common_init;
-		wd_ecc_init_attrs.alg_poll_ctx = wd_ecc_poll_ctx;
-		ret = wd_alg_attrs_init(&wd_ecc_init_attrs);
+		wd_ecc_init_attrs.alg_poll_ctx = wd_ecc_poll_ctx_;
+		ret = wd_alg_attrs_init(worker, &wd_ecc_init_attrs);
+		wd_ctx_param_uninit(&ecc_ctx_params);
 		if (ret) {
-			if (ret == -WD_ENODEV) {
-				wd_disable_drv(wd_ecc_setting.driver);
-				wd_alg_drv_unbind(wd_ecc_setting.driver);
-				wd_ctx_param_uninit(&ecc_ctx_params);
-				continue;
-			}
 			WD_ERR("failed to init alg attrs!\n");
-			goto out_params_uninit;
+			goto out_dlopen;
 		}
-	}
+		adapter->workers_nb++;
+		if (++idx >= UADK_MAX_NB_WORKERS)
+			break;
+	} while (drv);
 
 	wd_alg_set_init(&wd_ecc_setting.status);
-	wd_ctx_param_uninit(&ecc_ctx_params);
 
 	return WD_SUCCESS;
 
-out_params_uninit:
-	wd_ctx_param_uninit(&ecc_ctx_params);
-out_driver:
-	wd_alg_drv_unbind(wd_ecc_setting.driver);
 out_dlopen:
 	wd_ecc_close_driver(WD_TYPE_V2);
 out_clear_init:
@@ -371,14 +373,18 @@ out_clear_init:
 
 void wd_ecc_uninit2(void)
 {
+	struct uadk_adapter_worker *worker;
 	int ret;
 
 	ret = wd_ecc_common_uninit();
 	if (ret)
 		return;
 
-	wd_alg_attrs_uninit(&wd_ecc_init_attrs);
-	wd_alg_drv_unbind(wd_ecc_setting.driver);
+	for (int i = 0; i < wd_ecc_setting.adapter->workers_nb; i++) {
+		worker = &wd_ecc_setting.adapter->workers[i];
+		wd_alg_attrs_uninit(worker);
+	}
+
 	wd_ecc_close_driver(WD_TYPE_V2);
 	wd_ecc_setting.dlh_list = NULL;
 	wd_alg_clear_init(&wd_ecc_setting.status);
@@ -1168,21 +1174,26 @@ static void del_sess_key(struct wd_ecc_sess *sess)
 
 handle_t wd_ecc_alloc_sess(struct wd_ecc_sess_setup *setup)
 {
+	struct uadk_adapter_worker *worker;
 	struct wd_ecc_sess *sess;
 	int ret;
 
 	if (setup_param_check(setup))
 		return (handle_t)0;
 
-	ret = wd_drv_alg_support(setup->alg, wd_ecc_setting.driver);
-	if (!ret) {
-		WD_ERR("failed to support this algorithm: %s!\n", setup->alg);
-		return (handle_t)0;
-	}
-
 	sess = calloc(1, sizeof(struct wd_ecc_sess));
 	if (!sess)
 		return (handle_t)0;
+
+	/* todo, use workers[0] now, will adapter.choose_worker later */
+	worker = sess->worker = &wd_ecc_setting.adapter->workers[0];
+	worker->valid = true;
+
+	ret = wd_drv_alg_support(setup->alg, worker->driver);
+	if (!ret) {
+		WD_ERR("failed to support this algorithm: %s!\n", setup->alg);
+		goto sess_err;
+	}
 
 	memcpy(&sess->setup, setup, sizeof(*setup));
 	sess->key_size = BITS_TO_BYTES(setup->key_bits);
@@ -1194,8 +1205,8 @@ handle_t wd_ecc_alloc_sess(struct wd_ecc_sess_setup *setup)
 	}
 
 	/* Some simple scheduler don't need scheduling parameters */
-	sess->sched_key = (void *)wd_ecc_setting.sched.sched_init(
-		     wd_ecc_setting.sched.h_sched_ctx, setup->sched_param);
+	sess->sched_key = (void *)worker->sched->sched_init(
+		worker->sched->h_sched_ctx, setup->sched_param);
 	if (WD_IS_ERR(sess->sched_key)) {
 		WD_ERR("failed to init session schedule key!\n");
 		goto sched_err;
@@ -1557,9 +1568,8 @@ static void msg_pack(char *dst, __u64 *out_len,
 
 int wd_do_ecc_sync(handle_t h_sess, struct wd_ecc_req *req)
 {
-	struct wd_ctx_config_internal *config = &wd_ecc_setting.config;
-	handle_t h_sched_ctx = wd_ecc_setting.sched.h_sched_ctx;
 	struct wd_ecc_sess *sess = (struct wd_ecc_sess *)h_sess;
+	struct uadk_adapter_worker *worker;
 	struct wd_msg_handle msg_handle;
 	struct wd_ctx_internal *ctx;
 	struct wd_ecc_msg msg;
@@ -1571,27 +1581,31 @@ int wd_do_ecc_sync(handle_t h_sess, struct wd_ecc_req *req)
 		return -WD_EINVAL;
 	}
 
-	idx = wd_ecc_setting.sched.pick_next_ctx(h_sched_ctx,
-							    sess->sched_key,
-							    CTX_MODE_SYNC);
-	ret = wd_check_ctx(config, CTX_MODE_SYNC, idx);
+	pthread_spin_lock(&sess->worker_lock);
+	worker = sess->worker;
+	pthread_spin_unlock(&sess->worker_lock);
+	
+	idx = worker->sched->pick_next_ctx(
+		     worker->sched->h_sched_ctx,
+ 		     sess->sched_key, CTX_MODE_SYNC);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_SYNC, idx);
 	if (ret)
 		return ret;
 
-	wd_dfx_msg_cnt(config, WD_CTX_CNT_NUM, idx);
-	ctx = config->ctxs + idx;
+	wd_dfx_msg_cnt(&worker->config, WD_CTX_CNT_NUM, idx);
+	ctx = worker->config.ctxs + idx;
 
 	memset(&msg, 0, sizeof(struct wd_ecc_msg));
 	ret = fill_ecc_msg(&msg, req, sess);
 	if (unlikely(ret))
 		return ret;
 
-	msg_handle.send = wd_ecc_setting.driver->send;
-	msg_handle.recv = wd_ecc_setting.driver->recv;
+	msg_handle.send = worker->driver->send;
+	msg_handle.recv = worker->driver->recv;
 
 	pthread_spin_lock(&ctx->lock);
-	ret = wd_handle_msg_sync(wd_ecc_setting.driver, &msg_handle, ctx->ctx, &msg,
-				 &balance, wd_ecc_setting.config.epoll_en);
+	ret = wd_handle_msg_sync(worker->driver, &msg_handle, ctx->ctx, &msg,
+				 &balance, worker->config.epoll_en);
 	pthread_spin_unlock(&ctx->lock);
 	if (unlikely(ret))
 		return ret;
@@ -2243,11 +2257,10 @@ struct wd_ecc_in *wd_ecdsa_new_verf_in(handle_t sess,
 	return new_verf_in(sess, dgst, r, s, NULL, 1);
 }
 
-int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
+int wd_do_ecc_async(handle_t h_sess, struct wd_ecc_req *req)
 {
-	struct wd_ctx_config_internal *config = &wd_ecc_setting.config;
-	handle_t h_sched_ctx = wd_ecc_setting.sched.h_sched_ctx;
-	struct wd_ecc_sess *sess_t = (struct wd_ecc_sess *)sess;
+	struct wd_ecc_sess *sess = (struct wd_ecc_sess *)h_sess;
+	struct uadk_adapter_worker *worker;
 	struct wd_ecc_msg *msg = NULL;
 	struct wd_ctx_internal *ctx;
 	int ret, mid;
@@ -2258,16 +2271,20 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
 		return -WD_EINVAL;
 	}
 
-	idx = wd_ecc_setting.sched.pick_next_ctx(h_sched_ctx,
-						 sess_t->sched_key,
-						 CTX_MODE_ASYNC);
-	ret = wd_check_ctx(config, CTX_MODE_ASYNC, idx);
+	pthread_spin_lock(&sess->worker_lock);
+	worker = sess->worker;
+	pthread_spin_unlock(&sess->worker_lock);
+	
+	idx = worker->sched->pick_next_ctx(
+		     worker->sched->h_sched_ctx,
+ 		     sess->sched_key, CTX_MODE_ASYNC);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_ASYNC, idx);
 	if (ret)
 		return ret;
 
-	ctx = config->ctxs + idx;
+	ctx = worker->config.ctxs + idx;
 
-	mid = wd_get_msg_from_pool(&wd_ecc_setting.pool, idx, (void **)&msg);
+	mid = wd_get_msg_from_pool(&worker->pool, idx, (void **)&msg);
 	if (unlikely(mid < 0)) {
 		WD_ERR("failed to get msg from pool!\n");
 		return mid;
@@ -2278,7 +2295,7 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
 		goto fail_with_msg;
 	msg->tag = mid;
 
-	ret = wd_alg_driver_send(wd_ecc_setting.driver, ctx->ctx, msg);
+	ret = wd_alg_driver_send(worker->driver, ctx->ctx, msg);
 	if (unlikely(ret)) {
 		if (ret != -WD_EBUSY)
 			WD_ERR("failed to send ecc BD, hw is err!\n");
@@ -2286,7 +2303,7 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
 		goto fail_with_msg;
 	}
 
-	wd_dfx_msg_cnt(config, WD_CTX_CNT_NUM, idx);
+	wd_dfx_msg_cnt(&worker->config, WD_CTX_CNT_NUM, idx);
 	ret = wd_add_task_to_async_queue(&wd_ecc_env_config, idx);
 	if (ret)
 		goto fail_with_msg;
@@ -2294,18 +2311,13 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
 	return WD_SUCCESS;
 
 fail_with_msg:
-	wd_put_msg_to_pool(&wd_ecc_setting.pool, idx, mid);
+	wd_put_msg_to_pool(&worker->pool, idx, msg->tag);
 	return ret;
 }
 
-struct wd_ecc_msg *wd_ecc_get_msg(__u32 idx, __u32 tag)
+int wd_ecc_poll_ctx_(struct wd_sched *sched, __u32 idx, __u32 expt, __u32 *count)
 {
-	return wd_find_msg_in_pool(&wd_ecc_setting.pool, idx, tag);
-}
-
-int wd_ecc_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
-{
-	struct wd_ctx_config_internal *config = &wd_ecc_setting.config;
+	struct uadk_adapter_worker *worker;
 	struct wd_ecc_msg recv_msg, *msg;
 	struct wd_ctx_internal *ctx;
 	struct wd_ecc_req *req;
@@ -2318,27 +2330,33 @@ int wd_ecc_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 		return -WD_EINVAL;
 	}
 
+	/* back-compatible with init1 api */
+	if (sched == NULL)
+		worker = &wd_ecc_setting.adapter->workers[0];
+	else
+		worker = sched->worker; 
+
 	*count = 0;
 
-	ret = wd_check_ctx(config, CTX_MODE_ASYNC, idx);
+	ret = wd_check_ctx(&worker->config, CTX_MODE_ASYNC, idx);
 	if (ret)
 		return ret;
 
-	ctx = config->ctxs + idx;
+	ctx = worker->config.ctxs + idx;
 
 	do {
-		ret = wd_alg_driver_recv(wd_ecc_setting.driver, ctx->ctx, &recv_msg);
+		ret = wd_alg_driver_recv(worker->driver, ctx->ctx, &recv_msg);
 		if (ret == -WD_EAGAIN) {
 			return ret;
 		} else if (ret < 0) {
 			WD_ERR("failed to async recv, ret = %d!\n", ret);
 			*count = rcv_cnt;
-			wd_put_msg_to_pool(&wd_ecc_setting.pool, idx,
+			wd_put_msg_to_pool(&worker->pool, idx,
 					   recv_msg.tag);
 			return ret;
 		}
 		rcv_cnt++;
-		msg = wd_find_msg_in_pool(&wd_ecc_setting.pool, idx,
+		msg = wd_find_msg_in_pool(&worker->pool, idx,
 					  recv_msg.tag);
 		if (!msg) {
 			WD_ERR("failed to find msg from pool!\n");
@@ -2349,23 +2367,47 @@ int wd_ecc_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 		msg->req.status = recv_msg.result;
 		req = &msg->req;
 		req->cb(req);
-		wd_put_msg_to_pool(&wd_ecc_setting.pool, idx, recv_msg.tag);
+		wd_put_msg_to_pool(&worker->pool, idx, recv_msg.tag);
 		*count = rcv_cnt;
 	} while (--tmp);
 
 	return ret;
 }
 
+int wd_ecc_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
+{
+	return wd_ecc_poll_ctx_(NULL, idx, expt, count);
+}
+
 int wd_ecc_poll(__u32 expt, __u32 *count)
 {
-	handle_t h_sched_sess = wd_ecc_setting.sched.h_sched_ctx;
+	struct uadk_adapter_worker *worker;
+	__u32 recv = 0;
+	int ret = WD_SUCCESS;
 
 	if (unlikely(!count)) {
 		WD_ERR("invalid: ecc poll param count is NULL!\n");
 		return -WD_EINVAL;
 	}
 
-	return wd_ecc_setting.sched.poll_policy(h_sched_sess, expt, count);
+	for (int i = 0; i < wd_ecc_setting.adapter->workers_nb; i++) {
+		worker = &wd_ecc_setting.adapter->workers[i];
+
+		if (worker->valid) {
+			struct wd_sched *sched = worker->sched;
+
+			ret = worker->sched->poll_policy(sched, expt, &recv);
+			if (ret)
+				return ret;
+
+			*count += recv;
+			expt -= recv;
+
+			if (expt == 0)
+				break;
+		}
+	}
+	return ret;
 }
 
 static const struct wd_config_variable table[] = {

--- a/wd_util.c
+++ b/wd_util.c
@@ -2729,7 +2729,6 @@ int wd_alg_attrs_init(struct uadk_adapter_worker *worker,
 {
 	wd_alg_poll_ctx alg_poll_func = attrs->alg_poll_ctx;
 	wd_alg_init alg_init_func = attrs->alg_init;
-	__u32 sched_type = attrs->sched_type;
 	struct wd_ctx_config *ctx_config = NULL;
 	struct wd_sched *alg_sched = NULL;
 	char alg_type[CRYPTO_MAX_ALG_NAME];
@@ -2814,7 +2813,8 @@ int wd_alg_attrs_init(struct uadk_adapter_worker *worker,
 		attrs->ctx_config = ctx_config;
 		worker->ctx_config = ctx_config;
 
-		alg_sched = wd_sched_rr_alloc(sched_type, attrs->ctx_params->op_type_num,
+		/* Use default sched_type to alloc scheduler */
+		alg_sched = wd_sched_rr_alloc(SCHED_POLICY_RR, attrs->ctx_params->op_type_num,
 						  numa_max_node() + 1, alg_poll_func);
 		if (!alg_sched) {
 			WD_ERR("fail to instance scheduler\n");


### PR DESCRIPTION
1.增加一个workers[2]数组，
a.workers 数组默认是按优先级排序。
b.也可以通过config文件，export UADK_CONF=xxx/uadk.conf
i.系统中存在多个驱动，只选择其中2个，
ii.可以切换优先级，前面的驱动优先级高
c.struct worker 不仅包括驱动，还包括驱动需要的资源
d.现在worker[]只有2个，可以修改宏改成多个。
2.要求：init完后 所有worker均初始化好，工作时随便选哪个worker 都能工作，方便随时切换。
3.工作切换
a.默认primary_mode，worker[0]出错 -> worker[1] 10次 -> worker[0]
b.roundrobin_mode, worker[0] 10次 -> worker[1] 10次 -> worker[0] 10次 -> ...
