### PR TITLE
uadk/isa-ce: fix sm4 CE driver initialization error

### DIFF
--- a/drv/isa_ce_sm3.c
+++ b/drv/isa_ce_sm3.c
@@ -373,22 +373,19 @@ static int sm3_ce_drv_recv(struct wd_alg_driver *drv, handle_t ctx, void *digest
 static int sm3_ce_drv_init(struct wd_alg_driver *drv, void *conf)
 {
 	struct wd_ctx_config_internal *config = (struct wd_ctx_config_internal *)conf;
-	struct sm3_ce_drv_ctx *sctx = (struct sm3_ce_drv_ctx *)drv->priv;
+	struct sm3_ce_drv_ctx *priv;
 
 	/* Fallback init is NULL */
 	if (!drv || !conf)
 		return 0;
 
-	config->epoll_en = 0;
-
-	/* return if already inited */
-	if (sctx)
-		return WD_SUCCESS;
-	sctx = malloc(sizeof(struct sm3_ce_drv_ctx));
-	if (!sctx)
+	priv = malloc(sizeof(struct sm3_ce_drv_ctx));
+	if (!priv)
 		return -WD_EINVAL;
 
-	memcpy(&sctx->config, config, sizeof(struct wd_ctx_config_internal));
+	config->epoll_en = 0;
+	memcpy(&priv->config, config, sizeof(struct wd_ctx_config_internal));
+	drv->priv = priv;
 
 	return WD_SUCCESS;
 }

--- a/drv/isa_ce_sm4.c
+++ b/drv/isa_ce_sm4.c
@@ -34,20 +34,32 @@
 static int isa_ce_init(struct wd_alg_driver *drv, void *conf)
 {
 	struct wd_ctx_config_internal *config = conf;
-	struct sm4_ce_drv_ctx *sctx = drv->priv;
+	struct sm4_ce_drv_ctx *priv;
 
 	/* Fallback init is NULL */
 	if (!drv || !conf)
 		return 0;
 
-	config->epoll_en = 0;
-	memcpy(&sctx->config, config, sizeof(struct wd_ctx_config_internal));
+	priv = malloc(sizeof(struct sm4_ce_drv_ctx));
+	if (!priv)
+		return -WD_EINVAL;
 
-	return 0;
+	config->epoll_en = 0;
+	memcpy(&priv->config, config, sizeof(struct wd_ctx_config_internal));
+	drv->priv = priv;
+
+	return WD_SUCCESS;
 }
 
 static void isa_ce_exit(struct wd_alg_driver *drv)
 {
+	struct sm4_ce_drv_ctx *sctx = (struct sm4_ce_drv_ctx *)drv->priv;
+
+	if (!sctx)
+		return;
+
+	free(sctx);
+	drv->priv = NULL;
 }
 
 /* increment upper 96 bits of 128-bit counter by 1 */


### PR DESCRIPTION
CE driver of sm4 should alloc and free private ctx by himself. The cleancode issue of sm3 CE driver is also solved.