### PR TITLE
uadk bugfix

### DIFF
--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -836,7 +836,7 @@ out:
 static void hisi_zip_exit(struct wd_alg_driver *drv)
 {
 	struct hisi_zip_ctx *priv = (struct hisi_zip_ctx *)drv->priv;
-	struct wd_ctx_config_internal *config = &priv->config;
+	struct wd_ctx_config_internal *config;
 	handle_t h_qp;
 	__u32 i;
 
@@ -845,6 +845,7 @@ static void hisi_zip_exit(struct wd_alg_driver *drv)
 		return;
 	}
 
+	config = &priv->config;
 	for (i = 0; i < config->ctx_num; i++) {
 		h_qp = (handle_t)wd_ctx_get_priv(config->ctxs[i].ctx);
 		hisi_qm_free_qp(h_qp);

--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -584,7 +584,7 @@ static int hpre_ecc_init(struct wd_alg_driver *drv, void *conf)
 static void hpre_exit(struct wd_alg_driver *drv)
 {
 	struct hisi_hpre_ctx *priv = (struct hisi_hpre_ctx *)drv->priv;
-	struct wd_ctx_config_internal *config = &priv->config;
+	struct wd_ctx_config_internal *config;
 	handle_t h_qp;
 	__u32 i;
 
@@ -593,6 +593,7 @@ static void hpre_exit(struct wd_alg_driver *drv)
 		return;
 	}
 
+	config = &priv->config;
 	for (i = 0; i < config->ctx_num; i++) {
 		h_qp = (handle_t)wd_ctx_get_priv(config->ctxs[i].ctx);
 		hisi_qm_free_qp(h_qp);

--- a/v1/drv/hisi_zip_udrv.c
+++ b/v1/drv/hisi_zip_udrv.c
@@ -254,7 +254,6 @@ int qm_parse_zip_sqe(void *hw_msg, const struct qm_queue_info *info,
 		     __u16 i, __u16 usr)
 {
 	struct wcrypto_comp_msg *recv_msg = info->req_cache[i];
-	struct wcrypto_comp_tag *tag = (void *)(uintptr_t)recv_msg->udata;
 	struct hisi_zip_sqe *sqe = hw_msg;
 	__u16 ctx_st = sqe->ctx_dw0 & HZ_CTX_ST_MASK;
 	__u16 lstblk = sqe->dw3 & HZ_LSTBLK_MASK;
@@ -262,12 +261,14 @@ int qm_parse_zip_sqe(void *hw_msg, const struct qm_queue_info *info,
 	__u32 type = sqe->dw9 & HZ_REQ_TYPE_MASK;
 	uintptr_t phy_in, phy_out, phy_ctxbuf;
 	struct wd_queue *q = info->q;
+	struct wcrypto_comp_tag *tag;
 
 	if (unlikely(!recv_msg)) {
 		WD_ERR("info->req_cache is null at index:%hu\n", i);
 		return 0;
 	}
 
+	tag = (void *)(uintptr_t)recv_msg->udata;
 	if (usr && sqe->tag != usr)
 		return 0;
 

--- a/wd.c
+++ b/wd.c
@@ -938,9 +938,6 @@ void wd_release_alg_cap(struct wd_capability *head)
 		cap_pnext = cap_pnext->next;
 		free(cap_node);
 	}
-
-	if (head)
-		free(head);
 }
 
 struct wd_capability *wd_get_alg_cap(void)

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -805,7 +805,7 @@ int wd_do_aead_async(handle_t h_sess, struct wd_aead_req *req)
 				     idx, (void **)&msg);
 	if (unlikely(msg_id < 0)) {
 		WD_ERR("failed to get msg from pool!\n");
-		return -WD_EBUSY;
+		return msg_id;
 	}
 
 	fill_request_msg(msg, req, sess);

--- a/wd_agg.c
+++ b/wd_agg.c
@@ -1192,8 +1192,8 @@ static int wd_agg_async_job(struct wd_agg_sess *sess, struct wd_agg_req *req, bo
 	ctx = config->ctxs + idx;
 	msg_id = wd_get_msg_from_pool(&wd_agg_setting.pool, idx, (void **)&msg);
 	if (unlikely(msg_id < 0)) {
-		WD_ERR("busy, failed to get agg msg from pool!\n");
-		return -WD_EBUSY;
+		WD_ERR("failed to get agg msg from pool!\n");
+		return msg_id;
 	}
 
 	if (is_input)

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -741,8 +741,8 @@ int wd_do_cipher_async(handle_t h_sess, struct wd_cipher_req *req)
 	msg_id = wd_get_msg_from_pool(&wd_cipher_setting.pool, idx,
 				   (void **)&msg);
 	if (unlikely(msg_id < 0)) {
-		WD_ERR("busy, failed to get msg from pool!\n");
-		return -WD_EBUSY;
+		WD_ERR("failed to get msg from pool!\n");
+		return msg_id;
 	}
 
 	fill_request_msg(msg, req, sess);

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -860,7 +860,7 @@ int wd_do_comp_async(handle_t h_sess, struct wd_comp_req *req)
 	tag = wd_get_msg_from_pool(&wd_comp_setting.pool, idx, (void **)&msg);
 	if (unlikely(tag < 0)) {
 		WD_ERR("failed to get msg from pool!\n");
-		return -WD_EBUSY;
+		return tag;
 	}
 	fill_comp_msg(sess, msg, req);
 	msg->tag = tag;

--- a/wd_dh.c
+++ b/wd_dh.c
@@ -422,8 +422,10 @@ int wd_do_dh_async(handle_t sess, struct wd_dh_req *req)
 	ctx = config->ctxs + idx;
 
 	mid = wd_get_msg_from_pool(&wd_dh_setting.pool, idx, (void **)&msg);
-	if (mid < 0)
-		return -WD_EBUSY;
+	if (unlikely(mid < 0)) {
+		WD_ERR("failed to get msg from pool!\n");
+		return mid;
+	}
 
 	ret = fill_dh_msg(msg, req, (struct wd_dh_sess *)sess);
 	if (ret)

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -706,8 +706,8 @@ int wd_do_digest_async(handle_t h_sess, struct wd_digest_req *req)
 	msg_id = wd_get_msg_from_pool(&wd_digest_setting.pool, idx,
 				   (void **)&msg);
 	if (unlikely(msg_id < 0)) {
-		WD_ERR("busy, failed to get msg from pool!\n");
-		return -WD_EBUSY;
+		WD_ERR("failed to get msg from pool!\n");
+		return msg_id;
 	}
 
 	fill_request_msg(msg, req, dsess);

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -2268,8 +2268,10 @@ int wd_do_ecc_async(handle_t sess, struct wd_ecc_req *req)
 	ctx = config->ctxs + idx;
 
 	mid = wd_get_msg_from_pool(&wd_ecc_setting.pool, idx, (void **)&msg);
-	if (mid < 0)
-		return -WD_EBUSY;
+	if (unlikely(mid < 0)) {
+		WD_ERR("failed to get msg from pool!\n");
+		return mid;
+	}
 
 	ret = fill_ecc_msg(msg, req, (struct wd_ecc_sess *)sess);
 	if (ret)

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -483,8 +483,10 @@ int wd_do_rsa_async(handle_t sess, struct wd_rsa_req *req)
 	ctx = config->ctxs + idx;
 
 	mid = wd_get_msg_from_pool(&wd_rsa_setting.pool, idx, (void **)&msg);
-	if (mid < 0)
-		return -WD_EBUSY;
+	if (unlikely(mid < 0)) {
+		WD_ERR("failed to get msg from pool!\n");
+		return mid;
+	}
 
 	ret = fill_rsa_msg(msg, req, (struct wd_rsa_sess *)sess);
 	if (ret)

--- a/wd_util.c
+++ b/wd_util.c
@@ -442,6 +442,10 @@ int wd_get_msg_from_pool(struct wd_async_msg_pool *pool,
 	__u32 cnt = 0;
 	__u32 idx = p->tail;
 
+	/* Scheduler set a sync ctx */
+	if (!msg_num)
+		return -WD_EINVAL;
+
 	while (__atomic_test_and_set(&p->used[idx], __ATOMIC_ACQUIRE)) {
 		idx = (idx + 1) % msg_num;
 		cnt++;

--- a/wd_zlibwrapper.c
+++ b/wd_zlibwrapper.c
@@ -220,9 +220,6 @@ static int wd_zlib_do_request(z_streamp strm, int flush, enum wd_comp_op_type ty
 	__u32 dst_len = strm->avail_out;
 	int ret;
 
-	if (unlikely(!strm))
-		return Z_STREAM_ERROR;
-
 	if (unlikely(flush != Z_SYNC_FLUSH && flush != Z_FINISH)) {
 		WD_ERR("invalid: flush is %d!\n", flush);
 		return Z_STREAM_ERROR;
@@ -267,12 +264,15 @@ int wd_deflate_init(z_streamp strm, int level, int windowbits)
 
 int wd_deflate(z_streamp strm, int flush)
 {
+	if (unlikely(!strm))
+		return Z_STREAM_ERROR;
+
 	return wd_zlib_do_request(strm, flush, WD_DIR_COMPRESS);
 }
 
 int wd_deflate_reset(z_streamp strm)
 {
-	if (!strm)
+	if (unlikely(!strm))
 		return Z_STREAM_ERROR;
 
 	wd_comp_reset_sess((handle_t)strm->reserved);


### PR DESCRIPTION
Qi Tao (3):
  acc/uadk: fix double-free error
  acc/uadk: fix queue configuration parameter error.
  uadk: fix the null pointer check error

 drv/hisi_comp.c        | 3 ++-
 drv/hisi_hpre.c        | 3 ++-
 v1/drv/hisi_zip_udrv.c | 3 ++-
 wd.c                   | 3 ---
 wd_aead.c              | 2 +-
 wd_agg.c               | 4 ++--
 wd_cipher.c            | 4 ++--
 wd_comp.c              | 2 +-
 wd_dh.c                | 6 ++++--
 wd_digest.c            | 4 ++--
 wd_ecc.c               | 6 ++++--
 wd_rsa.c               | 6 ++++--
 wd_util.c              | 4 ++++
 wd_zlibwrapper.c       | 8 ++++----
 14 files changed, 34 insertions(+), 24 deletions(-)
