### PR TITLE
cipher: remove req->out_bytes req->in_bytes check

### DIFF
--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -646,12 +646,6 @@ static int wd_cipher_check_params(handle_t h_sess,
 		return -WD_EINVAL;
 	}
 
-	if (unlikely(req->in_bytes != req->out_bytes)) {
-		WD_ERR("cipher set out_bytes is error, size = %u\n",
-			req->out_bytes);
-		return -WD_EINVAL;
-	}
-
 	ret = cipher_in_len_check(h_sess, req);
 	if (unlikely(ret))
 		return ret;


### PR DESCRIPTION
Commit "d99d0e2 uadk: fix for cipher update iv" add check for req->out_bytes req->in_bytes, however, this breaks uadk_engine and uadk_provider,

Remove this check first, until uadk_engine and uadk_provider patches are ready.