### PR TITLE
uadk: fix code compatibility issue

### DIFF
--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -751,7 +751,7 @@ static void update_iv(struct wd_cipher_msg *msg)
 				msg->iv_bytes, msg->iv_bytes);
 		break;
 	case WD_CIPHER_OFB:
-		if (msg->in_bytes < msg->iv_bytes)
+		if (msg->in_bytes < msg->iv_bytes || msg->out_bytes < msg->iv_bytes)
 			break;
 		/* The iv_bytes has been checked and it is not greater than AES_BLOCK_SIZE. */
 		for (i = 0; i < msg->iv_bytes; i++)
@@ -793,7 +793,7 @@ static void update_iv_sgl(struct wd_cipher_msg *msg)
 		break;
 	case WD_CIPHER_OFB:
 		/* The iv_bytes has been checked and it is not greater than AES_BLOCK_SIZE. */
-		if (msg->in_bytes >= msg->iv_bytes) {
+		if (msg->in_bytes >= msg->iv_bytes && msg->out_bytes >= msg->iv_bytes) {
 			hisi_qm_sgl_copy(in, msg->in,
 					 msg->in_bytes - msg->iv_bytes,
 					 msg->iv_bytes, COPY_SGL_TO_PBUFF);

--- a/include/drv/wd_agg_drv.h
+++ b/include/drv/wd_agg_drv.h
@@ -8,6 +8,7 @@
 
 #include <asm/types.h>
 #include "wd_agg.h"
+#include "wd_util.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/wd_agg.h
+++ b/include/wd_agg.h
@@ -8,7 +8,6 @@
 
 #include <dlfcn.h>
 #include <asm/types.h>
-#include "wd_util.h"
 #include "wd_dae.h"
 
 #ifdef __cplusplus

--- a/include/wd_dae.h
+++ b/include/wd_dae.h
@@ -9,6 +9,7 @@
 #include <dlfcn.h>
 #include <stdbool.h>
 #include <asm/types.h>
+#include "wd_alg_common.h"
 #include "wd.h"
 
 #ifdef __cplusplus

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -646,12 +646,6 @@ static int wd_cipher_check_params(handle_t h_sess,
 		return -WD_EINVAL;
 	}
 
-	if (unlikely(req->in_bytes != req->out_bytes)) {
-		WD_ERR("cipher set out_bytes is error, size = %u\n",
-			req->out_bytes);
-		return -WD_EINVAL;
-	}
-
 	ret = cipher_in_len_check(h_sess, req);
 	if (unlikely(ret))
 		return ret;


### PR DESCRIPTION
  Qi Tao (2):
    uadk: fix for hashagg include files
    uadk: fix code compatibility issue
 
   drv/hisi_sec.c           | 4 ++--
   include/drv/wd_agg_drv.h | 1 +
   include/wd_agg.h         | 1 -
   include/wd_dae.h         | 1 +
   wd_cipher.c              | 6 ------
   5 files changed, 4 insertions(+), 9 deletions(-)
