### PR TITLE
uadk_tool: comp_lib build error on OpenSSL 3.0

### DIFF
--- a/uadk_tool/Makefile.am
+++ b/uadk_tool/Makefile.am
@@ -19,8 +19,7 @@ uadk_tool_SOURCES=uadk_tool.c dfx/uadk_dfx.c dfx/uadk_dfx.h \
 		benchmark/zip_wd_benchmark.c benchmark/zip_wd_benchmark.h \
 		benchmark/trng_wd_benchmark.c benchmark/trng_wd_benchmark.h \
 		test/uadk_test.c test/uadk_test.h \
-		test/test_sec.c test/test_sec.h test/sec_template_tv.h \
-		test/comp_main.c test/comp_main.h test/comp_lib.c test/comp_lib.h
+		test/test_sec.c test/test_sec.h test/sec_template_tv.h
 
 if WD_STATIC_DRV
 AM_CFLAGS+=-Bstatic
@@ -51,6 +50,7 @@ uadk_tool_LDADD+= $(with_zlib_fse_dir)/libfse.a
 endif
 
 if HAVE_CRYPTO
-uadk_tool_SOURCES+=benchmark/sec_soft_benchmark.c benchmark/sec_soft_benchmark.h
+uadk_tool_SOURCES+=benchmark/sec_soft_benchmark.c benchmark/sec_soft_benchmark.h \
+		   test/comp_main.c test/comp_main.h test/comp_lib.c test/comp_lib.h
 uadk_tool_LDADD+=$(libcrypto_LIBS)
 endif

--- a/uadk_tool/test/uadk_test.c
+++ b/uadk_tool/test/uadk_test.c
@@ -62,8 +62,10 @@ void acc_test_run(int argc, char *argv[])
 				(void)test_hpre_entry(argc, argv);
 			} else if (!strcmp(input_module, "sec")) {
 				(void)test_sec_entry(argc, argv);
+#ifdef HAVE_CRYPTO
 			} else if (!strcmp(input_module, "zip")) {
 				(void)test_comp_entry(argc, argv);
+#endif
 			} else {
 				print_test_help();
 				printf("failed to parse module parameter!\n");


### PR DESCRIPTION
On OpenSSL 3.0 comp_lib build error

test/comp_lib.c: In function 'calculate_md5':
test/comp_lib.c:258:9: error: 'MD5_Init' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
  258 |         MD5_Init(&md5->md5_ctx);
      |         ^~~~~~~~
In file included from test/comp_lib.h:11,
                 from test/comp_lib.c:14:
/usr/local/include/openssl/md5.h:49:27: note: declared here
   49 | OSSL_DEPRECATEDIN_3_0 int MD5_Init(MD5_CTX *c);
      |                           ^~~~~~~~
test/comp_lib.c:259:9: error: 'MD5_Update' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
  259 |         MD5_Update(&md5->md5_ctx, buf, len);
      |         ^~~~~~~~~~
/usr/local/include/openssl/md5.h:50:27: note: declared here
   50 | OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
      |                           ^~~~~~~~~~
test/comp_lib.c:260:9: error: 'MD5_Final' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
  260 |         MD5_Final(md5->md, &md5->md5_ctx);
      |         ^~~~~~~~~
/usr/local/include/openssl/md5.h:51:27: note: declared here
   51 | OSSL_DEPRECATEDIN_3_0 int MD5_Final(unsigned char *md, MD5_CTX *c);
      |                           ^~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:773: test/uadk_tool-comp_lib.o] Error 1
make[1]: Leaving directory '/mnt/uadk/uadk_tool'
make: *** [Makefile:1144: install-recursive] Error 1

Fixed by checking #ifdef HAVE_CRYPTO