### PR TITLE
uadk: add new algs and bugfix 

### DIFF
--- a/drv/hash_mb/hash_mb.c
+++ b/drv/hash_mb/hash_mb.c
@@ -427,6 +427,8 @@ static int hash_do_partial(struct hash_mb_poll_queue *poll_queue,
 			total_len += HASH_BLOCK_SIZE;
 		hash_signle_block_process(d_msg, job, total_len);
 		break;
+	default:
+		break;
 	}
 
 	return ret;
@@ -480,6 +482,8 @@ static void hash_mb_init_iv(struct hash_mb_poll_queue *poll_queue,
 		job->buffer = key_ipad;
 		memcpy(job->result_digest, poll_queue->ops->iv_data, poll_queue->ops->iv_bytes);
 		poll_queue->ops->asimd_x1(job, 1);
+		break;
+	default:
 		break;
 	}
 }

--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -194,7 +194,7 @@ struct hisi_zip_ctx {
 static void dump_zip_msg(struct wd_comp_msg *msg)
 {
 	WD_ERR("dump zip message after a task error occurs.\n");
-	WD_ERR("avali_out:%u in_cons:%u produced:%u data_fmt:%d.\n",
+	WD_ERR("avali_out:%u in_cons:%u produced:%u data_fmt:%u.\n",
 		msg->avail_out, msg->in_cons, msg->produced, msg->data_fmt);
 }
 
@@ -653,7 +653,7 @@ static int fill_comp_level_lz77_zstd(struct hisi_zip_sqe *sqe, enum wd_comp_leve
 		sqe->dw9 = val;
 		break;
 	default:
-		WD_ERR("invalid: comp_lv(%d) is unsupport!\n", comp_lv);
+		WD_ERR("invalid: comp_lv(%u) is unsupport!\n", comp_lv);
 		return -WD_EINVAL;
 	}
 
@@ -870,7 +870,7 @@ static int fill_zip_comp_sqe(struct hisi_qp *qp, struct wd_comp_msg *msg,
 
 	if (unlikely((hw_type <= HISI_QM_API_VER2_BASE && alg_type > WD_GZIP) ||
 		     (hw_type >= HISI_QM_API_VER3_BASE && alg_type >= WD_COMP_ALG_MAX))) {
-		WD_ERR("invalid: algorithm type is %d!\n", alg_type);
+		WD_ERR("invalid: algorithm type is %u!\n", alg_type);
 		return -WD_EINVAL;
 	}
 

--- a/drv/hisi_dae.c
+++ b/drv/hisi_dae.c
@@ -303,6 +303,8 @@ static void fill_hashagg_task_type(struct wd_agg_msg *msg, struct dae_sqe *sqe)
 	case WD_AGG_REHASH_OUTPUT:
 		sqe->task_type_ext = DAE_HASHAGG_OUTPUT;
 		break;
+	default:
+		break;
 	}
 }
 
@@ -351,6 +353,8 @@ static void fill_hashagg_table_data(struct dae_sqe *sqe, struct dae_addr_list *a
 	case WD_AGG_REHASH_OUTPUT:
 		hw_table = &addr_list->src_table;
 		table_data = &agg_ctx->rehash_table;
+		break;
+	default:
 		break;
 	}
 
@@ -472,6 +476,8 @@ static void fill_hashagg_input_data(struct dae_sqe *sqe, struct dae_ext_sqe *ext
 		usr_agg_addr = msg->req.out_agg_cols;
 		agg_col_num = cols_data->output_num;
 		fill_hashagg_normal_info(sqe, ext_sqe, cols_data, cols_data->input_num);
+		break;
+	default:
 		break;
 	}
 
@@ -640,7 +646,7 @@ static void fill_hashagg_msg_task_err(struct dae_sqe *sqe, struct wd_agg_msg *ms
 		break;
 	default:
 		WD_ERR("failed to do hashagg task! done_flag=0x%x, etype=0x%x, ext_type = 0x%x!\n",
-			sqe->done_flag, sqe->err_type, sqe->ext_err_type);
+			(__u32)sqe->done_flag, (__u32)sqe->err_type, (__u32)sqe->ext_err_type);
 		msg->result = WD_AGG_PARSE_ERROR;
 		break;
 	}
@@ -751,7 +757,7 @@ static int agg_get_output_num(enum wd_dae_data_type type,
 		(*size16)++;
 		break;
 	default:
-		WD_ERR("invalid: output data type %d not support!\n", type);
+		WD_ERR("invalid: output data type %u not support!\n", type);
 		return -WD_EINVAL;
 	}
 
@@ -808,7 +814,7 @@ static int hashagg_init_param_check(struct wd_agg_sess_setup *setup)
 	}
 
 	if (setup->is_count_all && setup->count_all_data_type != WD_DAE_LONG) {
-		WD_ERR("invalid: count all output data type %d error,  only support long!\n",
+		WD_ERR("invalid: count all output data type %u error,  only support long!\n",
 			setup->count_all_data_type);
 		return -WD_EINVAL;
 	}
@@ -834,6 +840,8 @@ static __u32 hashagg_get_data_type_size(enum dae_data_type type, __u16 data_info
 		return ALIGN(data_info, DAE_CHAR_ALIGN_SIZE);
 	case DAE_VCHAR:
 		return data_info;
+	default:
+		break;
 	}
 
 	return 0;
@@ -873,7 +881,7 @@ static int transfer_key_col_info(struct wd_key_col_info *key_cols,
 			key_data[i].hw_type = DAE_SINT32;
 			break;
 		default:
-			WD_ERR("invalid: unsupport key col %u data type %d!\n",
+			WD_ERR("invalid: unsupport key col %u data type %u!\n",
 				i, key_cols[i].input_data_type);
 			return -WD_EINVAL;
 		}
@@ -948,7 +956,7 @@ static int hashagg_check_sum_info(struct wd_agg_col_info *agg_col,
 	switch (agg_col->input_data_type) {
 	case WD_DAE_LONG:
 		if (agg_col->output_data_types[index] != WD_DAE_LONG) {
-			WD_ERR("invalid: long type do sum output data type %d error!\n",
+			WD_ERR("invalid: long type do sum output data type %u error!\n",
 				agg_col->output_data_types[index]);
 			return -WD_EINVAL;
 		}
@@ -971,7 +979,7 @@ static int hashagg_check_sum_info(struct wd_agg_col_info *agg_col,
 			user_input_data->sum_outtype = DECIMAL64_TO_DECIMAL128;
 			user_output_data->hw_type = DAE_DECIMAL128;
 		} else {
-			WD_ERR("invalid: short decimal do sum output data type %d error!\n",
+			WD_ERR("invalid: short decimal do sum output data type %u error!\n",
 				agg_col->output_data_types[index]);
 			return -WD_EINVAL;
 		}
@@ -979,7 +987,7 @@ static int hashagg_check_sum_info(struct wd_agg_col_info *agg_col,
 		break;
 	case WD_DAE_LONG_DECIMAL:
 		if (agg_col->output_data_types[index] != WD_DAE_LONG_DECIMAL) {
-			WD_ERR("invalid: long decimal do sum output data type %d error!\n",
+			WD_ERR("invalid: long decimal do sum output data type %u error!\n",
 				agg_col->output_data_types[index]);
 			return -WD_EINVAL;
 		}
@@ -990,7 +998,7 @@ static int hashagg_check_sum_info(struct wd_agg_col_info *agg_col,
 		user_output_data->hw_type = DAE_DECIMAL128;
 		break;
 	default:
-		WD_ERR("invalid: device not support col data type %d do sum!\n",
+		WD_ERR("invalid: device not support col data type %u do sum!\n",
 			agg_col->input_data_type);
 		return -WD_EINVAL;
 	}
@@ -1002,12 +1010,12 @@ static int hashagg_check_count_info(enum wd_dae_data_type input_type,
 				    enum wd_dae_data_type output_type)
 {
 	if (input_type > WD_DAE_VARCHAR) {
-		WD_ERR("invalid: device not support agg col data type %d do count!\n", input_type);
+		WD_ERR("invalid: device not support agg col data type %u do count!\n", input_type);
 		return -WD_EINVAL;
 	}
 
 	if (output_type != WD_DAE_LONG) {
-		WD_ERR("invalid: input data type %d do count output data type %d error!\n",
+		WD_ERR("invalid: input data type %u do count output data type %u error!\n",
 			input_type, output_type);
 		return -WD_EINVAL;
 	}
@@ -1039,7 +1047,7 @@ static int hashagg_check_input_data(struct wd_agg_col_info *agg_col,
 		user_output_data->optype = DAE_COUNT;
 		break;
 	default:
-		WD_ERR("invalid: device not support alg %d!\n", agg_col->output_col_algs[index]);
+		WD_ERR("invalid: device not support alg %u!\n", agg_col->output_col_algs[index]);
 		return -WD_EINVAL;
 	}
 	user_output_data->data_info = agg_col->col_data_info;
@@ -1487,7 +1495,7 @@ static int dae_std_table_init(struct hash_table_data *hw_table,
 		return -WD_EINVAL;
 	}
 
-	hw_table->table_width = log2(row_num);
+	hw_table->table_width = (__u32)log2(row_num);
 	if (hw_table->table_width < HASH_TABLE_MIN_WIDTH ||
 	    hw_table->table_width > HASH_TABLE_MAX_WIDTH) {
 		WD_ERR("invalid: standard table width %u is out of device support range %d~%d!\n",
@@ -1495,7 +1503,7 @@ static int dae_std_table_init(struct hash_table_data *hw_table,
 		return -WD_EINVAL;
 	}
 
-	row_num = pow(HASH_TABLE_WITDH_POWER, hw_table->table_width);
+	row_num = (__u64)pow(HASH_TABLE_WITDH_POWER, hw_table->table_width);
 	hw_table->std_table_size = row_num * row_size;
 	memset(hw_table->std_table, 0, hw_table->std_table_size);
 

--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -967,7 +967,7 @@ static int ecc_prepare_prikey(struct wd_ecc_key *key, void **data, int id)
 	struct wd_dtb *b = NULL;
 	struct wd_dtb *n = NULL;
 	struct wd_dtb *d = NULL;
-	char bsize, dsize;
+	__u32 bsize, dsize;
 	char *dat;
 	int ret;
 
@@ -980,6 +980,10 @@ static int ecc_prepare_prikey(struct wd_ecc_key *key, void **data, int id)
 	ret = trans_d_to_hpre_bin(d);
 	if (ret)
 		return ret;
+
+	/* X448 will do specific offset */
+	if (id != WD_X448)
+		d->dsize = d->bsize;
 
 	/*
 	 * This is a pretreatment of X25519/X448, as described in RFC 7748:
@@ -1007,12 +1011,6 @@ static int ecc_prepare_prikey(struct wd_ecc_key *key, void **data, int id)
 
 	if (!big_than_one(dat, bsize)) {
 		WD_ERR("failed to prepare ecc prikey: d <= 1!\n");
-		return -WD_EINVAL;
-	}
-
-	if (id != WD_X25519 && id != WD_X448 &&
-		!less_than_latter(d, n)) {
-		WD_ERR("failed to prepare ecc prikey: d >= n!\n");
 		return -WD_EINVAL;
 	}
 

--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -646,10 +646,10 @@ static void hpre_result_check(struct hisi_hpre_sqe *hw_msg,
 	if (hw_msg->done != HPRE_HW_TASK_DONE ||
 			hw_msg->etype || hw_msg->etype1) {
 		WD_ERR("failed to do hpre task! done=0x%x, etype=0x%x, etype1=0x%x!\n",
-			hw_msg->done, hw_msg->etype, hw_msg->etype1);
+			(__u32)hw_msg->done, (__u32)hw_msg->etype, (__u32)hw_msg->etype1);
 		if (hw_msg->etype1 & HPRE_HW_SVA_ERROR)
 			WD_ERR("failed to SVA prefetch: status=%u!\n",
-				hw_msg->sva_status);
+				(__u32)hw_msg->sva_status);
 		if (hw_msg->done == HPRE_HW_TASK_INIT)
 			*result = WD_EINVAL;
 		else
@@ -2032,7 +2032,7 @@ static int ecc_out_transfer(struct wd_ecc_msg *msg,
 		 hw_msg->alg == HPRE_ALG_X_DH_MULTIPLY)
 		ret = ecdh_out_transfer(msg, hw_msg);
 	else
-		WD_ERR("invalid: algorithm type %u is error!\n", hw_msg->alg);
+		WD_ERR("invalid: algorithm type %u is error!\n", (__u32)hw_msg->alg);
 
 	return ret;
 }

--- a/drv/hisi_sec.c
+++ b/drv/hisi_sec.c
@@ -2518,7 +2518,7 @@ static int fill_aead_bd2(struct wd_aead_msg *msg, struct hisi_sec_sqe *sqe)
 	return 0;
 }
 
-int aead_msg_state_check(struct wd_aead_msg *msg)
+static int aead_msg_state_check(struct wd_aead_msg *msg)
 {
 	if (msg->cmode == WD_CIPHER_GCM) {
 		if (unlikely(msg->msg_state >= AEAD_MSG_INVALID)) {

--- a/include/wd_rsa.h
+++ b/include/wd_rsa.h
@@ -161,8 +161,6 @@ handle_t wd_rsa_alloc_sess(struct wd_rsa_sess_setup *setup);
  */
 void wd_rsa_free_sess(handle_t sess);
 
-int wd_do_rsa_async(handle_t sess, struct wd_rsa_req *req);
-
 int wd_rsa_poll(__u32 expt, __u32 *count);
 
 /**

--- a/include/wd_util.h
+++ b/include/wd_util.h
@@ -98,12 +98,12 @@ struct wd_env_config {
 
 struct wd_config_variable {
 	const char *name;
-	char *def_val;
+	const char *def_val;
 	int (*parse_fn)(struct wd_env_config *, const char *);
 };
 
 struct wd_alg_ops {
-	char *alg_name;
+	const char *alg_name;
 	__u8 op_type_num;
 	int (*alg_init)(struct wd_ctx_config *, struct wd_sched *);
 	void (*alg_uninit)(void);
@@ -124,7 +124,7 @@ struct wd_msg_handle {
 
 struct wd_init_attrs {
 	__u32 sched_type;
-	char *alg;
+	const char *alg;
 	struct wd_alg_driver *driver;
 	struct wd_sched *sched;
 	struct wd_ctx_params *ctx_params;
@@ -476,7 +476,7 @@ void wd_alg_attrs_uninit(struct wd_init_attrs *attrs);
  *
  * Return device driver if succeed and other NULL if fail.
  */
-struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name);
+struct wd_alg_driver *wd_alg_drv_bind(int task_type, const char *alg_name);
 void wd_alg_drv_unbind(struct wd_alg_driver *drv);
 
 /**
@@ -506,7 +506,7 @@ void wd_dlclose_drv(void *dlh_list);
  * @lib_path: the found dynamic library file path.
  * @is_dir: Specify whether to query the file dir or the file path.
  */
-int wd_get_lib_file_path(char *lib_file, char *lib_path, bool is_dir);
+int wd_get_lib_file_path(const char *lib_file, char *lib_path, bool is_dir);
 
 /**
  * wd_dfx_msg_cnt() - Message counter interface for ctx

--- a/uadk_tool/benchmark/sec_uadk_benchmark.c
+++ b/uadk_tool/benchmark/sec_uadk_benchmark.c
@@ -1356,6 +1356,12 @@ static void *sec_uadk_aead_async(void *arg)
 			break;
 		try_cnt = 0;
 		i = count % MAX_POOL_LENTH;
+
+		if (i == 0 && count > 0) {
+			count++;
+			continue;
+		}
+
 		areq.src = uadk_pool->bds[i].src;
 		areq.dst = uadk_pool->bds[i].dst;
 		areq.mac = uadk_pool->bds[i].mac;

--- a/v1/drv/hisi_hpre_udrv.c
+++ b/v1/drv/hisi_hpre_udrv.c
@@ -854,14 +854,8 @@ static int trans_cv_param_to_hpre_bin(struct wd_dtb *p, struct wd_dtb *a,
 
 static int trans_d_to_hpre_bin(struct wd_dtb *d)
 {
-	int ret;
-
-	ret = qm_crypto_bin_to_hpre_bin(d->data, (const char *)d->data,
+	return qm_crypto_bin_to_hpre_bin(d->data, (const char *)d->data,
 					d->bsize, d->dsize, "ecc d");
-	if (unlikely(ret))
-		return ret;
-
-	return 0;
 }
 
 static bool less_than_latter(struct wd_dtb *d, struct wd_dtb *n)

--- a/v1/drv/hisi_hpre_udrv.c
+++ b/v1/drv/hisi_hpre_udrv.c
@@ -889,7 +889,7 @@ static int ecc_prepare_prikey(struct wcrypto_ecc_key *key, void **data, int id)
 	struct wd_dtb *b = NULL;
 	struct wd_dtb *n = NULL;
 	struct wd_dtb *d = NULL;
-	char bsize, dsize;
+	__u32 bsize, dsize;
 	char *dat;
 	int ret;
 
@@ -902,6 +902,10 @@ static int ecc_prepare_prikey(struct wcrypto_ecc_key *key, void **data, int id)
 	ret = trans_d_to_hpre_bin(d);
 	if (unlikely(ret))
 		return ret;
+
+	/* X448 will do specific offset */
+	if (id != WCRYPTO_X448)
+		d->dsize = d->bsize;
 
 	dat = d->data;
 	bsize = d->bsize;
@@ -926,12 +930,6 @@ static int ecc_prepare_prikey(struct wcrypto_ecc_key *key, void **data, int id)
 	} else if (id == WCRYPTO_X448) {
 		dat[55 + bsize - dsize] &= 252;
 		dat[0 + bsize - dsize] |= 128;
-	}
-
-	if (id != WCRYPTO_X25519 && id != WCRYPTO_X448 &&
-	    !less_than_latter(d, n)) {
-		WD_ERR("failed to prepare ecc prikey: d >= n!\n");
-		return -WD_EINVAL;
 	}
 
 	*data = p->data;

--- a/v1/drv/hisi_hpre_udrv.c
+++ b/v1/drv/hisi_hpre_udrv.c
@@ -533,7 +533,7 @@ int qm_parse_rsa_sqe(void *msg, const struct qm_queue_info *info,
 	kbytes = rsa_msg->key_bytes;
 	if (hw_msg->done != HPRE_HW_TASK_DONE || hw_msg->etype) {
 		WD_ERR("HPRE do %s fail!done=0x%x, etype=0x%x\n", "rsa",
-			hw_msg->done, hw_msg->etype);
+			(__u32)hw_msg->done, (__u32)hw_msg->etype);
 		if (hw_msg->done == HPRE_HW_TASK_INIT) {
 			rsa_msg->result = WD_EINVAL;
 		} else { /* Need to identify which hw err happened */
@@ -740,7 +740,7 @@ int qm_parse_dh_sqe(void *msg, const struct qm_queue_info *info,
 		return 0;
 	if (hw_msg->done != HPRE_HW_TASK_DONE || hw_msg->etype) {
 		WD_ERR("HPRE do %s fail!done=0x%x, etype=0x%x\n", "dh",
-			hw_msg->done, hw_msg->etype);
+			(__u32)hw_msg->done, (__u32)hw_msg->etype);
 		if (hw_msg->done == HPRE_HW_TASK_INIT) {
 			dh_msg->result = WD_EINVAL;
 			ret = -WD_EINVAL;
@@ -1639,7 +1639,7 @@ static int qm_ecc_out_transfer(struct wcrypto_ecc_msg *msg,
 	else if (hw_msg->alg == HPRE_ALG_SM2_KEY_GEN)
 		ret = sm2_kg_out_transfer(msg, hw_msg);
 	else
-		WD_ERR("ecc out trans fail alg %u error!\n", hw_msg->alg);
+		WD_ERR("ecc out trans fail alg %u error!\n", (__u32)hw_msg->alg);
 
 	return ret;
 }
@@ -2032,7 +2032,7 @@ static int qm_parse_ecc_sqe_general(void *msg, const struct qm_queue_info *info,
 	if (hw_msg->done != HPRE_HW_TASK_DONE ||
 			hw_msg->etype || hw_msg->etype1) {
 		WD_ERR("HPRE do ecc fail!done=0x%x, etype=0x%x, etype1=0x%x\n",
-			hw_msg->done, hw_msg->etype, hw_msg->etype1);
+			(__u32)hw_msg->done, (__u32)hw_msg->etype, (__u32)hw_msg->etype1);
 
 		if (hw_msg->done == HPRE_HW_TASK_INIT)
 			ecc_msg->result = WD_EINVAL;

--- a/v1/drv/hisi_qm_udrv.c
+++ b/v1/drv/hisi_qm_udrv.c
@@ -41,7 +41,7 @@
  * a sge size: 1B ~ 8M;
  * data in little-endian in sgl;
  */
-int qm_hw_sgl_info(struct hw_sgl_info *sgl_info)
+static int qm_hw_sgl_info(struct hw_sgl_info *sgl_info)
 {
 	sgl_info->sge_sz = sizeof(struct hisi_sge);
 	sgl_info->sge_align_sz = HISI_SGL_SGE_ALIGN_SZ;
@@ -75,7 +75,7 @@ static int qm_hw_sgl_sge_init(struct wd_sgl *sgl, struct hisi_sgl *hisi_sgl,
 }
 
 /* 'num' starts from 1 */
-void qm_hw_sgl_sge_uninit(struct wd_sgl *sgl, struct hisi_sgl *hisi_sgl,
+static void qm_hw_sgl_sge_uninit(struct wd_sgl *sgl, struct hisi_sgl *hisi_sgl,
 			  int num, struct wd_mm_br *br, __u32 buf_sz)
 {
 	void *buf;
@@ -88,7 +88,7 @@ void qm_hw_sgl_sge_uninit(struct wd_sgl *sgl, struct hisi_sgl *hisi_sgl,
 		       buf, buf_sz);
 }
 
-int qm_hw_sgl_init(void *pool, struct wd_sgl *sgl)
+static int qm_hw_sgl_init(void *pool, struct wd_sgl *sgl)
 {
 	int buf_num = wd_get_sgl_buf_num(sgl);
 	int sge_num = wd_get_sgl_sge_num(sgl);
@@ -148,7 +148,7 @@ sgl_sge_init_err:
 	return ret;
 }
 
-void qm_hw_sgl_uninit(void *pool, struct wd_sgl *sgl)
+static void qm_hw_sgl_uninit(void *pool, struct wd_sgl *sgl)
 {
 	struct hisi_sgl *hisi_sgl = drv_get_sgl_pri(sgl);
 	int buf_num = wd_get_sgl_buf_num(sgl);
@@ -181,7 +181,7 @@ void qm_hw_sgl_uninit(void *pool, struct wd_sgl *sgl)
 	br->free(br->usr, hisi_sgl);
 }
 
-int qm_hw_sgl_merge(void *pool, struct wd_sgl *dst_sgl, struct wd_sgl *src_sgl)
+static int qm_hw_sgl_merge(void *pool, struct wd_sgl *dst_sgl, struct wd_sgl *src_sgl)
 {
 	struct hisi_sgl *d = drv_get_sgl_pri(dst_sgl);
 	struct hisi_sgl *s = drv_get_sgl_pri(src_sgl);
@@ -201,7 +201,7 @@ int qm_hw_sgl_merge(void *pool, struct wd_sgl *dst_sgl, struct wd_sgl *src_sgl)
 	return WD_SUCCESS;
 }
 
-int qm_db_v1(struct qm_queue_info *q, __u8 cmd,
+static int qm_db_v1(struct qm_queue_info *q, __u8 cmd,
 	       __u16 idx, __u8 priority)
 {
 	void *base = q->doorbell_base;

--- a/v1/drv/hisi_qm_udrv.h
+++ b/v1/drv/hisi_qm_udrv.h
@@ -166,8 +166,8 @@ struct qm_queue_info {
 	qm_sqe_parse sqe_parse[WCRYPTO_MAX_ALG];
 	hisi_qm_sqe_fill_priv sqe_fill_priv;
 	hisi_qm_sqe_parse_priv sqe_parse_priv;
-	pthread_spinlock_t sd_lock;
-	pthread_spinlock_t rc_lock;
+	struct wd_fair_lock sd_lock;
+	struct wd_fair_lock rc_lock;
 	struct wd_queue *q;
 	int (*sgl_info)(struct hw_sgl_info *info);
 	int (*sgl_init)(void *pool, struct wd_sgl *sgl);

--- a/v1/drv/hisi_sec_udrv.c
+++ b/v1/drv/hisi_sec_udrv.c
@@ -1797,7 +1797,7 @@ static void parse_cipher_bd1(struct wd_queue *q, struct hisi_sec_sqe *sqe,
 
 	if (sqe->type1.done != SEC_HW_TASK_DONE || sqe->type1.error_type) {
 		WD_ERR("SEC BD1 %s fail!done=0x%x, etype=0x%x\n", "cipher",
-		sqe->type1.done, sqe->type1.error_type);
+		(__u32)sqe->type1.done, (__u32)sqe->type1.error_type);
 		cipher_msg->result = WD_IN_EPARA;
 	} else {
 		if (sqe->type1.dif_check == DIF_VERIFY_FAIL)
@@ -1868,7 +1868,7 @@ static void parse_cipher_bd2(struct wd_queue *q, struct hisi_sec_sqe *sqe,
 
 	if (sqe->type2.done != SEC_HW_TASK_DONE || sqe->type2.error_type) {
 		WD_ERR("SEC BD2 %s fail!done=0x%x, etype=0x%x\n", "cipher",
-		sqe->type2.done, sqe->type2.error_type);
+		(__u32)sqe->type2.done, (__u32)sqe->type2.error_type);
 		cipher_msg->result = WD_IN_EPARA;
 	} else
 		cipher_msg->result = WD_SUCCESS;
@@ -1908,7 +1908,7 @@ static void parse_cipher_bd3(struct wd_queue *q, struct hisi_sec_bd3_sqe *sqe,
 
 	if (sqe->done != SEC_HW_TASK_DONE || sqe->error_type) {
 		WD_ERR("Fail to parse SEC BD3 %s, done=0x%x, etype=0x%x\n", "cipher",
-		sqe->done, sqe->error_type);
+		(__u32)sqe->done, (__u32)sqe->error_type);
 		cipher_msg->result = WD_IN_EPARA;
 	} else {
 		cipher_msg->result = WD_SUCCESS;
@@ -2021,7 +2021,7 @@ static void parse_digest_bd1(struct wd_queue *q, struct hisi_sec_sqe *sqe,
 	if (sqe->type1.done != SEC_HW_TASK_DONE
 		|| sqe->type1.error_type) {
 		WD_ERR("SEC BD1 %s fail!done=0x%x, etype=0x%x\n", "digest",
-		sqe->type1.done, sqe->type1.error_type);
+		(__u32)sqe->type1.done, (__u32)sqe->type1.error_type);
 		digest_msg->result = WD_IN_EPARA;
 	} else {
 		if (sqe->type1.dif_check == DIF_VERIFY_FAIL)
@@ -2047,7 +2047,7 @@ static void parse_digest_bd2(struct wd_queue *q, struct hisi_sec_sqe *sqe,
 	if (sqe->type2.done != SEC_HW_TASK_DONE
 		|| sqe->type2.error_type) {
 		WD_ERR("SEC BD2 %s fail!done=0x%x, etype=0x%x\n", "digest",
-		sqe->type2.done, sqe->type2.error_type);
+		(__u32)sqe->type2.done, (__u32)sqe->type2.error_type);
 		digest_msg->result = WD_IN_EPARA;
 	} else
 		digest_msg->result = WD_SUCCESS;
@@ -2574,7 +2574,7 @@ static void parse_aead_bd3(struct wd_queue *q, struct hisi_sec_bd3_sqe *sqe3,
 	if (sqe3->done != SEC_HW_TASK_DONE || sqe3->error_type ||
 	    sqe3->icv == SEC_HW_ICV_ERR) {
 		WD_ERR("SEC BD3 aead fail! done=0x%x, etype=0x%x, icv=0x%x\n",
-		sqe3->done, sqe3->error_type, sqe3->icv);
+		(__u32)sqe3->done, (__u32)sqe3->error_type, (__u32)sqe3->icv);
 		msg->result = WD_IN_EPARA;
 	} else {
 		msg->result = WD_SUCCESS;
@@ -2658,7 +2658,7 @@ static void parse_digest_bd3(struct wd_queue *q, struct hisi_sec_bd3_sqe *sqe,
 
 	if (sqe->done != SEC_HW_TASK_DONE || sqe->error_type) {
 		WD_ERR("SEC BD3 %s fail!done=0x%x, etype=0x%x\n", "digest",
-		sqe->done, sqe->error_type);
+		(__u32)sqe->done, (__u32)sqe->error_type);
 		digest_msg->result = WD_IN_EPARA;
 	} else {
 		digest_msg->result = WD_SUCCESS;
@@ -3163,7 +3163,7 @@ static void parse_aead_bd2(struct wd_queue *q, struct hisi_sec_sqe *sqe,
 	if (sqe->type2.done != SEC_HW_TASK_DONE || sqe->type2.error_type ||
 	    sqe->type2.icv == SEC_HW_ICV_ERR) {
 		WD_ERR("SEC BD2 aead fail! done=0x%x, etype=0x%x, icv=0x%x\n",
-		sqe->type2.done, sqe->type2.error_type, sqe->type2.icv);
+		(__u32)sqe->type2.done, (__u32)sqe->type2.error_type, (__u32)sqe->type2.icv);
 		msg->result = WD_IN_EPARA;
 	} else {
 		msg->result = WD_SUCCESS;

--- a/v1/test/hisi_sec_test/test_hisi_sec.c
+++ b/v1/test/hisi_sec_test/test_hisi_sec.c
@@ -163,7 +163,7 @@ static bool is_exit(struct test_sec_pthread_dt *pdata)
 	return false;
 }
 
-void hexdump(char *buf, int num)
+void hexdump(const char *buf, int num)
 {
 	int i;
 
@@ -1053,7 +1053,7 @@ static int sec_cipher_sync_test(int thread_num, __u64 lcore_mask,
 	    setup.block_num = MAX_BLOCK_NM;
 	    setup.align_size = SQE_SIZE;
 
-	    SEC_TST_PRT("create pool memory: %d\n", MAX_BLOCK_NM * setup.block_size);
+	    SEC_TST_PRT("create pool memory: %u\n", MAX_BLOCK_NM * setup.block_size);
 	    pool[j] = wd_blkpool_create(&q[j], &setup);
 	    if (!pool[j]) {
 			SEC_TST_PRT("%s(): create %dth pool fail!\n", __func__, j);

--- a/v1/wd_adapter.c
+++ b/v1/wd_adapter.c
@@ -150,7 +150,7 @@ void drv_free_slice(struct wd_queue *q)
 	}
 }
 
-void drv_add_slice(struct wd_queue *q, struct wd_ss_region *rgn)
+static void drv_add_slice(struct wd_queue *q, struct wd_ss_region *rgn)
 {
 	struct q_info *qinfo = q->qinfo;
 	struct wd_ss_region *rg;
@@ -167,7 +167,7 @@ void drv_add_slice(struct wd_queue *q, struct wd_ss_region *rgn)
 	TAILQ_INSERT_TAIL(&qinfo->ss_list, rgn, next);
 }
 
-void drv_show_ss_slices(struct wd_queue *q)
+static void drv_show_ss_slices(struct wd_queue *q)
 {
 	struct q_info *qinfo = q->qinfo;
 	struct wd_ss_region *rgn;

--- a/v1/wd_adapter.h
+++ b/v1/wd_adapter.h
@@ -37,7 +37,7 @@ struct hw_sgl_info {
 
 struct wd_drv_dio_if {
 	/* vendor tag which is used to select right vendor driver */
-	char *hw_type;
+	const char *hw_type;
 	/* user space WD queue initialize */
 	int (*open)(struct wd_queue *q);
 	/* user space WD queue uninitialize */

--- a/v1/wd_cipher.c
+++ b/v1/wd_cipher.c
@@ -297,7 +297,7 @@ static int cipher_key_len_check(struct wcrypto_cipher_ctx_setup *setup,
 			ret = -WD_EINVAL;
 		break;
 	default:
-		WD_ERR("cipher input alg err, alg is %d.\n", setup->alg);
+		WD_ERR("cipher input alg err, alg is %u.\n", setup->alg);
 		return -WD_EINVAL;
 	}
 

--- a/v1/wd_digest.c
+++ b/v1/wd_digest.c
@@ -106,13 +106,13 @@ static int create_ctx_para_check(struct wd_queue *q,
 	}
 
 	if (setup->alg >= WCRYPTO_MAX_DIGEST_TYPE) {
-		WD_ERR("invalid: the alg %d does not support!\n", setup->alg);
+		WD_ERR("invalid: the alg %u does not support!\n", setup->alg);
 		return -WD_EINVAL;
 	}
 
 	if (setup->mode == WCRYPTO_DIGEST_NORMAL &&
 	    setup->alg >= WCRYPTO_AES_XCBC_MAC_96) {
-		WD_ERR("invalid: the alg %d does not support normal mode!\n", setup->alg);
+		WD_ERR("invalid: the alg %u does not support normal mode!\n", setup->alg);
 		return -WD_EINVAL;
 	}
 
@@ -292,7 +292,7 @@ static int digest_hmac_key_check(enum wcrypto_digest_alg alg, __u16 key_len)
 		}
 		break;
 	default:
-		WD_ERR("failed to check digest key bytes, invalid alg type = %d\n", alg);
+		WD_ERR("failed to check digest key bytes, invalid alg type = %u\n", alg);
 		return -WD_EINVAL;
 	}
 

--- a/v1/wd_ecc.c
+++ b/v1/wd_ecc.c
@@ -78,7 +78,7 @@ struct wcrypto_ecc_ctx {
 
 struct wcrypto_ecc_curve_list {
 	__u32 id;
-	char *name;
+	const char *name;
 	__u32 key_bits;
 	__u8 data[MAX_CURVE_SIZE];
 };
@@ -1318,7 +1318,7 @@ int wcrypto_get_ecc_pubkey(struct wcrypto_ecc_key *ecc_key,
 	return WD_SUCCESS;
 }
 
-int wcrypto_get_ecc_curve(struct wcrypto_ecc_key *ecc_key,
+static int wcrypto_get_ecc_curve(struct wcrypto_ecc_key *ecc_key,
 			   struct wcrypto_ecc_curve **cv)
 {
 	if (unlikely(!ecc_key || !cv || !ecc_key->cv)) {
@@ -1670,7 +1670,7 @@ int wcrypto_do_ecxdh(void *ctx, struct wcrypto_ecc_op_data *opdata, void *tag)
 
 	if (unlikely(opdata->op_type != WCRYPTO_ECXDH_GEN_KEY &&
 		opdata->op_type != WCRYPTO_ECXDH_COMPUTE_KEY)) {
-		WD_ERR("do ecxdh: op_type = %d error!\n", opdata->op_type);
+		WD_ERR("do ecxdh: op_type = %u error!\n", opdata->op_type);
 		return -WD_EINVAL;
 	}
 
@@ -2189,7 +2189,7 @@ int wcrypto_do_ecdsa(void *ctx, struct wcrypto_ecc_op_data *opdata, void *tag)
 
 	if (unlikely(opdata->op_type != WCRYPTO_ECDSA_SIGN &&
 	    opdata->op_type != WCRYPTO_ECDSA_VERIFY)) {
-		WD_ERR("do ecdsa: op_type = %d error!\n", opdata->op_type);
+		WD_ERR("do ecdsa: op_type = %u error!\n", opdata->op_type);
 		return -WD_EINVAL;
 	}
 
@@ -2479,7 +2479,7 @@ int wcrypto_do_sm2(void *ctx, struct wcrypto_ecc_op_data *opdata, void *tag)
 		opdata->op_type != WCRYPTO_SM2_KG &&
 		opdata->op_type != WCRYPTO_SM2_ENCRYPT &&
 		opdata->op_type != WCRYPTO_SM2_DECRYPT)) {
-		WD_ERR("do sm2: op_type = %d error!\n", opdata->op_type);
+		WD_ERR("do sm2: op_type = %u error!\n", opdata->op_type);
 		return -WD_EINVAL;
 	}
 

--- a/v1/wd_util.h
+++ b/v1/wd_util.h
@@ -111,6 +111,11 @@ struct wd_lock {
 	__u8 lock;
 };
 
+struct wd_fair_lock {
+	__u32 ticket;
+	__u32 serving;
+};
+
 struct wd_ss_region {
 	void *va;
 	unsigned long long pa;
@@ -392,6 +397,9 @@ static inline uint32_t wd_reg_read(void *reg_addr)
 
 void wd_spinlock(struct wd_lock *lock);
 void wd_unspinlock(struct wd_lock *lock);
+void wd_fair_init(struct wd_fair_lock *lock);
+void wd_fair_lock(struct wd_fair_lock *lock);
+void wd_fair_unlock(struct wd_fair_lock *lock);
 void *wd_drv_mmap_qfr(struct wd_queue *q, enum uacce_qfrt qfrt, size_t size);
 void wd_drv_unmmap_qfr(struct wd_queue *q, void *addr,
 		       enum uacce_qfrt qfrt, size_t size);

--- a/wd.c
+++ b/wd.c
@@ -504,7 +504,7 @@ void *wd_ctx_mmap_qfr(handle_t h_ctx, enum uacce_qfrt qfrt)
 
 	addr = mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED, ctx->fd, off);
 	if (addr == MAP_FAILED) {
-		WD_ERR("failed to mmap, qfrt = %d, err = %d!\n", qfrt, -errno);
+		WD_ERR("failed to mmap, qfrt = %u, err = %d!\n", qfrt, -errno);
 		return NULL;
 	}
 

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -21,7 +21,7 @@ static int g_aead_mac_len[WD_DIGEST_TYPE_MAX] = {
 };
 
 /* These algs's name need correct match with alg/mode type */
-static char *wd_aead_alg_name[WD_CIPHER_ALG_TYPE_MAX][WD_CIPHER_MODE_TYPE_MAX] = {
+static const char *wd_aead_alg_name[WD_CIPHER_ALG_TYPE_MAX][WD_CIPHER_MODE_TYPE_MAX] = {
 	{"", "authenc(hmac(sha256),cbc(sm4))", "", "", "", "", "", "", "",
 	"ccm(sm4)", "gcm(sm4)"},
 	{"", "authenc(hmac(sha256),cbc(aes))", "", "", "", "", "", "", "",
@@ -39,7 +39,7 @@ struct wd_aead_setting {
 } wd_aead_setting;
 
 struct wd_aead_sess {
-	char			*alg_name;
+	const char		*alg_name;
 	enum wd_cipher_alg	calg;
 	enum wd_cipher_mode	cmode;
 	enum wd_digest_type	dalg;
@@ -155,7 +155,7 @@ static int cipher_key_len_check(enum wd_cipher_alg alg, __u16 length)
 		ret = aes_key_len_check(length);
 		break;
 	default:
-		WD_ERR("failed to set the cipher alg, alg = %d\n", alg);
+		WD_ERR("failed to set the cipher alg, alg = %u\n", alg);
 		return -WD_EINVAL;
 	}
 

--- a/wd_agg.c
+++ b/wd_agg.c
@@ -55,7 +55,7 @@ struct wd_agg_sess_agg_conf {
 };
 
 struct wd_agg_sess {
-	char *alg_name;
+	const char *alg_name;
 	wd_dev_mask_t *dev_mask;
 	struct wd_alg_agg *drv;
 	void *priv;
@@ -69,7 +69,7 @@ struct wd_agg_sess {
 	struct wd_dae_hash_table rehash_table;
 };
 
-static char *wd_agg_alg_name = "hashagg";
+static const char *wd_agg_alg_name = "hashagg";
 static struct wd_init_attrs wd_agg_init_attrs;
 static int wd_agg_poll_ctx(__u32 idx, __u32 expt, __u32 *count);
 
@@ -155,7 +155,7 @@ static int check_col_data_info(enum wd_dae_data_type type, __u16 col_data_info)
 		}
 		break;
 	default:
-		WD_ERR("invalid: agg data type is %d!\n", type);
+		WD_ERR("invalid: agg data type is %u!\n", type);
 		return -WD_EINVAL;
 	}
 
@@ -240,7 +240,7 @@ static int check_agg_cols_info(struct wd_agg_sess_setup *setup, __u32 *out_agg_c
 			}
 			alg = info[i].output_col_algs[j];
 			if (alg >= WD_AGG_ALG_TYPE_MAX || alg_cnt[alg]) {
-				WD_ERR("invalid agg output col alg type: %d, col idx: %u\n",
+				WD_ERR("invalid agg output col alg type: %u, col idx: %u\n",
 				       alg, i);
 				return -WD_EINVAL;
 			}
@@ -497,7 +497,7 @@ static int wd_agg_check_sess_state(struct wd_agg_sess *sess, enum wd_agg_sess_st
 	ret = __atomic_compare_exchange_n(&sess->state, expected, next,
 					  false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 	if (!ret) {
-		WD_ERR("invalid: agg sess state is %d!\n", *expected);
+		WD_ERR("invalid: agg sess state is %u!\n", *expected);
 		return -WD_EINVAL;
 	}
 
@@ -1113,7 +1113,7 @@ static int wd_agg_input_try_init(struct wd_agg_sess *sess, enum wd_agg_sess_stat
 					  false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 	state = __atomic_load_n(&sess->state, __ATOMIC_RELAXED);
 	if (unlikely(state != WD_AGG_SESS_INPUT)) {
-		WD_ERR("failed to set agg input sess state: %d!\n", state);
+		WD_ERR("failed to set agg input sess state: %u!\n", state);
 		return -WD_EINVAL;
 	}
 
@@ -1251,7 +1251,7 @@ static int wd_agg_output_try_init(struct wd_agg_sess *sess, enum wd_agg_sess_sta
 					  false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 	state = __atomic_load_n(&sess->state, __ATOMIC_RELAXED);
 	if (unlikely(state != WD_AGG_SESS_OUTPUT)) {
-		WD_ERR("failed to set agg output sess state: %d!\n", state);
+		WD_ERR("failed to set agg output sess state: %u!\n", state);
 		return -WD_EINVAL;
 	}
 
@@ -1459,7 +1459,7 @@ static int wd_agg_rehash_try_init(struct wd_agg_sess *sess, enum wd_agg_sess_sta
 	ret = __atomic_compare_exchange_n(&sess->state, expected, WD_AGG_SESS_REHASH,
 					  false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 	if (!ret) {
-		WD_ERR("invalid: agg rehash sess state is %d!\n", *expected);
+		WD_ERR("invalid: agg rehash sess state is %u!\n", *expected);
 		return -WD_EINVAL;
 	}
 

--- a/wd_alg.c
+++ b/wd_alg.c
@@ -141,6 +141,8 @@ static bool wd_alg_check_available(int calc_type, const char *dev_name)
 	case UADK_ALG_HW:
 		ret = wd_check_accel_dev(dev_name);
 		break;
+	default:
+		break;
 	}
 
 	return ret;

--- a/wd_cipher.c
+++ b/wd_cipher.c
@@ -37,7 +37,7 @@ static const unsigned char des_weak_keys[DES_WEAK_KEY_NUM][DES_KEY_SIZE] = {
 	{0xFE, 0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1}
 };
 
-static char *wd_cipher_alg_name[WD_CIPHER_ALG_TYPE_MAX][WD_CIPHER_MODE_TYPE_MAX] = {
+static const char *wd_cipher_alg_name[WD_CIPHER_ALG_TYPE_MAX][WD_CIPHER_MODE_TYPE_MAX] = {
 	{"ecb(sm4)", "cbc(sm4)", "ctr(sm4)", "xts(sm4)", "ofb(sm4)",
 	 "cfb(sm4)", "cbc-cs1(sm4)", "cbc-cs2(sm4)", "cbc-cs3(sm4)",
 	 "", "", "xts(sm4)"},
@@ -58,7 +58,7 @@ struct wd_cipher_setting {
 } wd_cipher_setting;
 
 struct wd_cipher_sess {
-	char			*alg_name;
+	const char		*alg_name;
 	enum wd_cipher_alg	alg;
 	enum wd_cipher_mode	mode;
 	wd_dev_mask_t		*dev_mask;
@@ -199,7 +199,7 @@ static int cipher_key_len_check(struct wd_cipher_sess *sess, __u32 length)
 			ret = -WD_EINVAL;
 		break;
 	default:
-		WD_ERR("cipher input alg err, alg = %d\n", sess->alg);
+		WD_ERR("cipher input alg err, alg = %u\n", sess->alg);
 		return -WD_EINVAL;
 	}
 

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -26,7 +26,7 @@
 
 #define cpu_to_be32(x) swap_byte(x)
 
-static char *wd_comp_alg_name[WD_COMP_ALG_MAX] = {
+static const char *wd_comp_alg_name[WD_COMP_ALG_MAX] = {
 	"zlib", "gzip", "deflate", "lz77_zstd"
 };
 
@@ -409,12 +409,12 @@ int wd_comp_poll_ctx(__u32 idx, __u32 expt, __u32 *count)
 static int wd_comp_check_sess_params(struct wd_comp_sess_setup *setup)
 {
 	if (setup->alg_type >= WD_COMP_ALG_MAX)  {
-		WD_ERR("invalid: alg_type is %d!\n", setup->alg_type);
+		WD_ERR("invalid: alg_type is %u!\n", setup->alg_type);
 		return -WD_EINVAL;
 	}
 
 	if (setup->op_type >= WD_DIR_MAX)  {
-		WD_ERR("invalid: op_type is %d!\n", setup->op_type);
+		WD_ERR("invalid: op_type is %u!\n", setup->op_type);
 		return -WD_EINVAL;
 	}
 
@@ -422,12 +422,12 @@ static int wd_comp_check_sess_params(struct wd_comp_sess_setup *setup)
 		return WD_SUCCESS;
 
 	if (setup->comp_lv > WD_COMP_L15) {
-		WD_ERR("invalid: comp_lv is %d!\n", setup->comp_lv);
+		WD_ERR("invalid: comp_lv is %u!\n", setup->comp_lv);
 		return -WD_EINVAL;
 	}
 
 	if (setup->win_sz > WD_COMP_WS_32K) {
-		WD_ERR("invalid: win_sz is %d!\n", setup->win_sz);
+		WD_ERR("invalid: win_sz is %u!\n", setup->win_sz);
 		return -WD_EINVAL;
 	}
 
@@ -554,7 +554,7 @@ static int wd_comp_check_params(struct wd_comp_sess *sess,
 	}
 
 	if (unlikely(req->data_fmt > WD_SGL_BUF)) {
-		WD_ERR("invalid: data_fmt is %d!\n", req->data_fmt);
+		WD_ERR("invalid: data_fmt is %u!\n", req->data_fmt);
 		return -WD_EINVAL;
 	}
 
@@ -564,7 +564,7 @@ static int wd_comp_check_params(struct wd_comp_sess *sess,
 
 	if (unlikely(req->op_type != WD_DIR_COMPRESS &&
 		     req->op_type != WD_DIR_DECOMPRESS)) {
-		WD_ERR("invalid: op_type is %d!\n", req->op_type);
+		WD_ERR("invalid: op_type is %u!\n", req->op_type);
 		return -WD_EINVAL;
 	}
 
@@ -793,7 +793,7 @@ int wd_do_comp_strm(handle_t h_sess, struct wd_comp_req *req)
 		return ret;
 
 	if (unlikely(req->data_fmt > WD_FLAT_BUF)) {
-		WD_ERR("invalid: data_fmt is %d!\n", req->data_fmt);
+		WD_ERR("invalid: data_fmt is %u!\n", req->data_fmt);
 		return -WD_EINVAL;
 	}
 

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -30,7 +30,7 @@ static __u32 g_digest_mac_full_len[WD_DIGEST_TYPE_MAX] = {
 };
 
 /* These algs's name need correct match with digest alg type */
-static char *wd_digest_alg_name[WD_DIGEST_TYPE_MAX] = {
+static const char *wd_digest_alg_name[WD_DIGEST_TYPE_MAX] = {
 	"sm3", "md5", "sha1", "sha256", "sha224", "sha384",
 	"sha512", "sha512-224", "sha512-256", "xcbc-mac-96(aes)",
 	"xcbc-prf-128(aes)", "cmac(aes)", "gmac(aes)"
@@ -60,7 +60,7 @@ struct wd_digest_stream_data {
 };
 
 struct wd_digest_sess {
-	char			*alg_name;
+	const char		*alg_name;
 	enum wd_digest_type	alg;
 	enum wd_digest_mode	mode;
 	void			*priv;
@@ -471,7 +471,7 @@ static int wd_aes_hmac_length_check(struct wd_digest_sess *sess,
 	case WD_DIGEST_AES_XCBC_PRF_128:
 	case WD_DIGEST_AES_CMAC:
 		if (!req->in_bytes) {
-			WD_ERR("failed to check 0 packet length, alg = %d\n",
+			WD_ERR("failed to check 0 packet length, alg = %u\n",
 				sess->alg);
 			return -WD_EINVAL;
 		}
@@ -487,7 +487,7 @@ static int wd_mac_length_check(struct wd_digest_sess *sess,
 			       struct wd_digest_req *req)
 {
 	if (unlikely(req->out_bytes == 0)) {
-		WD_ERR("invalid: digest alg:%d mac length is 0.\n", sess->alg);
+		WD_ERR("invalid: digest alg:%u mac length is 0.\n", sess->alg);
 		return -WD_EINVAL;
 	}
 
@@ -495,7 +495,7 @@ static int wd_mac_length_check(struct wd_digest_sess *sess,
 	case WD_DIGEST_END:
 	case WD_DIGEST_STREAM_END:
 		if (unlikely(req->out_bytes > g_digest_mac_len[sess->alg])) {
-			WD_ERR("invalid: digest mac length, alg = %d, out_bytes = %u\n",
+			WD_ERR("invalid: digest mac length, alg = %u, out_bytes = %u\n",
 			       sess->alg, req->out_bytes);
 			return -WD_EINVAL;
 		}
@@ -504,7 +504,7 @@ static int wd_mac_length_check(struct wd_digest_sess *sess,
 	case WD_DIGEST_STREAM_DOING:
 		/* User need to input full mac buffer in first and middle hash */
 		if (unlikely(req->out_bytes != g_digest_mac_full_len[sess->alg])) {
-			WD_ERR("invalid: digest mac full length, alg = %d, out_bytes = %u\n",
+			WD_ERR("invalid: digest mac full length, alg = %u, out_bytes = %u\n",
 			       sess->alg, req->out_bytes);
 			return -WD_EINVAL;
 		}
@@ -533,7 +533,7 @@ static int wd_digest_param_check(struct wd_digest_sess *sess,
 	}
 
 	if (unlikely(sess->alg >= WD_DIGEST_TYPE_MAX)) {
-		WD_ERR("invalid: check digest type, alg = %d\n", sess->alg);
+		WD_ERR("invalid: check digest type, alg = %u\n", sess->alg);
 		return -WD_EINVAL;
 	}
 

--- a/wd_ecc.c
+++ b/wd_ecc.c
@@ -1324,19 +1324,6 @@ int wd_ecc_get_pubkey(struct wd_ecc_key *ecc_key,
 	return WD_SUCCESS;
 }
 
-int wd_ecc_get_curve(struct wd_ecc_key *ecc_key,
-		     struct wd_ecc_curve **cv)
-{
-	if (!ecc_key || !cv) {
-		WD_ERR("invalid: get ecc pubkey parameter err!\n");
-		return -WD_EINVAL;
-	}
-
-	*cv = ecc_key->cv;
-
-	return WD_SUCCESS;
-}
-
 void wd_ecc_get_prikey_params(struct wd_ecc_key *key,
 			      struct wd_dtb **p, struct wd_dtb **a,
 			      struct wd_dtb **b, struct wd_dtb **n,

--- a/wd_mempool.c
+++ b/wd_mempool.c
@@ -893,7 +893,7 @@ handle_t wd_mempool_create(size_t size, int node)
 	int ret;
 
 	if (!tmp || node < 0 || node > numa_max_node()) {
-		WD_ERR("invalid: numa node is %d, size is %ld!\n", node, tmp);
+		WD_ERR("invalid: numa node is %d, size is %zu!\n", node, tmp);
 		return (handle_t)(-WD_EINVAL);
 	}
 

--- a/wd_rsa.c
+++ b/wd_rsa.c
@@ -1128,21 +1128,19 @@ static int rsa_prikey2_param_set(struct wd_rsa_prikey2 *pkey2,
 	case WD_CRT_PRIKEY_DQ:
 		ret = rsa_set_param(&pkey2->dq, param);
 		break;
-
 	case WD_CRT_PRIKEY_DP:
 		ret = rsa_set_param(&pkey2->dp, param);
 		break;
-
 	case WD_CRT_PRIKEY_QINV:
 		ret = rsa_set_param(&pkey2->qinv, param);
 		break;
-
 	case WD_CRT_PRIKEY_P:
 		ret = rsa_set_param(&pkey2->p, param);
 		break;
-
 	case WD_CRT_PRIKEY_Q:
 		ret = rsa_set_param(&pkey2->q, param);
+		break;
+	default:
 		break;
 	}
 

--- a/wd_util.c
+++ b/wd_util.c
@@ -92,8 +92,8 @@ struct drv_lib_list {
 };
 
 struct acc_alg_item {
-	char *name;
-	char *algtype;
+	const char *name;
+	const char *algtype;
 };
 
 struct wd_ce_ctx {
@@ -2181,7 +2181,7 @@ static void dladdr_empty(void)
 {
 }
 
-int wd_get_lib_file_path(char *lib_file, char *lib_path, bool is_dir)
+int wd_get_lib_file_path(const char *lib_file, char *lib_path, bool is_dir)
 {
 	char file_path[PATH_MAX] = {0};
 	char path[PATH_MAX] = {0};
@@ -2300,7 +2300,7 @@ free_list:
 	return NULL;
 }
 
-struct wd_alg_driver *wd_alg_drv_bind(int task_type, char *alg_name)
+struct wd_alg_driver *wd_alg_drv_bind(int task_type, const char *alg_name)
 {
 	struct wd_alg_driver *set_driver = NULL;
 	struct wd_alg_driver *drv;
@@ -2395,7 +2395,7 @@ static __u32 wd_get_ctx_numbers(struct wd_ctx_params ctx_params, int end)
 	return count;
 }
 
-struct uacce_dev_list *wd_get_usable_list(struct uacce_dev_list *list, struct bitmask *bmp)
+static struct uacce_dev_list *wd_get_usable_list(struct uacce_dev_list *list, struct bitmask *bmp)
 {
 	struct uacce_dev_list *p, *node, *result = NULL;
 	struct uacce_dev *dev;
@@ -2736,7 +2736,7 @@ int wd_alg_attrs_init(struct wd_init_attrs *attrs)
 	struct wd_sched *alg_sched = NULL;
 	char alg_type[CRYPTO_MAX_ALG_NAME];
 	int driver_type = UADK_ALG_HW;
-	char *alg = attrs->alg;
+	const char *alg = attrs->alg;
 	int ret = -WD_EINVAL;
 
 	if (!attrs->ctx_params)


### PR DESCRIPTION
Qi Tao (2):
  uadk: add compilation options
  uadk_tool: fix error in saving the aead dst data

Wenkai Lin (7):
  uadk: fix for set hashagg session state
  uadk/v1: support the hmac(sm3)-cbc(sm4) algorithm
  uadk: fix for the algorithm name of the aead cbc mode
  uadk/v1: Add stream mode for AES-GCM and SM4-GCM
  uadk/v1: add assoc bytes check
  uadk/v1: set aead msg state for the hardware v2
  uadk/v1: fix input length check for aead stream mode.

Yang Shen (1):
  uadk/v1 - add fair lock to replace CAS

Zhiqi Song (3):
  uadk/hpre: modify privkey transform method of ecc
  v1/hpre: modify privkey transform method of ecc
  uadk/v1: cleanup key format transform function

 Makefile.am                              |  17 +-
 drv/hash_mb/hash_mb.c                    |   4 +
 drv/hisi_comp.c                          |   6 +-
 drv/hisi_dae.c                           |  34 ++-
 drv/hisi_hpre.c                          |  18 +-
 drv/hisi_sec.c                           |   8 +-
 include/crypto/sm4.h                     |  18 ++
 include/wd_rsa.h                         |   2 -
 include/wd_util.h                        |  10 +-
 lib/crypto/sm4.c                         | 176 ++++++++++++++
 uadk_tool/benchmark/sec_uadk_benchmark.c |   6 +
 uadk_tool/benchmark/uadk_benchmark.c     |   6 +-
 uadk_tool/test/test_sec.c                |   4 +-
 v1/drv/hisi_hpre_udrv.c                  |  28 +--
 v1/drv/hisi_qm_udrv.c                    |  51 ++--
 v1/drv/hisi_qm_udrv.h                    |   4 +-
 v1/drv/hisi_sec_udrv.c                   | 296 ++++++++++++++++++++++-
 v1/drv/hisi_sec_udrv.h                   |   9 +-
 v1/drv/hisi_zip_udrv.c                   |  26 +-
 v1/test/hisi_sec_test/test_hisi_sec.c    |   4 +-
 v1/wd_adapter.c                          |   4 +-
 v1/wd_adapter.h                          |   2 +-
 v1/wd_aead.c                             |  67 ++++-
 v1/wd_aead.h                             |  12 +
 v1/wd_cipher.c                           |   2 +-
 v1/wd_digest.c                           |   6 +-
 v1/wd_ecc.c                              |  10 +-
 v1/wd_util.c                             |  31 +++
 v1/wd_util.h                             |   8 +
 wd.c                                     |   2 +-
 wd_aead.c                                |  10 +-
 wd_agg.c                                 |  43 ++--
 wd_alg.c                                 |   2 +
 wd_cipher.c                              |   6 +-
 wd_comp.c                                |  16 +-
 wd_digest.c                              |  14 +-
 wd_ecc.c                                 |  13 -
 wd_mempool.c                             |   2 +-
 wd_rsa.c                                 |   6 +-
 wd_util.c                                |  16 +-
 40 files changed, 792 insertions(+), 207 deletions(-)
 create mode 100644 include/crypto/sm4.h
 create mode 100644 lib/crypto/sm4.c