### PR TITLE
sanity_test: add set -x to print cmd

### DIFF
--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -15,6 +15,7 @@
 
 #VALGRIND=valgrind
 
+set -x
 have_hisi_zip=0
 have_hisi_sec=0
 have_hisi_hpre=0


### PR DESCRIPTION
When ci fails, it is very difficult to reproduce.

Add set -x in build script, to make it is easier to find which cmd fails.