### PR TITLE
uadk: some bugfix

### DIFF
--- a/drv/isa_ce_sm3.c
+++ b/drv/isa_ce_sm3.c
@@ -293,11 +293,6 @@ static int do_hmac_sm3_ce(struct wd_digest_msg *msg, __u8 *out_hmac)
 	/* Use last output as the iv in current cycle */
 	iv = msg->out;
 
-	if (!key_len) {
-		WD_ERR("invalid hmac key_len is 0!\n");
-		return -WD_EINVAL;
-	}
-
 	block_type = get_hash_block_type(msg);
 	switch(block_type) {
 	case HASH_SINGLE_BLOCK:

--- a/uadk_tool/benchmark/uadk_benchmark.c
+++ b/uadk_tool/benchmark/uadk_benchmark.c
@@ -635,7 +635,7 @@ int acc_default_case(struct acc_option *option)
 	return acc_benchmark_run(option);
 }
 
-static void print_help(void)
+void print_benchmark_help(void)
 {
 	ACC_TST_PRT("NAME\n");
 	ACC_TST_PRT("    benchmark: test UADK acc performance,etc\n");
@@ -728,7 +728,7 @@ int acc_cmd_parse(int argc, char *argv[], struct acc_option *option)
 
 		switch (c) {
 		case 0:
-			print_help();
+			print_benchmark_help();
 			goto to_exit;
 		case 1:
 			option->algtype = get_alg_type(optarg);
@@ -791,7 +791,7 @@ int acc_cmd_parse(int argc, char *argv[], struct acc_option *option)
 			break;
 		default:
 			ACC_TST_PRT("invalid: bad input parameter!\n");
-			print_help();
+			print_benchmark_help();
 			goto to_exit;
 		}
 	}

--- a/uadk_tool/benchmark/uadk_benchmark.h
+++ b/uadk_tool/benchmark/uadk_benchmark.h
@@ -225,5 +225,6 @@ int acc_cmd_parse(int argc, char *argv[], struct acc_option *option);
 int acc_default_case(struct acc_option *option);
 int acc_option_convert(struct acc_option *option);
 int acc_benchmark_run(struct acc_option *option);
+void print_benchmark_help(void);
 
 #endif /* UADK_BENCHMARK_H */

--- a/uadk_tool/uadk_tool.c
+++ b/uadk_tool/uadk_tool.c
@@ -22,11 +22,16 @@ int main(int argc, char **argv)
 
 	if (argc > index) {
 		if (!strcmp("dfx", argv[index])) {
+			if (!argv[++index])
+				print_dfx_help();
+
 			dfx_cmd_parse(argc, argv);
 		} else if (!strcmp("benchmark", argv[index])) {
 			printf("start UADK benchmark test.\n");
-			if (!argv[++index])
+			if (!argv[++index]) {
+				print_benchmark_help();
 				acc_default_case(&option);
+			}
 
 			ret = acc_cmd_parse(argc, argv, &option);
 			if (ret)
@@ -37,6 +42,9 @@ int main(int argc, char **argv)
 				return ret;
 			(void)acc_benchmark_run(&option);
 		} else if (!strcmp("test", argv[index])) {
+			if (!argv[++index])
+				print_test_help();
+
 			printf("start UADK acc algorithm test.\n");
 			acc_test_run(argc, argv);
 		} else {

--- a/v1/drv/hisi_sec_udrv.c
+++ b/v1/drv/hisi_sec_udrv.c
@@ -2732,26 +2732,13 @@ static int aead_comb_param_check(struct wcrypto_aead_msg *msg)
 	}
 
 	if (msg->cmode == WCRYPTO_CIPHER_CCM) {
-		if (unlikely(msg->auth_bytes < WORD_BYTES ||
-			     msg->auth_bytes > AES_BLOCK_SIZE ||
-			     msg->auth_bytes % (WORD_BYTES >> 1))) {
-			WD_ERR("Invalid aead ccm mode auth_bytes!\n");
-			return -WD_EINVAL;
-		}
 		if (unlikely(msg->assoc_bytes > MAX_CCM_AAD_LEN)) {
 			WD_ERR("aead ccm mode aasoc_bytes is too long!\n");
 			return -WD_EINVAL;
 		}
 		return WD_SUCCESS;
-	}
-	if (msg->cmode == WCRYPTO_CIPHER_GCM) {
-		if (unlikely(msg->auth_bytes < U64_DATA_BYTES ||
-			     msg->auth_bytes > AES_BLOCK_SIZE)) {
-			WD_ERR("Invalid aead gcm mode auth_bytes!\n");
-			return -WD_EINVAL;
-		}
+	} else if (msg->cmode == WCRYPTO_CIPHER_GCM)
 		return WD_SUCCESS;
-	}
 
 	/* CCM/GCM support 0 in_bytes, but others not support */
 	if (unlikely(msg->in_bytes == 0)) {
@@ -2759,8 +2746,7 @@ static int aead_comb_param_check(struct wcrypto_aead_msg *msg)
 		return -WD_EINVAL;
 	}
 
-	if (unlikely(msg->auth_bytes != AES_BLOCK_SIZE &&
-	    msg->auth_bytes != AES_BLOCK_SIZE << 1)) {
+	if (unlikely(msg->auth_bytes & WORD_ALIGNMENT_MASK)) {
 		WD_ERR("Invalid aead auth_bytes!\n");
 		return -WD_EINVAL;
 	}

--- a/v1/wd_aead.c
+++ b/v1/wd_aead.c
@@ -387,13 +387,10 @@ int wcrypto_set_aead_akey(void *ctx, __u8 *key, __u16 key_len)
 {
 	struct wcrypto_aead_ctx *ctxt = ctx;
 
-	if (!ctx || !key) {
-		WD_ERR("input param is NULL!\n");
+	if (!ctx || (key_len && !key)) {
+		WD_ERR("failed to check authenticate key param!\n");
 		return -WD_EINVAL;
 	}
-
-	if (key_len == 0)
-		goto err_key_len;
 
 	if (ctxt->setup.dalg > WCRYPTO_SHA256) {
 		if (key_len > MAX_HMAC_KEY_SIZE)
@@ -405,6 +402,9 @@ int wcrypto_set_aead_akey(void *ctx, __u8 *key, __u16 key_len)
 
 	ctxt->akey_bytes = key_len;
 
+	if (!key_len)
+		return WD_SUCCESS;
+
 	if (ctxt->setup.data_fmt == WD_SGL_BUF)
 		wd_sgl_cp_from_pbuf(ctxt->akey, 0, key, key_len);
 	else
@@ -413,7 +413,7 @@ int wcrypto_set_aead_akey(void *ctx, __u8 *key, __u16 key_len)
 	return WD_SUCCESS;
 
 err_key_len:
-	WD_ERR("fail to check key length!\n");
+	WD_ERR("failed to check authenticate key length, size = %u\n", key_len);
 	return -WD_EINVAL;
 }
 

--- a/v1/wd_aead.c
+++ b/v1/wd_aead.c
@@ -362,7 +362,7 @@ int wcrypto_set_aead_ckey(void *ctx, __u8 *key, __u16 key_len)
 	struct wcrypto_aead_ctx *ctxt = ctx;
 	int ret;
 
-	if (!ctx || !key) {
+	if (!ctx || !ctxt->ckey || !key) {
 		WD_ERR("input param is NULL!\n");
 		return -WD_EINVAL;
 	}
@@ -387,7 +387,7 @@ int wcrypto_set_aead_akey(void *ctx, __u8 *key, __u16 key_len)
 {
 	struct wcrypto_aead_ctx *ctxt = ctx;
 
-	if (!ctx || (key_len && !key)) {
+	if (!ctx || !ctxt->akey || (key_len && !key)) {
 		WD_ERR("failed to check authenticate key param!\n");
 		return -WD_EINVAL;
 	}

--- a/v1/wd_cipher.c
+++ b/v1/wd_cipher.c
@@ -309,7 +309,7 @@ int wcrypto_set_cipher_key(void *ctx, __u8 *key, __u16 key_len)
 	struct wcrypto_cipher_ctx *ctxt = ctx;
 	int ret;
 
-	if (!ctx || !key) {
+	if (!ctx || !ctxt->key || !key) {
 		WD_ERR("%s: input param err!\n", __func__);
 		return -WD_EINVAL;
 	}

--- a/v1/wd_digest.c
+++ b/v1/wd_digest.c
@@ -308,7 +308,7 @@ int wcrypto_set_digest_key(void *ctx, __u8 *key, __u16 key_len)
 	struct wcrypto_digest_ctx *ctxt = ctx;
 	int ret;
 
-	if (!ctx || (key_len && !key)) {
+	if (!ctx || !ctxt->key || (key_len && !key)) {
 		WD_ERR("%s(): input param err!\n", __func__);
 		return -WD_EINVAL;
 	}

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -208,13 +208,10 @@ int wd_aead_set_akey(handle_t h_sess, const __u8 *key, __u16 key_len)
 {
 	struct wd_aead_sess *sess = (struct wd_aead_sess *)h_sess;
 
-	if (unlikely(!key || !sess)) {
+	if (!sess || (key_len && !key)) {
 		WD_ERR("failed to check authenticate key param!\n");
 		return -WD_EINVAL;
 	}
-
-	if (key_len == 0)
-		goto err_key_len;
 
 	/*
 	 * Here dalg only supports sha1, sha256, sha512,
@@ -229,7 +226,8 @@ int wd_aead_set_akey(handle_t h_sess, const __u8 *key, __u16 key_len)
 	}
 
 	sess->akey_bytes = key_len;
-	memcpy(sess->akey, key, key_len);
+	if (key_len)
+		memcpy(sess->akey, key, key_len);
 
 	return 0;
 

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -262,7 +262,6 @@ int wd_aead_set_authsize(handle_t h_sess, __u16 authsize)
 		}
 	} else {
 		if (sess->dalg >= WD_DIGEST_TYPE_MAX || !authsize ||
-		    authsize & (WD_AEAD_CCM_GCM_MAX - 1) ||
 		    authsize > g_aead_mac_len[sess->dalg]) {
 			WD_ERR("failed to check aead mac authsize, size = %u\n",
 				authsize);

--- a/wd_aead.c
+++ b/wd_aead.c
@@ -263,7 +263,7 @@ int wd_aead_set_authsize(handle_t h_sess, __u16 authsize)
 			return -WD_EINVAL;
 		}
 	} else {
-		if (sess->dalg >= WD_DIGEST_TYPE_MAX ||
+		if (sess->dalg >= WD_DIGEST_TYPE_MAX || !authsize ||
 		    authsize & (WD_AEAD_CCM_GCM_MAX - 1) ||
 		    authsize > g_aead_mac_len[sess->dalg]) {
 			WD_ERR("failed to check aead mac authsize, size = %u\n",

--- a/wd_digest.c
+++ b/wd_digest.c
@@ -158,14 +158,13 @@ int wd_digest_set_key(handle_t h_sess, const __u8 *key, __u32 key_len)
 	struct wd_digest_sess *sess = (struct wd_digest_sess *)h_sess;
 	int ret;
 
-	if (!key || !sess) {
-		WD_ERR("invalid: failed to check input param, sess or key is NULL!\n");
+	if (!sess || (key_len && !key)) {
+		WD_ERR("invalid: digest session or key is NULL!\n");
 		return -WD_EINVAL;
 	}
 
-	if ((sess->alg <= WD_DIGEST_SHA224 && key_len >
-		MAX_HMAC_KEY_SIZE >> 1) || key_len == 0 ||
-		key_len > MAX_HMAC_KEY_SIZE) {
+	if ((sess->alg <= WD_DIGEST_SHA224 && key_len > MAX_HMAC_KEY_SIZE >> 1) ||
+	    key_len > MAX_HMAC_KEY_SIZE) {
 		WD_ERR("failed to check digest key length, size = %u\n",
 			key_len);
 		return -WD_EINVAL;
@@ -181,7 +180,8 @@ int wd_digest_set_key(handle_t h_sess, const __u8 *key, __u32 key_len)
 	}
 
 	sess->key_bytes = key_len;
-	memcpy(sess->key, key, key_len);
+	if (key_len)
+		memcpy(sess->key, key, key_len);
 
 	return 0;
 }


### PR DESCRIPTION
Junchong Pan (1):
  uadk_tool: print help when empty parameters

Wenkai Lin (7):
  uadk: fix for aead authsize check
  uadk: fix for aead auth key length
  uadk: fix for digest auth key length
  uadk: fix for ce key_len check
  uadk: fix for key address check
  uadk: fix for v1 aead authsize check
  uadk: fix for aead cbc mode authsize

 drv/hisi_sec.c                       | 40 +++++++++++++-------------
 drv/isa_ce_sm3.c                     |  5 ----
 uadk_tool/benchmark/uadk_benchmark.c |  6 ++--
 uadk_tool/benchmark/uadk_benchmark.h |  1 +
 uadk_tool/uadk_tool.c                | 10 ++++++-
 v1/drv/hisi_sec_udrv.c               | 18 ++----------
 v1/wd_aead.c                         | 41 ++++++++++++++++++++-------
 v1/wd_cipher.c                       |  2 +-
 v1/wd_digest.c                       | 42 ++++++++++++++++++++++------
 v1/wd_digest.h                       | 19 +++++++++++--
 wd_aead.c                            | 11 +++-----
 wd_digest.c                          | 12 ++++----
 12 files changed, 127 insertions(+), 80 deletions(-)