### PR TITLE
uadk: fix a double free issue in zlibwrapper

### DIFF
--- a/wd_zlibwrapper.c
+++ b/wd_zlibwrapper.c
@@ -303,5 +303,6 @@ int wd_inflate_end(z_streamp strm)
 
 __attribute__ ((destructor)) static void wd_zlibwrapper_destory(void)
 {
-	wd_zlib_uadk_uninit();
+	if (zlib_status == WD_ZLIB_INIT)
+		wd_zlib_uadk_uninit();
 }


### PR DESCRIPTION
In the destructor, it need to check whether zlibwrapper has been initialized, otherwise it will cause double free.