### PR TITLE
uadk: check whether host cpu is aarch64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,7 @@ libhisi_sec_la_SOURCES=drv/hisi_sec.c drv/hisi_qm_udrv.c \
 libhisi_hpre_la_SOURCES=drv/hisi_hpre.c drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h
 
+if ARCH_ARM64
 libisa_ce_la_SOURCES=arm_arch_ce.h drv/isa_ce_sm3.c drv/isa_ce_sm3_armv8.S isa_ce_sm3.h \
 		drv/isa_ce_sm4.c drv/isa_ce_sm4_armv8.S drv/isa_ce_sm4.h
 
@@ -102,6 +103,7 @@ libisa_sve_la_SOURCES=drv/hash_mb/hash_mb.c wd_digest_drv.h drv/hash_mb/hash_mb.
 		drv/hash_mb/sm3_mb_asimd_x4.S drv/hash_mb/sm3_mb_sve.S \
 		drv/hash_mb/md5_sve_common.S drv/hash_mb/md5_mb_asimd_x1.S \
 		drv/hash_mb/md5_mb_asimd_x4.S drv/hash_mb/md5_mb_sve.S
+endif
 
 libhisi_dae_la_SOURCES=drv/hisi_dae.c drv/hisi_qm_udrv.c \
 		hisi_qm_udrv.h

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,14 @@ AC_ARG_ENABLE([perf],
   [perf=false]
 )
 
+AC_CANONICAL_HOST
+AS_IF([test "$host_cpu" = "aarch64"],[
+     arch_arm64="true"
+])
+AM_CONDITIONAL([ARCH_ARM64], [test "x$arch_arm64" = "xtrue"])
+
+AC_MSG_NOTICE([Detected host_cpu: $host_cpu])
+
 AC_CHECK_LIB(z, zlibVersion,
 	     [ AC_DEFINE(HAVE_ZLIB, 1, [Have zlib])
 	       have_zlib=true ],


### PR DESCRIPTION
Only build aarch64 cpu instruction if host is aarch64, to solve build failure on x86.