### PR TITLE
uadk: support lz77_only and  lz4

### DIFF
--- a/drv/hisi_comp.c
+++ b/drv/hisi_comp.c
@@ -69,9 +69,9 @@
 #define upper_32_bits(addr)		((__u32)((uintptr_t)(addr) >> HZ_HADDR_SHIFT))
 
 /* the min output buffer size is (input size * 1.125) */
-#define min_out_buf_size(inl)		((((__u64)inl * 9) + 7) >> 3)
+#define min_out_buf_size(inl)		((((__u64)(inl) * 9) + 7) >> 3)
 /* the max input size is (output buffer size * 8 / 9) and align with 4 byte */
-#define max_in_data_size(outl)		((__u32)(((__u64)outl << 3) / 9) & 0xfffffffc)
+#define max_in_data_size(outl)		((__u32)(((__u64)(outl) << 3) / 9) & 0xfffffffc)
 
 #define HZ_MAX_SIZE			(8 * 1024 * 1024)
 
@@ -100,7 +100,7 @@
 #define CTX_WIN_LEN_MASK		0xffff
 #define CTX_HEAD_BIT_CNT_SHIFT		0xa
 #define CTX_HEAD_BIT_CNT_MASK		0xfC00
-#define WIN_LEN_ALIGN(len)		((len + 15) & ~(__u32)0x0F)
+#define WIN_LEN_ALIGN(len)		(((len) + 15) & ~(__u32)0x0F)
 
 enum alg_type {
 	HW_DEFLATE = 0x1,

--- a/drv/hisi_comp_huf.c
+++ b/drv/hisi_comp_huf.c
@@ -96,15 +96,10 @@ static int check_store_huffman_block(struct bit_reader *br)
 	/* go to a byte boundary */
 	pad = bit_len & BYTE_ALIGN_MASK;
 	bit_len -= pad;
-	data = read_bits(br, pad);
-	if (data < 0)
-		return BLOCK_IS_INCOMPLETE;
-
-	data = read_bits(br, bit_len);
-	if (data < 0)
-		return BLOCK_IS_INCOMPLETE;
+	br->cur_pos += pad;
 
 	/* check len and nlen */
+	data = read_bits(br, bit_len);
 	if (LEN_NLEN_CHECK(data))
 		return -WD_EINVAL;
 

--- a/drv/hisi_comp_huf.c
+++ b/drv/hisi_comp_huf.c
@@ -14,7 +14,7 @@
 #define EMPTY_STORE_BLOCK_VAL		0xffff0000L
 #define BLOCK_IS_COMPLETE		1
 #define BLOCK_IS_INCOMPLETE		0
-#define LEN_NLEN_CHECK(data)		((data & 0xffff) != ((data >> 16) ^ 0xffff))
+#define LEN_NLEN_CHECK(data)		(((data) & 0xffff) != (((data) >> 16) ^ 0xffff))
 
 /* Constants related to the Huffman code table */
 #define LIT_LEN_7BIT_THRESHOLD		7

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -20,6 +20,7 @@ enum wd_comp_alg_type {
 	WD_ZLIB,
 	WD_GZIP,
 	WD_LZ77_ZSTD,
+	WD_LZ77_ONLY,
 	WD_COMP_ALG_MAX,
 };
 

--- a/include/wd_comp.h
+++ b/include/wd_comp.h
@@ -20,6 +20,7 @@ enum wd_comp_alg_type {
 	WD_ZLIB,
 	WD_GZIP,
 	WD_LZ77_ZSTD,
+	WD_LZ4,
 	WD_LZ77_ONLY,
 	WD_COMP_ALG_MAX,
 };

--- a/uadk_tool/benchmark/uadk_benchmark.c
+++ b/uadk_tool/benchmark/uadk_benchmark.c
@@ -68,6 +68,7 @@ static struct acc_alg_item alg_options[] = {
 	{"gzip",		"gzip",			GZIP},
 	{"deflate",		"deflate",		DEFLATE},
 	{"lz77_zstd",		"lz77_zstd",		LZ77_ZSTD},
+	{"lz4",			"lz4",			LZ4},
 	{"lz77_only",		"lz77_only",		LZ77_ONLY},
 	{"rsa",			"rsa-1024",		RSA_1024},
 	{"rsa",			"rsa-2048",		RSA_2048},
@@ -365,6 +366,11 @@ static void parse_alg_param(struct acc_option *option)
 		break;
 	case LZ77_ZSTD:
 		snprintf(option->algclass, MAX_ALG_NAME, "%s", "lz77_zstd");
+		option->acctype = ZIP_TYPE;
+		option->subtype = DEFAULT_TYPE;
+		break;
+	case LZ4:
+		snprintf(option->algclass, MAX_ALG_NAME, "%s", "lz4");
 		option->acctype = ZIP_TYPE;
 		option->subtype = DEFAULT_TYPE;
 		break;

--- a/uadk_tool/benchmark/uadk_benchmark.c
+++ b/uadk_tool/benchmark/uadk_benchmark.c
@@ -68,6 +68,7 @@ static struct acc_alg_item alg_options[] = {
 	{"gzip",		"gzip",			GZIP},
 	{"deflate",		"deflate",		DEFLATE},
 	{"lz77_zstd",		"lz77_zstd",		LZ77_ZSTD},
+	{"lz77_only",		"lz77_only",		LZ77_ONLY},
 	{"rsa",			"rsa-1024",		RSA_1024},
 	{"rsa",			"rsa-2048",		RSA_2048},
 	{"rsa",			"rsa-3072",		RSA_3072},
@@ -364,6 +365,11 @@ static void parse_alg_param(struct acc_option *option)
 		break;
 	case LZ77_ZSTD:
 		snprintf(option->algclass, MAX_ALG_NAME, "%s", "lz77_zstd");
+		option->acctype = ZIP_TYPE;
+		option->subtype = DEFAULT_TYPE;
+		break;
+	case LZ77_ONLY:
+		snprintf(option->algclass, MAX_ALG_NAME, "%s", "lz77_only");
 		option->acctype = ZIP_TYPE;
 		option->subtype = DEFAULT_TYPE;
 		break;

--- a/uadk_tool/benchmark/uadk_benchmark.h
+++ b/uadk_tool/benchmark/uadk_benchmark.h
@@ -120,6 +120,7 @@ enum test_alg {
 	GZIP, // gzip
 	DEFLATE, // deflate
 	LZ77_ZSTD, // lz77_zstd
+	LZ4,
 	LZ77_ONLY,
 	RSA_1024, // rsa
 	RSA_2048,

--- a/uadk_tool/benchmark/uadk_benchmark.h
+++ b/uadk_tool/benchmark/uadk_benchmark.h
@@ -120,6 +120,7 @@ enum test_alg {
 	GZIP, // gzip
 	DEFLATE, // deflate
 	LZ77_ZSTD, // lz77_zstd
+	LZ77_ONLY,
 	RSA_1024, // rsa
 	RSA_2048,
 	RSA_3072,

--- a/uadk_tool/benchmark/zip_uadk_benchmark.c
+++ b/uadk_tool/benchmark/zip_uadk_benchmark.c
@@ -277,6 +277,12 @@ static int zip_uadk_param_parse(thread_data *tddata, struct acc_option *options)
 			ZIP_TST_PRT("Zip LZ77_ZSTD just support compress!\n");
 		optype = WD_DIR_COMPRESS;
 		break;
+	case LZ77_ONLY:
+		alg = WD_LZ77_ONLY;
+		if (optype == WD_DIR_DECOMPRESS)
+			ZIP_TST_PRT("Zip LZ77_ONLY just support compress!\n");
+		optype = WD_DIR_COMPRESS;
+		break;
 	default:
 		ZIP_TST_PRT("failed to set zip alg\n");
 		return -EINVAL;
@@ -1200,12 +1206,12 @@ static int zip_uadk_sync_threads(struct acc_option *options)
 
 	threads_option.optype = options->optype;
 	if (threads_option.mode == 1) {// stream mode
-		if (threads_option.alg == LZ77_ZSTD)
+		if (threads_option.alg == WD_LZ77_ZSTD || threads_option.alg == WD_LZ77_ONLY)
 			uadk_zip_sync_run = zip_uadk_stm_lz77_sync_run;
 		else
 			uadk_zip_sync_run = zip_uadk_stm_sync_run;
 	} else {
-		if (threads_option.alg == LZ77_ZSTD)
+		if (threads_option.alg == WD_LZ77_ZSTD || threads_option.alg == WD_LZ77_ONLY)
 			uadk_zip_sync_run = zip_uadk_blk_lz77_sync_run;
 		else
 			uadk_zip_sync_run = zip_uadk_blk_sync_run;
@@ -1257,7 +1263,7 @@ static int zip_uadk_async_threads(struct acc_option *options)
 		return 0;
 	}
 
-	if (threads_option.alg == LZ77_ZSTD)
+	if (threads_option.alg == WD_LZ77_ZSTD || threads_option.alg == WD_LZ77_ONLY)
 		uadk_zip_async_run = zip_uadk_blk_lz77_async_run;
 	else
 		uadk_zip_async_run = zip_uadk_blk_async_run;
@@ -1282,7 +1288,7 @@ static int zip_uadk_async_threads(struct acc_option *options)
 		threads_args[i].win_sz = threads_option.win_sz;
 		threads_args[i].comp_lv = threads_option.comp_lv;
 		threads_args[i].td_id = i;
-		if (threads_option.alg == LZ77_ZSTD) {
+		if (threads_option.alg == WD_LZ77_ZSTD || threads_option.alg == WD_LZ77_ONLY) {
 			struct bd_pool *uadk_pool = &g_zip_pool.pool[i];
 			u32 out_len = uadk_pool->bds[0].dst_len;
 
@@ -1345,7 +1351,7 @@ tag_free:
 			free(threads_args[i].tag);
 	}
 lz77_free:
-	if (threads_option.alg == LZ77_ZSTD) {
+	if (threads_option.alg == WD_LZ77_ZSTD || threads_option.alg == WD_LZ77_ONLY) {
 		for (i = 0; i < g_thread_num; i++) {
 			if (threads_args[i].ftuple)
 				free(threads_args[i].ftuple);

--- a/uadk_tool/benchmark/zip_uadk_benchmark.c
+++ b/uadk_tool/benchmark/zip_uadk_benchmark.c
@@ -16,7 +16,7 @@
 #define MAX_POOL_LENTH_COMP		1
 #define COMPRESSION_RATIO_FACTOR	0.7
 #define CHUNK_SIZE			(128 * 1024)
-#define MAX_UNRECV_PACKET_NUM		2
+#define MAX_UNRECV_PACKET_NUM		1
 struct uadk_bd {
 	u8 *src;
 	u8 *dst;

--- a/uadk_tool/benchmark/zip_uadk_benchmark.c
+++ b/uadk_tool/benchmark/zip_uadk_benchmark.c
@@ -277,6 +277,12 @@ static int zip_uadk_param_parse(thread_data *tddata, struct acc_option *options)
 			ZIP_TST_PRT("Zip LZ77_ZSTD just support compress!\n");
 		optype = WD_DIR_COMPRESS;
 		break;
+	case LZ4:
+		alg = WD_LZ4;
+		if (optype == WD_DIR_DECOMPRESS)
+			ZIP_TST_PRT("Zip LZ4 just support compress!\n");
+		optype = WD_DIR_COMPRESS;
+		break;
 	case LZ77_ONLY:
 		alg = WD_LZ77_ONLY;
 		if (optype == WD_DIR_DECOMPRESS)

--- a/v1/drv/hisi_zip_huf.c
+++ b/v1/drv/hisi_zip_huf.c
@@ -96,15 +96,10 @@ static int check_store_huffman_block(struct bit_reader *br)
 	/* go to a byte boundary */
 	pad = bits & BYTE_ALIGN_MASK;
 	bits -= pad;
-	data = read_bits(br, pad);
-	if (data < 0)
-		return HF_BLOCK_IS_INCOMPLETE;
-
-	data = read_bits(br, bits);
-	if (data < 0)
-		return HF_BLOCK_IS_INCOMPLETE;
+	br->cur_pos += pad;
 
 	/* check len and nlen */
+	data = read_bits(br, bits);
 	if (LEN_NLEN_CHECK(data))
 		return -WD_EINVAL;
 

--- a/v1/drv/hisi_zip_huf.c
+++ b/v1/drv/hisi_zip_huf.c
@@ -14,7 +14,7 @@
 #define EMPTY_STORE_BLOCK_VAL		0xffff0000L
 #define HF_BLOCK_IS_COMPLETE		1
 #define HF_BLOCK_IS_INCOMPLETE		0
-#define LEN_NLEN_CHECK(data)		((data & 0xffff) != ((data >> 16) ^ 0xffff))
+#define LEN_NLEN_CHECK(data)		(((data) & 0xffff) != (((data) >> 16) ^ 0xffff))
 
 /* Constants related to the Huffman code table */
 #define LIT_LEN_7BITS_THRESHOLD		7

--- a/v1/drv/hisi_zip_udrv.c
+++ b/v1/drv/hisi_zip_udrv.c
@@ -88,7 +88,7 @@
 #define CTX_WIN_LEN_MASK		0xffff
 #define CTX_HEAD_BIT_CNT_SHIFT		0xa
 #define CTX_HEAD_BIT_CNT_MASK		0xfC00
-#define WIN_LEN_ALIGN(len)		((len + 15) & ~(__u32)0x0F)
+#define WIN_LEN_ALIGN(len)		(((len) + 15) & ~(__u32)0x0F)
 
 enum {
 	BD_TYPE,

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -27,7 +27,7 @@
 #define cpu_to_be32(x) swap_byte(x)
 
 static const char *wd_comp_alg_name[WD_COMP_ALG_MAX] = {
-	"zlib", "gzip", "deflate", "lz77_zstd", "lz77_only"
+	"zlib", "gzip", "deflate", "lz77_zstd", "lz4", "lz77_only"
 };
 
 struct wd_comp_sess {

--- a/wd_comp.c
+++ b/wd_comp.c
@@ -27,7 +27,7 @@
 #define cpu_to_be32(x) swap_byte(x)
 
 static const char *wd_comp_alg_name[WD_COMP_ALG_MAX] = {
-	"zlib", "gzip", "deflate", "lz77_zstd"
+	"zlib", "gzip", "deflate", "lz77_zstd", "lz77_only"
 };
 
 struct wd_comp_sess {

--- a/wd_util.c
+++ b/wd_util.c
@@ -106,6 +106,7 @@ static struct acc_alg_item alg_options[] = {
 	{"gzip", "gzip"},
 	{"deflate", "deflate"},
 	{"lz77_zstd", "lz77_zstd"},
+	{"lz77_only", "lz77_only"},
 	{"hashagg", "hashagg"},
 
 	{"rsa", "rsa"},

--- a/wd_util.c
+++ b/wd_util.c
@@ -106,6 +106,7 @@ static struct acc_alg_item alg_options[] = {
 	{"gzip", "gzip"},
 	{"deflate", "deflate"},
 	{"lz77_zstd", "lz77_zstd"},
+	{"lz4", "lz4"},
 	{"lz77_only", "lz77_only"},
 	{"hashagg", "hashagg"},
 


### PR DESCRIPTION
Chenghai Huang (7):
uadk: fix definition coding standard issues
uadk: add or remove some store buf condition judgments
uadk: add new alg called lz77_only
uadk: remove redundant checks on bit read results
uadk_tool: modify unrecv num in async benchmark test
uadk_tool: add lz77_only alg in zip benchmark test
uadk_tool: add lz4 alg in zip benchmark test

Qinxin Xia (3):
uadk: hisi_comp - abstract get sgl function and general deflate
functions
uadk: hisi_comp - support the new algorithm 'lz4'
uadk: wd_comp - support the new algorithm 'lz4'