### PR TITLE
uadk: Fix compilation issues when the __DATE__ and __TIME__ macros

### DIFF
--- a/uadk_tool/Makefile.am
+++ b/uadk_tool/Makefile.am
@@ -1,9 +1,15 @@
 ACLOCAL_AMFLAGS = -I m4 -I./include
 AUTOMAKE_OPTIONS = foreign subdir-objects
+
+# get UADK build time
+BUILD_DATETIME := $(shell date -u +"%Y-%m-%d_%H:%M:%S")
+
 AM_CFLAGS=-Wall -Werror -fno-strict-aliasing -I$(top_srcdir) -I$(top_srcdir)/benchmark/include \
 			-pthread
 AM_CFLAGS += -fPIC -fPIE -pie -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
 -O2 -ftrapv -Wl,-z,now -Wl,-s
+
+AM_CFLAGS += -DUADK_BUILD_DATETIME=\"$(BUILD_DATETIME)\"
 
 #AUTOMAKE_OPTIONS = subdir-objects
 

--- a/uadk_tool/dfx/uadk_dfx.c
+++ b/uadk_tool/dfx/uadk_dfx.c
@@ -14,7 +14,11 @@
 #include "include/wd.h"
 #include "uadk_dfx.h"
 
-#define uadk_build_date()	printf("built on: %s %s\n", __DATE__, __TIME__)
+#ifndef UADK_BUILD_DATETIME
+#define UADK_BUILD_DATETIME "unknown"
+#endif
+
+#define uadk_build_date()	printf("built on: %s\n", UADK_BUILD_DATETIME)
 #define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
 #define PRIVILEGE_FLAG		0666
 


### PR DESCRIPTION
On some Ubuntu systems, the gcc compiler disables the DATE and TIME macros via the -Wdate-time flag during compilation. To ensure the compilation timestamp feature remains functional, this issue is addressed through the Makefile.