### PR TITLE
uadk: modify the return value of rsa_prepare_key() in hpre

### DIFF
--- a/drv/hisi_hpre.c
+++ b/drv/hisi_hpre.c
@@ -599,7 +599,7 @@ static int rsa_prepare_key(struct wd_rsa_msg *msg, struct hisi_hpre_sqe *hw_msg,
 		return -WD_ENOMEM;
 	fill_hw_msg_addr(HW_MSG_KEY, hw_msg, addr);
 
-	return ret;
+	return WD_SUCCESS;
 }
 
 static int rsa_prepare_iot(struct wd_rsa_msg *msg, struct hisi_hpre_sqe *hw_msg,


### PR DESCRIPTION
The 'ret' value is assigned in the case of 'req->op_type == WD_RSA_GENKEY'. When 'op_type' is not 'WD_RSA_GENKEY', 'ret' is not initialized. If 'ret' is directly returned, the caller may incorrectly determine that the operation fails. Therefore, 'WD_SUCCESS' instead of 'ret' is directly returned.